### PR TITLE
fix: Result.gen union type inference for multiple return errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# opensrc - source code for packages
+opensrc/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "strict": true,
     "declaration": true,
     "declarationMap": true,
@@ -15,6 +17,12 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "opensrc"
+  ]
 }


### PR DESCRIPTION
Closes #3

## Summary

- **Fix `Result.gen` to properly infer union of error types** when multiple `return Result.err()` statements exist in generator body
- Add 11 runtime type inference tests in `src/result.test.ts`

## Problem

Before this fix, `Result.gen` failed to infer the correct error type when a generator had multiple `return Result.err()` statements with different error types:

```typescript
const result = Result.gen(function* () {
  if (cond1) return Result.err(new ErrorA());
  if (cond2) return Result.err(new ErrorB());
  return Result.ok(value);
});
// ERROR: Type was not correctly inferred as Result<T, ErrorA | ErrorB>
```

## Solution

Added helper types in `src/result.ts` (lines 314-337) to extract error types distributively:

```typescript
type InferResultOk<R> = R extends Ok<infer T, unknown> ? T : never;
type InferResultErr<R> = R extends Err<unknown, infer E> ? E : never;
```

## New Test Coverage

| Category | Coverage |
|----------|----------|
| `mapError` on union types | Partial transformation, full transformation |
| `Err.map` error preservation | Error type preserved through map |
| `never` error propagation | Through gen, map, andThen |
| `unwrapOr` type widening | Different fallback types |
| Generic Result preservation | Through gen with type constraints |
| Multiple return error inference | 3+ different error types per gen |

## Verification

```bash
bun run check  # tsc --noEmit passes
bun test       # 86 tests pass
bun run build  # Build succeeds
```

> [!NOTE]
> This PR was written with AI assistance.

<details><summary>AI Session Export</summary>
<p>

```json
{
  "info": {
    "title": "fix result.gen type inference",
    "agent": "opencode",
    "models": ["claude-sonnet-4-20250514"]
  },
  "summary": [
    "user asked for session summary of prior work",
    "agent summarized: fixed Result.gen type inference bug, created 65 type examples, fixed examples 26/29/31/37/40",
    "user requested continuation",
    "agent verified all tasks complete, 75 tests pass, build succeeds",
    "user requested code review with 3 subagents focused on type inference test correctness",
    "agent detected jj VCS, checked uncommitted changes",
    "agent launched 3 parallel review subagents (examples 1-25, 26-50, 51-65)",
    "subagents returned: 0 critical, 3 medium, 9 low severity issues; identified 8+ coverage gaps",
    "agent correlated findings into severity-ranked summary",
    "user requested: add improvements, move tests to test file, commit, create bookmark, push, open PR",
    "agent added 11 new type inference tests to result.test.ts covering: mapError on unions, Err.map preservation, never propagation, unwrapOr widening, generic Result preservation",
    "agent verified 86 tests pass, tsc passes, build succeeds",
    "agent committed changes with jj describe",
    "agent created bookmark fix-result-gen-type-inference",
    "agent pushed bookmark to origin",
    "agent created PR #4 via gh CLI",
    "agent loaded session-export skill and updated PR description",
    "user requested removal of examples.ts and amend",
    "agent removed src/examples.ts, amended commit, force pushed",
    "agent updated PR to close issue #3"
  ]
}
```

</p>
</details>