### PR TITLE
feat: expose some utility typings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { Result, Ok, Err } from "./result";
-export type { Result as ResultType, AnyResult, InferResultOk, InferResultErr } from "./result";
+export type { Result as ResultType, InferResultOk, InferResultErr } from "./result";
 export { TaggedError, UnhandledException } from "./error";

--- a/src/result.ts
+++ b/src/result.ts
@@ -334,7 +334,7 @@ export type InferResultErr<R> = R extends Err<unknown, infer E> ? E : never;
  * Constraint for any union of Ok/Err types.
  * Used in Result.gen to accept flexible return types from generators.
  */
-export type AnyResult = Ok<unknown, unknown> | Err<unknown, unknown>;
+type AnyResult = Ok<unknown, unknown> | Err<unknown, unknown>;
 
 const ok = <A, E = never>(value: A): Ok<A, E> => new Ok<A, E>(value);
 


### PR DESCRIPTION
i've just rolled the same typings internally to use when writing helper/utility methods - would be easier to use imports from `better-result` itself

feel free to close though if you'd rather not export these explicitly, they're simple enough for anyone to recreate either way - thanks!