### PR TITLE
FEAT: Added convenience methods for tagged error ergonomics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,41 @@ TaggedError.matchPartial(
 );
 ```
 
+You can also use the factory helpers to avoid declaring `_tag` manually:
+
+```ts
+import { TaggedError } from "better-result";
+
+class NotFoundError extends TaggedError.define("NotFoundError") {
+  constructor(readonly id: string) {
+    super(`Not found: ${id}`);
+  }
+}
+
+class ValidationError extends TaggedError.define("ValidationError") {
+  constructor(readonly field: string) {
+    super(`Invalid: ${field}`);
+  }
+}
+
+type AppError = NotFoundError | ValidationError;
+
+const error = NotFoundError.from("123");
+
+// Exhaustive matching
+TaggedError.match(error, {
+  NotFoundError: (e) => `Missing: ${e.id}`,
+  ValidationError: (e) => `Bad field: ${e.field}`,
+});
+
+// Partial matching with fallback
+TaggedError.matchPartial(
+  error,
+  { NotFoundError: (e) => `Missing: ${e.id}` },
+  (e) => `Unknown error: ${e.message}`,
+);
+```
+
 ## Serialization
 
 Rehydrate Results from JSON for storage or network transfer:
@@ -245,6 +280,8 @@ const rehydrated = Result.hydrate(JSON.parse(JSON.stringify(errResult)));
 
 | Method                                     | Description                          |
 | ------------------------------------------ | ------------------------------------ |
+| `TaggedError.define(tag)`                  | Create a tagged error subclass       |
+| `TaggedError.from(...args)`                | Instantiate a tagged error subclass  |
 | `TaggedError.isError(value)`               | Type guard for Error                 |
 | `TaggedError.isTaggedError(value)`         | Type guard for TaggedError           |
 | `TaggedError.match(error, handlers)`       | Exhaustive pattern match by `_tag`   |


### PR DESCRIPTION
Thanks so much for this library, it's great in places where Effect can't be used. I've created a PR here to improve the ergonomics of the TaggedError and bring it closer to Effect's `Data.TaggedError`. 

AI summary of my changes below: 



## Summary
This PR improves TaggedError ergonomics by adding two static helpers:
- `TaggedError.define(tag)` creates a tagged subclass with `_tag` baked in, so you no longer need to declare `_tag` in every error class.
- `TaggedErrorInstance.from(...args)` instantiates the current error class without `new`, mirroring a lightweight factory style.

The goal is to reduce boilerplate and make tagged error definitions feel closer to Effect’s TaggedError ergonomics, while keeping the same runtime behavior and exhaustive matching via `_tag`.

## Changes
- Added `TaggedError.define` and `TaggedError.from` with strict typings that preserve `_tag` literals and static metadata.
- Updated README examples to use `define` and documented `from`.
- Expanded tests to cover the new factories, static metadata preservation, and instance metadata parity with the old extends style.

## Usage example
```ts
import { TaggedError } from "better-result";

class NotFoundError extends TaggedError.define("NotFoundError") {
  constructor(readonly id: string) {
    super(`Not found: ${id}`);
  }
}

const err = NotFoundError.from("123");
// err._tag === "NotFoundError"
```

## Notes
- Existing `TaggedError.match` and `matchPartial` remain unchanged and work with the new factory-defined errors.
