### PR TITLE
fix: ensure generator cleanup in Result.gen to support finally blocks

### DIFF
--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -325,6 +325,24 @@ describe("Result", () => {
       }
     });
 
+    it("runs finally blocks when short-circuiting", () => {
+      let finallyCalled = false;
+
+      const getA = () => Result.err<number, string>("a failed");
+
+      const result = Result.gen(function* () {
+        try {
+          yield* getA();
+          return Result.ok(1);
+        } finally {
+          finallyCalled = true;
+        }
+      });
+
+      expect(Result.isError(result)).toBe(true);
+      expect(finallyCalled).toBe(true);
+    });
+
     it("collects error types from yields", () => {
       class ErrorA extends Error {
         readonly _tag = "ErrorA" as const;
@@ -392,6 +410,24 @@ describe("Result", () => {
 
       expect(Result.isError(result)).toBe(true);
       expect(bCalled).toBe(false);
+    });
+
+    it("runs finally blocks when short-circuiting (async)", async () => {
+      let finallyCalled = false;
+
+      const fetchA = () => Promise.resolve(Result.err<number, string>("a failed"));
+
+      const result = await Result.gen(async function* () {
+        try {
+          yield* Result.await(fetchA());
+          return Result.ok(1);
+        } finally {
+          finallyCalled = true;
+        }
+      });
+
+      expect(Result.isError(result)).toBe(true);
+      expect(finallyCalled).toBe(true);
     });
   });
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -567,6 +567,12 @@ const gen: {
       const asyncIter = iterator as unknown as AsyncGenerator<Yield, R, unknown>;
       const state = await asyncIter.next();
       assertIsResult(state.value);
+      if (!state.done) {
+        // SAFETY: `.return()` requires a value of the generator's return type `R`,
+        // but we only need to close the generator to run `finally` blocks. The
+        // value is ignored by consumers, so `undefined` is safe here.
+        await asyncIter.return?.(undefined as unknown as R);
+      }
       return state.value as Result<InferResultOk<R>, InferYieldErr<Yield> | InferResultErr<R>>;
     })();
   }
@@ -576,6 +582,12 @@ const gen: {
   const syncIter = iterator as Generator<Yield, R, unknown>;
   const state = syncIter.next();
   assertIsResult(state.value);
+  if (!state.done) {
+    // SAFETY: `.return()` requires a value of the generator's return type `R`,
+    // but we only need to close the generator to run `finally` blocks. The
+    // value is ignored by consumers, so `undefined` is safe here.
+    syncIter.return?.(undefined as unknown as R);
+  }
   return state.value as Result<InferResultOk<R>, InferYieldErr<Yield> | InferResultErr<R>>;
 }) as {
   <Yield extends Err<never, unknown>, R extends AnyResult>(


### PR DESCRIPTION
- Calls .return() when Result.gen short-circuits to ensure finally blocks execute
- Added sync and async test cases to verify cleanup behavior