### PR TITLE
v2: factory TaggedError, Panic, CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,26 @@ bun test          # Run tests (none exist yet)
 - **dist/ is committed**: Unusual for libraries; published via npm
 - **No CI/CD**: Tests/builds run locally only
 - **No linter/formatter**: Rely on editor defaults
+
+<!-- opensrc:start -->
+
+## Source Code Reference
+
+Source code for dependencies is available in `opensrc/` for deeper understanding of implementation details.
+
+See `opensrc/sources.json` for the list of available packages and their versions.
+
+Use this source code when you need to understand how a package works internally, not just its types/interface.
+
+### Fetching Additional Source Code
+
+To fetch source code for a package or repository you need to understand, run:
+
+```bash
+npx opensrc <package>           # npm package (e.g., npx opensrc zod)
+npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
+npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
+```
+
+<!-- opensrc:end -->

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,121 @@
+# Migration Guide: v1 to v2
+
+## Breaking Changes
+
+### TaggedError API
+
+**Before (v1):**
+```typescript
+class NotFoundError extends TaggedError {
+  readonly _tag = "NotFoundError" as const;
+  constructor(readonly id: string) {
+    super(`Not found: ${id}`);
+  }
+}
+
+const err = new NotFoundError("123");
+```
+
+**After (v2):**
+```typescript
+class NotFoundError extends TaggedError("NotFoundError")<{
+  id: string;
+  message: string;
+}> {}
+
+const err = new NotFoundError({ id: "123", message: "Not found: 123" });
+```
+
+### Match functions
+
+**Before:**
+```typescript
+TaggedError.match(error, { ... })
+TaggedError.matchPartial(error, { ... }, fallback)
+TaggedError.isTaggedError(value)
+```
+
+**After:**
+```typescript
+matchError(error, { ... })
+matchErrorPartial(error, { ... }, fallback)
+isTaggedError(value)
+```
+
+
+## Automated Migration
+
+Install the OpenCode migration skill:
+
+```bash
+npx better-result-migrate v2
+```
+
+Then in OpenCode:
+```
+/skill better-result-migrate-v2
+```
+
+Ask: "Migrate my TaggedError classes to v2"
+
+The skill handles:
+- Simple and complex class transformations
+- Computed messages and validation logic
+- Static method migrations (`TaggedError.match` → `matchError`)
+- Import updates
+
+## Manual Migration Steps
+
+1. Update class declarations to use factory pattern
+2. Change constructor calls to pass object with all props
+3. Replace `TaggedError.match` with `matchError`
+4. Replace `TaggedError.matchPartial` with `matchErrorPartial`
+5. Replace `TaggedError.isTaggedError` with `isTaggedError`
+6. Update imports to include new exports
+
+## New Features
+
+### Simpler error definitions
+```typescript
+// No more boilerplate _tag declarations
+class MyError extends TaggedError("MyError")<{ code: number; message: string }>() {}
+```
+
+### Dual-style match functions
+```typescript
+// Data-first
+matchError(error, { MyError: e => e.code })
+
+// Data-last (pipeable)
+pipe(error, matchError({ MyError: e => e.code }))
+```
+
+### Panic (new)
+
+v2 introduces `Panic` — an unrecoverable error thrown when user callbacks throw inside Result operations. This replaces silent failures with explicit defect handling.
+
+```typescript
+import { Panic, panic, isPanic } from "better-result";
+
+// Callbacks that throw now cause Panic instead of corrupting state
+Result.ok(1).map(() => { throw new Error("bug"); }); // throws Panic
+
+// Generator cleanup throws → Panic
+Result.gen(function* () {
+  try {
+    yield* Result.err("expected");
+  } finally {
+    throw new Error("cleanup bug"); // throws Panic
+  }
+});
+
+// Manual panic
+panic("something went wrong", cause);
+
+// Type guard
+if (isPanic(error)) {
+  console.log(error.message, error.cause);
+}
+```
+
+**Why Panic?** `Err` is for recoverable domain errors. Panic is for bugs — like Rust's `panic!()`. Returning `Err` would collapse type safety.

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,829 @@
+#!/usr/bin/env node
+
+import {
+  readdirSync,
+  existsSync,
+  statSync,
+  readFileSync,
+  mkdirSync,
+  cpSync,
+  writeFileSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as p from "@clack/prompts";
+import color from "picocolors";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = join(__dirname, "..", "skills");
+
+/** Create a clickable terminal hyperlink */
+function link(text, url) {
+  return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
+}
+
+/** @typedef {"opencode" | "claude" | "codex"} Agent */
+
+/**
+ * Agent configuration for skill/command paths
+ */
+const AGENT_CONFIG = {
+  opencode: {
+    skillDir: ".opencode/skill",
+    commandDir: ".opencode/command",
+    cli: "opencode",
+    configFiles: [".opencode", "opencode.json"],
+  },
+  claude: {
+    skillDir: ".claude/skills",
+    commandDir: ".claude/commands",
+    cli: "claude",
+    configFiles: [".claude", "claude.json", "CLAUDE.md"],
+  },
+  codex: {
+    skillDir: ".codex/skills",
+    commandDir: ".codex/commands",
+    cli: "codex",
+    configFiles: [".codex", "codex.json", "AGENTS.md"],
+  },
+};
+
+/** @typedef {"npm" | "bun" | "pnpm"} PackageManager */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Check if a CLI binary is available */
+function hasBinary(name) {
+  try {
+    execSync(`which ${name}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect package manager from lockfiles
+ * @returns {PackageManager | null}
+ */
+function detectPackageManager() {
+  const cwd = process.cwd();
+  if (existsSync(join(cwd, "bun.lock")) || existsSync(join(cwd, "bun.lockb"))) {
+    return "bun";
+  }
+  if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
+    return "pnpm";
+  }
+  if (existsSync(join(cwd, "package-lock.json"))) {
+    return "npm";
+  }
+  return null;
+}
+
+/**
+ * Detect harness from repo config files
+ * @returns {Agent | null}
+ */
+function detectConfiguredAgent() {
+  const cwd = process.cwd();
+  for (const [agent, config] of Object.entries(AGENT_CONFIG)) {
+    for (const file of config.configFiles) {
+      if (existsSync(join(cwd, file))) {
+        return /** @type {Agent} */ (agent);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Get all agents with binary available
+ * @returns {Agent[]}
+ */
+function getAvailableAgents() {
+  return /** @type {Agent[]} */ (
+    Object.keys(AGENT_CONFIG).filter((agent) =>
+      hasBinary(AGENT_CONFIG[/** @type {Agent} */ (agent)].cli)
+    )
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Skills
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Recursively find all SKILL.md files and return skill info */
+function discoverSkills() {
+  const skills = [];
+
+  function walk(dir, prefix = "") {
+    if (!existsSync(dir)) return;
+
+    for (const entry of readdirSync(dir)) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        const skillFile = join(fullPath, "SKILL.md");
+        if (existsSync(skillFile)) {
+          const id = prefix ? `${prefix}/${entry}` : entry;
+          skills.push({ id, path: fullPath, skillFile });
+        } else {
+          walk(fullPath, prefix ? `${prefix}/${entry}` : entry);
+        }
+      }
+    }
+  }
+
+  walk(SKILLS_DIR);
+  return skills;
+}
+
+/** Parse YAML frontmatter from SKILL.md */
+function parseSkillMeta(skillFile) {
+  const content = readFileSync(skillFile, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return { name: "unknown", description: "" };
+
+  const yaml = match[1];
+  const name = yaml.match(/name:\s*(.+)/)?.[1]?.trim() || "unknown";
+  const description = yaml.match(/description:\s*(.+)/)?.[1]?.trim() || "";
+  return { name, description };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Installation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Install skill to target agent */
+function installSkill(skillPath, skillName, agent) {
+  const cwd = process.cwd();
+  const config = AGENT_CONFIG[agent];
+  const targetSkillDir = join(cwd, config.skillDir, skillName);
+
+  if (!existsSync(skillPath)) {
+    return { success: false, message: `Skill source not found: ${skillPath}` };
+  }
+
+  mkdirSync(dirname(targetSkillDir), { recursive: true });
+  if (existsSync(targetSkillDir)) {
+    return { success: true, message: `${targetSkillDir}`, existed: true };
+  }
+
+  cpSync(skillPath, targetSkillDir, { recursive: true });
+  return { success: true, message: `${targetSkillDir}`, existed: false };
+}
+
+/** Install command wrapper for skill */
+function installCommand(skillName, agent) {
+  const cwd = process.cwd();
+  const config = AGENT_CONFIG[agent];
+  const commandDir = join(cwd, config.commandDir);
+  const commandFile = join(commandDir, "adopt-better-result.md");
+
+  mkdirSync(commandDir, { recursive: true });
+
+  if (existsSync(commandFile)) {
+    return { success: true, message: `${commandFile}`, existed: true };
+  }
+
+  const commandContent = `---
+description: Use ${skillName} skill for better-result migration/adoption
+---
+
+Load and use the ${skillName} skill to help with this codebase.
+
+First, invoke the skill:
+
+\`\`\`
+skill({ name: '${skillName}' })
+\`\`\`
+
+Then follow the skill instructions.
+
+<user-request>
+$ARGUMENTS
+</user-request>
+`;
+
+  writeFileSync(commandFile, commandContent);
+  return { success: true, message: `${commandFile}`, existed: false };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Launch
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Launch agent CLI interactively
+ * @param {Agent} agent
+ */
+function launchAgent(agent) {
+  const config = AGENT_CONFIG[agent];
+
+  try {
+    execSync(config.cli, {
+      stdio: "inherit",
+      cwd: process.cwd(),
+      env: process.env,
+    });
+    process.exit(0);
+  } catch (err) {
+    process.exit(err.status ?? 0);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Version Detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {{ installed: false } | { installed: true; version: string; major: number }} VersionInfo
+ */
+
+/**
+ * Detect installed better-result version from package.json
+ * @returns {VersionInfo}
+ */
+function detectInstalledVersion() {
+  const cwd = process.cwd();
+  const pkgPath = join(cwd, "package.json");
+
+  if (!existsSync(pkgPath)) {
+    return { installed: false };
+  }
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    const versionSpec = deps["better-result"];
+
+    if (!versionSpec) {
+      return { installed: false };
+    }
+
+    // Try to get actual installed version from node_modules
+    const installedPkgPath = join(cwd, "node_modules", "better-result", "package.json");
+    if (existsSync(installedPkgPath)) {
+      const installedPkg = JSON.parse(readFileSync(installedPkgPath, "utf-8"));
+      const version = installedPkg.version;
+      const major = parseInt(version.split(".")[0], 10);
+      return { installed: true, version, major };
+    }
+
+    // Fallback: parse version from spec (strip ^, ~, etc.)
+    const version = versionSpec.replace(/^[\^~>=<]+/, "");
+    const major = parseInt(version.split(".")[0], 10);
+    return { installed: true, version, major };
+  } catch {
+    return { installed: false };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Help
+// ─────────────────────────────────────────────────────────────────────────────
+
+function printHelp() {
+  console.log(`
+${color.bold("better-result")} - Lightweight Result type for TypeScript
+
+${color.dim("Usage:")}
+  npx better-result init      Interactive setup (new projects)
+  npx better-result migrate   Detect version & guide migration
+  npx better-result --help    Show this help
+`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migrate Command
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runMigrate() {
+  console.log();
+  p.intro(color.bgCyan(color.black(" better-result migrate ")));
+
+  const versionInfo = detectInstalledVersion();
+
+  if (!versionInfo.installed) {
+    p.log.warn("better-result is not installed in this project");
+
+    const shouldInit = await p.confirm({
+      message: "Would you like to set up better-result now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(shouldInit) || !shouldInit) {
+      p.cancel("Migration cancelled.");
+      process.exit(0);
+    }
+
+    // Run init flow
+    return runInit();
+  }
+
+  p.log.info(`Detected version: ${color.cyan(versionInfo.version)}`);
+
+  if (versionInfo.major >= 2) {
+    p.log.success("Already on v2 - no migration needed!");
+    p.outro(color.green("You're up to date."));
+    process.exit(0);
+  }
+
+  // v1 detected - guide to v2 migration
+  p.log.step(`Migration available: v${versionInfo.major} → v2`);
+
+  console.log();
+  console.log(color.dim("  Breaking changes in v2:"));
+  console.log(color.dim("  • TaggedError: class-based → factory-based API"));
+  console.log(color.dim("  • TaggedError.match → matchError (standalone fn)"));
+  console.log(color.dim("  • TaggedError.matchPartial → matchErrorPartial"));
+  console.log(color.dim("  • New: Panic for unrecoverable errors"));
+  console.log();
+
+  const onCancel = () => {
+    p.cancel("Migration cancelled.");
+    process.exit(0);
+  };
+
+  // Detect defaults
+  const detectedPM = detectPackageManager();
+  const configuredAgent = detectConfiguredAgent();
+  const availableAgents = getAvailableAgents();
+  const detectedAgent =
+    configuredAgent ?? (availableAgents.length > 0 ? availableAgents[0] : null);
+
+  // Build package manager options
+  const pmList = /** @type {PackageManager[]} */ (["npm", "bun", "pnpm"]);
+  const pmOptions = pmList.map((pm) => ({
+    value: pm,
+    label: pm === detectedPM ? `${pm} ${color.dim("(detected)")}` : pm,
+  }));
+  if (detectedPM) {
+    const idx = pmOptions.findIndex((o) => o.value === detectedPM);
+    if (idx > 0) {
+      const [detected] = pmOptions.splice(idx, 1);
+      pmOptions.unshift(detected);
+    }
+  }
+
+  // Build agent options
+  const agents = /** @type {Agent[]} */ (["opencode", "claude", "codex"]);
+  const agentOptions = agents.map((agent) => ({
+    value: agent,
+    label: agent === detectedAgent ? `${agent} ${color.dim("(detected)")}` : agent,
+  }));
+  if (detectedAgent) {
+    const idx = agentOptions.findIndex((o) => o.value === detectedAgent);
+    if (idx > 0) {
+      const [detected] = agentOptions.splice(idx, 1);
+      agentOptions.unshift(detected);
+    }
+  }
+
+  const responses = await p.group(
+    {
+      pm: () =>
+        p.select({
+          message: "Package manager",
+          options: pmOptions,
+          initialValue: detectedPM ?? "npm",
+        }),
+      installSkill: () =>
+        p.confirm({
+          message: "Install AI migration skill? (recommended for large codebases)",
+          initialValue: true,
+        }),
+    },
+    { onCancel }
+  );
+
+  const selectedPM = /** @type {PackageManager} */ (responses.pm);
+
+  /** @type {Agent | null} */
+  let selectedAgent = null;
+  let shouldLaunch = false;
+
+  if (responses.installSkill) {
+    const toolResponses = await p.group(
+      {
+        agent: () =>
+          p.select({
+            message: "AI coding agent",
+            options: agentOptions,
+            initialValue: detectedAgent ?? "opencode",
+          }),
+        launch: () =>
+          p.confirm({
+            message: "Launch agent after install?",
+            initialValue: true,
+          }),
+      },
+      { onCancel }
+    );
+
+    selectedAgent = /** @type {Agent} */ (toolResponses.agent);
+    shouldLaunch = Boolean(toolResponses.launch);
+  }
+
+  // Upgrade package
+  const s = p.spinner();
+  s.start("Upgrading better-result to v2");
+
+  try {
+    const installCmd =
+      selectedPM === "npm"
+        ? "npm install better-result@latest"
+        : selectedPM === "bun"
+          ? "bun add better-result@latest"
+          : "pnpm add better-result@latest";
+    execSync(installCmd, { stdio: "ignore", cwd: process.cwd() });
+    s.stop("Upgraded to v2");
+  } catch {
+    s.stop(color.yellow("Upgrade failed - try manually"));
+  }
+
+  // Install migration skill + command
+  if (selectedAgent) {
+    const skills = discoverSkills();
+    const migrateSkill = skills.find((s) => s.id === "migrations/v2");
+
+    if (migrateSkill) {
+      const meta = parseSkillMeta(migrateSkill.skillFile);
+      const s2 = p.spinner();
+      s2.start(`Installing migration skill for ${selectedAgent}`);
+
+      const skillResult = installSkill(migrateSkill.path, meta.name, selectedAgent);
+      installMigrateCommand(meta.name, selectedAgent);
+
+      s2.stop("Migration skill installed");
+      p.log.success(`Skill: ${color.dim(skillResult.message)}`);
+    }
+  }
+
+  /** Strip ANSI codes for length calculation */
+  const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+  /** Print a styled box with title and message */
+  function box(title, lines) {
+    const titlePlain = stripAnsi(title);
+    const maxLen = Math.max(...lines.map((l) => stripAnsi(l).length), titlePlain.length + 4);
+    const padding = maxLen - titlePlain.length - 2;
+    const top = `${color.dim("┌──")} ${title} ${color.dim("─".repeat(Math.max(0, padding)) + "┐")}`;
+    const bot = color.dim(`└${"─".repeat(maxLen + 2)}┘`);
+    console.log(top);
+    for (const line of lines) {
+      const plainLen = stripAnsi(line).length;
+      console.log(`${color.dim("│")} ${line}${" ".repeat(maxLen - plainLen)} ${color.dim("│")}`);
+    }
+    console.log(bot);
+  }
+
+  const commandHintLines = [
+    `${color.white("Run")} ${color.bold(color.cyan("/migrate-better-result"))} ${color.white("to start migration.")}`,
+    "",
+    color.yellow("The AI will update TaggedError classes to v2 syntax."),
+    color.dim("See MIGRATION.md for manual migration steps."),
+  ];
+
+  // Launch or show next steps
+  if (selectedAgent && shouldLaunch) {
+    if (!hasBinary(AGENT_CONFIG[selectedAgent].cli)) {
+      p.log.warn(`${selectedAgent} binary not found`);
+      box(color.bold("Next steps"), commandHintLines);
+      p.outro(`Install ${selectedAgent}, then run: ${color.cyan(AGENT_CONFIG[selectedAgent].cli)}`);
+      process.exit(0);
+    }
+
+    console.log();
+    box(color.green("Once the agent opens"), commandHintLines);
+    console.log();
+
+    const confirmLaunch = await p.text({
+      message: `Press ${color.bold(color.cyan("Enter"))} to launch ${color.bold(selectedAgent)}...`,
+      placeholder: "",
+      defaultValue: "",
+    });
+
+    if (p.isCancel(confirmLaunch)) {
+      p.cancel("Migration cancelled.");
+      process.exit(0);
+    }
+
+    launchAgent(selectedAgent);
+  } else if (selectedAgent) {
+    const manualLines = [
+      `${color.white("Run:")} ${color.bold(color.cyan(AGENT_CONFIG[selectedAgent].cli))}`,
+      "",
+      ...commandHintLines,
+    ];
+    console.log();
+    box(color.bold("Next steps"), manualLines);
+    p.outro(color.green("Ready to migrate!"));
+    process.exit(0);
+  } else {
+    console.log();
+    p.log.info(`See ${color.cyan("MIGRATION.md")} for manual migration steps.`);
+    p.outro(color.green("Package upgraded to v2!"));
+    process.exit(0);
+  }
+}
+
+/** Install migrate command wrapper */
+function installMigrateCommand(skillName, agent) {
+  const cwd = process.cwd();
+  const config = AGENT_CONFIG[agent];
+  const commandDir = join(cwd, config.commandDir);
+  const commandFile = join(commandDir, "migrate-better-result.md");
+
+  mkdirSync(commandDir, { recursive: true });
+
+  if (existsSync(commandFile)) {
+    return { success: true, message: `${commandFile}`, existed: true };
+  }
+
+  const commandContent = `---
+description: Migrate TaggedError classes from better-result v1 to v2
+---
+
+Load and use the ${skillName} skill to migrate this codebase.
+
+First, invoke the skill:
+
+\`\`\`
+skill({ name: '${skillName}' })
+\`\`\`
+
+Then follow the skill instructions to migrate TaggedError classes.
+
+<user-request>
+$ARGUMENTS
+</user-request>
+`;
+
+  writeFileSync(commandFile, commandContent);
+  return { success: true, message: `${commandFile}`, existed: false };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const command = args[0];
+
+  if (command === "migrate") {
+    return runMigrate();
+  }
+
+  if (command !== "init") {
+    printHelp();
+    process.exit(command ? 1 : 0);
+  }
+
+  return runInit();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Init Command
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runInit() {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Interactive init flow
+  // ─────────────────────────────────────────────────────────────────────────
+
+  console.log();
+  p.intro(color.bgCyan(color.black(" better-result ")));
+
+  const skills = discoverSkills();
+  const adoptSkill = skills.find((s) => s.id === "adopt");
+  if (!adoptSkill) {
+    p.log.error("adopt skill not found in package");
+    process.exit(1);
+  }
+
+  const meta = parseSkillMeta(adoptSkill.skillFile);
+
+  // Detect defaults
+  const detectedPM = detectPackageManager();
+  const configuredAgent = detectConfiguredAgent();
+  const availableAgents = getAvailableAgents();
+  const detectedAgent =
+    configuredAgent ?? (availableAgents.length > 0 ? availableAgents[0] : null);
+
+  // Build package manager options
+  const pmList = /** @type {PackageManager[]} */ (["npm", "bun", "pnpm"]);
+  const pmOptions = pmList.map((pm) => ({
+    value: pm,
+    label: pm === detectedPM ? `${pm} ${color.dim("(detected)")}` : pm,
+  }));
+  if (detectedPM) {
+    const idx = pmOptions.findIndex((o) => o.value === detectedPM);
+    if (idx > 0) {
+      const [detected] = pmOptions.splice(idx, 1);
+      pmOptions.unshift(detected);
+    }
+  }
+
+  // Build agent options
+  const agents = /** @type {Agent[]} */ (["opencode", "claude", "codex"]);
+  const agentOptions = agents.map((agent) => ({
+    value: agent,
+    label: agent === detectedAgent ? `${agent} ${color.dim("(detected)")}` : agent,
+  }));
+  if (detectedAgent) {
+    const idx = agentOptions.findIndex((o) => o.value === detectedAgent);
+    if (idx > 0) {
+      const [detected] = agentOptions.splice(idx, 1);
+      agentOptions.unshift(detected);
+    }
+  }
+
+  const onCancel = () => {
+    p.cancel("Setup cancelled.");
+    process.exit(0);
+  };
+
+  const responses = await p.group(
+    {
+      pm: () =>
+        p.select({
+          message: "Package manager",
+          options: pmOptions,
+          initialValue: detectedPM ?? "npm",
+        }),
+      installTools: () =>
+        p.confirm({
+          message: "Install AI agent skill + command?",
+          initialValue: true,
+        }),
+    },
+    { onCancel }
+  );
+
+  const selectedPM = /** @type {PackageManager} */ (responses.pm);
+
+  // Conditional: agent selection + opensrc + launch option
+  /** @type {Agent | null} */
+  let selectedAgent = null;
+  let shouldLaunch = false;
+  let installOpensrc = false;
+
+  if (responses.installTools) {
+    const toolResponses = await p.group(
+      {
+        agent: () =>
+          p.select({
+            message: "AI coding agent",
+            options: agentOptions,
+            initialValue: detectedAgent ?? "opencode",
+          }),
+        opensrc: () =>
+          p.confirm({
+            message: `Add source code for better AI context? ${color.dim(`(${link("opensrc", "https://github.com/anthropics/opensrc")})`)}`,
+            initialValue: true,
+          }),
+        launch: () =>
+          p.confirm({
+            message: "Launch agent after install?",
+            initialValue: true,
+          }),
+      },
+      { onCancel }
+    );
+
+    selectedAgent = /** @type {Agent} */ (toolResponses.agent);
+    installOpensrc = Boolean(toolResponses.opensrc);
+    shouldLaunch = Boolean(toolResponses.launch);
+  }
+
+  // Install package
+  const s = p.spinner();
+  s.start("Installing better-result package");
+
+  try {
+    const installCmd =
+      selectedPM === "npm"
+        ? "npm install better-result"
+        : selectedPM === "bun"
+          ? "bun add better-result"
+          : "pnpm add better-result";
+    execSync(installCmd, { stdio: "ignore", cwd: process.cwd() });
+    s.stop("Package installed");
+  } catch {
+    s.stop("Package install failed (may already be installed)");
+  }
+
+  // Install source code via opensrc for better AI context
+  if (installOpensrc) {
+    const s3 = p.spinner();
+    s3.start("Fetching source code for AI context");
+
+    try {
+      // --modify to auto-update .gitignore, tsconfig, AGENTS.md
+      execSync("npx -y opensrc better-result --modify", { stdio: "ignore", cwd: process.cwd() });
+      s3.stop("Source code added to opensrc/");
+    } catch (err) {
+      s3.stop(color.yellow("Source fetch failed (opensrc may not be available)"));
+    }
+  }
+
+  // Install skill + command (if selected)
+  if (selectedAgent) {
+    const s2 = p.spinner();
+    s2.start(`Installing skill + command for ${selectedAgent}`);
+
+    const skillResult = installSkill(adoptSkill.path, meta.name, selectedAgent);
+    const commandResult = installCommand(meta.name, selectedAgent);
+
+    s2.stop("Skill + command installed");
+
+    p.log.success(
+      `Skill: ${color.dim(skillResult.message)}${skillResult.existed ? color.dim(" (existed)") : ""}`
+    );
+    p.log.success(
+      `Command: ${color.dim(commandResult.message)}${commandResult.existed ? color.dim(" (existed)") : ""}`
+    );
+  }
+
+  /** Strip ANSI codes for length calculation */
+  const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+  /** Print a styled box with title and message */
+  function box(title, lines) {
+    const titlePlain = stripAnsi(title);
+    const maxLen = Math.max(...lines.map((l) => stripAnsi(l).length), titlePlain.length + 4);
+    const padding = maxLen - titlePlain.length - 2;
+    const top = `${color.dim("┌──")} ${title} ${color.dim("─".repeat(Math.max(0, padding)) + "┐")}`;
+    const bot = color.dim(`└${"─".repeat(maxLen + 2)}┘`);
+    console.log(top);
+    for (const line of lines) {
+      const plainLen = stripAnsi(line).length;
+      console.log(`${color.dim("│")} ${line}${" ".repeat(maxLen - plainLen)} ${color.dim("│")}`);
+    }
+    console.log(bot);
+  }
+
+  const commandHintLines = [
+    `${color.white("Run")} ${color.bold(color.cyan("/adopt-better-result"))} ${color.white("to start adoption.")}`,
+    "",
+    color.yellow("This will analyze your codebase and suggest changes."),
+    color.dim("It may take a few minutes depending on project size."),
+  ];
+
+  // Launch or show next steps
+  if (selectedAgent && shouldLaunch) {
+    if (!hasBinary(AGENT_CONFIG[selectedAgent].cli)) {
+      p.log.warn(`${selectedAgent} binary not found`);
+      box(color.bold("Next steps"), commandHintLines);
+      p.outro(`Install ${selectedAgent}, then run: ${color.cyan(AGENT_CONFIG[selectedAgent].cli)}`);
+      process.exit(0);
+    }
+
+    console.log();
+    box(color.green("Once the agent opens"), commandHintLines);
+    console.log();
+
+    const confirmLaunch = await p.text({
+      message: `Press ${color.bold(color.cyan("Enter"))} to launch ${color.bold(selectedAgent)}...`,
+      placeholder: "",
+      defaultValue: "",
+    });
+
+    if (p.isCancel(confirmLaunch)) {
+      p.cancel("Setup cancelled.");
+      process.exit(0);
+    }
+
+    launchAgent(selectedAgent);
+  } else if (selectedAgent) {
+    const manualLines = [
+      `${color.white("Run:")} ${color.bold(color.cyan(AGENT_CONFIG[selectedAgent].cli))}`,
+      "",
+      ...commandHintLines,
+    ];
+    console.log();
+    box(color.bold("Next steps"), manualLines);
+    p.outro(color.green("Done!"));
+    process.exit(0);
+  } else {
+    p.outro(color.green("Done!"));
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  p.log.error(err.message);
+  process.exit(1);
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,8 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tryhard",
+      "dependencies": {
+        "@clack/prompts": "^0.11.0",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "oxfmt": "^0.23.0",
@@ -22,6 +26,10 @@
     "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+
+    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -143,6 +151,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
@@ -154,6 +164,8 @@
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.20.0", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ast-kit": "^2.2.0", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.0", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-beta.57", "typescript": "^5.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-cLAY1kN2ilTYMfZcFlGWbXnu6Nb+8uwUBsi+Mjbh4uIx7IN8uMOmJ7RxrrRgPsO4H7eSz3E+JwGoL1gyugiyUA=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-result",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Lightweight Result type with generator-based composition",
   "keywords": [
     "error-handling",
@@ -21,8 +21,13 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "skills",
+    "bin"
   ],
+  "bin": {
+    "better-result": "./bin/cli.mjs"
+  },
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
@@ -36,7 +41,7 @@
   "scripts": {
     "build": "tsdown",
     "prepublishOnly": "bun run build",
-    "test": "bun test",
+    "test": "bun test src/",
     "check": "tsc --noEmit",
     "publish": "npm publish",
     "lint": "oxlint .",
@@ -49,5 +54,8 @@
     "oxlint": "^1.38.0",
     "tsdown": "^0.19.0-beta.5",
     "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.11.0"
   }
 }

--- a/skills/adopt/SKILL.md
+++ b/skills/adopt/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: better-result-adopt
+description: Migrate codebase from try/catch or Promise-based error handling to better-result. Use when adopting Result types, converting thrown exceptions to typed errors, or refactoring existing error handling to railway-oriented programming.
+---
+
+# better-result Adoption
+
+Migrate existing error handling (try/catch, Promise rejections, thrown exceptions) to typed Result-based error handling with better-result.
+
+## When to Use
+
+- Adopting better-result in existing codebase
+- Converting try/catch blocks to Result types
+- Replacing thrown exceptions with typed errors
+- Migrating Promise-based code to Result.tryPromise
+- Introducing railway-oriented programming patterns
+
+## Migration Strategy
+
+### 1. Start at Boundaries
+
+Begin migration at I/O boundaries (API calls, DB queries, file ops) and work inward. Don't attempt full-codebase migration at once.
+
+### 2. Identify Error Categories
+
+Before migrating, categorize errors in target code:
+
+| Category | Example | Migration Target |
+|----------|---------|------------------|
+| Domain errors | NotFound, Validation | TaggedError + Result.err |
+| Infrastructure | Network, DB connection | Result.tryPromise + TaggedError |
+| Bugs/defects | null deref, type error | Let throw (becomes Panic if in Result callback) |
+
+### 3. Migration Order
+
+1. Define TaggedError classes for domain errors
+2. Wrap throwing functions with Result.try/tryPromise
+3. Convert imperative error checks to Result chains
+4. Refactor callbacks to generator composition
+
+## Pattern Transformations
+
+### Try/Catch to Result.try
+
+```typescript
+// BEFORE
+function parseConfig(json: string): Config {
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    throw new ParseError(e);
+  }
+}
+
+// AFTER
+function parseConfig(json: string): Result<Config, ParseError> {
+  return Result.try({
+    try: () => JSON.parse(json) as Config,
+    catch: (e) => new ParseError({ cause: e, message: `Parse failed: ${e}` })
+  });
+}
+```
+
+### Async/Await to Result.tryPromise
+
+```typescript
+// BEFORE
+async function fetchUser(id: string): Promise<User> {
+  const res = await fetch(`/api/users/${id}`);
+  if (!res.ok) throw new ApiError(res.status);
+  return res.json();
+}
+
+// AFTER
+async function fetchUser(id: string): Promise<Result<User, ApiError | UnhandledException>> {
+  return Result.tryPromise({
+    try: async () => {
+      const res = await fetch(`/api/users/${id}`);
+      if (!res.ok) throw new ApiError({ status: res.status, message: `API ${res.status}` });
+      return res.json() as Promise<User>;
+    },
+    catch: (e) => e instanceof ApiError ? e : new UnhandledException({ cause: e })
+  });
+}
+```
+
+### Null Checks to Result
+
+```typescript
+// BEFORE
+function findUser(id: string): User | null {
+  return users.find(u => u.id === id) ?? null;
+}
+// Caller must check: if (user === null) ...
+
+// AFTER
+function findUser(id: string): Result<User, NotFoundError> {
+  const user = users.find(u => u.id === id);
+  return user ? Result.ok(user) : Result.err(new NotFoundError({ id, message: `User ${id} not found` }));
+}
+// Caller: yield* findUser(id) in Result.gen, or .match()
+```
+
+### Callback Hell to Generator
+
+```typescript
+// BEFORE
+async function processOrder(orderId: string) {
+  try {
+    const order = await fetchOrder(orderId);
+    if (!order) throw new NotFoundError(orderId);
+    const validated = validateOrder(order);
+    if (!validated.ok) throw new ValidationError(validated.errors);
+    const result = await submitOrder(validated.data);
+    return result;
+  } catch (e) {
+    if (e instanceof NotFoundError) return { error: "not_found" };
+    if (e instanceof ValidationError) return { error: "invalid" };
+    throw e;
+  }
+}
+
+// AFTER
+async function processOrder(orderId: string): Promise<Result<OrderResult, OrderError>> {
+  return Result.gen(async function* () {
+    const order = yield* Result.await(fetchOrder(orderId));
+    const validated = yield* validateOrder(order);
+    const result = yield* Result.await(submitOrder(validated));
+    return Result.ok(result);
+  });
+}
+// Error type is union of all yielded errors
+```
+
+## Defining TaggedErrors
+
+See [references/tagged-errors.md](references/tagged-errors.md) for TaggedError patterns.
+
+## Workflow
+
+1. **Check for source reference**: Look for `opensrc/` directory - if present, read the better-result source code for implementation details and patterns
+2. **Audit**: Find try/catch, Promise.catch, thrown errors in target module
+3. **Define errors**: Create TaggedError classes for domain errors
+4. **Wrap boundaries**: Use Result.try/tryPromise at I/O points
+5. **Chain operations**: Convert if/else error checks to .andThen or Result.gen
+6. **Update signatures**: Change return types to Result<T, E>
+7. **Update callers**: Propagate Result handling up call stack
+8. **Test**: Verify error paths with .match or type narrowing
+
+## Common Pitfalls
+
+- **Over-wrapping**: Don't wrap every function. Start at boundaries, propagate inward.
+- **Losing error info**: Always include cause/context in TaggedError constructors.
+- **Mixing paradigms**: Once a module returns Result, callers should too (or explicitly .unwrap).
+- **Ignoring Panic**: Callbacks that throw become Panic. Fix the bug, don't catch Panic.
+
+## References
+
+- [TaggedError Patterns](references/tagged-errors.md) - Defining and matching typed errors
+- `opensrc/` directory (if present) - Full better-result source code for deeper context

--- a/skills/adopt/references/tagged-errors.md
+++ b/skills/adopt/references/tagged-errors.md
@@ -1,0 +1,185 @@
+# TaggedError Patterns
+
+## Defining Errors
+
+### Simple Error (no computed message)
+
+```typescript
+import { TaggedError } from "better-result";
+
+class NotFoundError extends TaggedError("NotFoundError")<{
+  resource: string;
+  id: string;
+  message: string;
+}>() {}
+
+// Usage
+new NotFoundError({ resource: "User", id: "123", message: "User 123 not found" });
+```
+
+### Error with Computed Message
+
+Keep constructor for derived message:
+
+```typescript
+class NotFoundError extends TaggedError("NotFoundError")<{
+  resource: string;
+  id: string;
+  message: string;
+}>() {
+  constructor(args: { resource: string; id: string }) {
+    super({ ...args, message: `${args.resource} not found: ${args.id}` });
+  }
+}
+
+// Usage: new NotFoundError({ resource: "User", id: "123" })
+```
+
+### Error with Cause
+
+Wrap underlying exceptions:
+
+```typescript
+class DatabaseError extends TaggedError("DatabaseError")<{
+  operation: string;
+  message: string;
+  cause: unknown;
+}>() {
+  constructor(args: { operation: string; cause: unknown }) {
+    const msg = args.cause instanceof Error ? args.cause.message : String(args.cause);
+    super({ ...args, message: `DB ${args.operation} failed: ${msg}` });
+  }
+}
+
+// Usage in Result.tryPromise
+Result.tryPromise({
+  try: () => db.query(sql),
+  catch: (e) => new DatabaseError({ operation: "query", cause: e })
+});
+```
+
+### Error with Validation/Runtime Props
+
+```typescript
+class RateLimitError extends TaggedError("RateLimitError")<{
+  retryAfter: number;
+  message: string;
+}>() {
+  constructor(args: { retryAfterMs: number }) {
+    super({
+      retryAfter: args.retryAfterMs,
+      message: `Rate limited, retry after ${args.retryAfterMs}ms`
+    });
+  }
+}
+```
+
+## Error Unions
+
+Group related errors for function signatures:
+
+```typescript
+// Domain errors
+class NotFoundError extends TaggedError("NotFoundError")<{ id: string; message: string }>() {}
+class ValidationError extends TaggedError("ValidationError")<{ field: string; message: string }>() {}
+class AuthError extends TaggedError("AuthError")<{ reason: string; message: string }>() {}
+
+// Union type
+type AppError = NotFoundError | ValidationError | AuthError;
+
+// Function signature
+function processRequest(req: Request): Result<Response, AppError> { ... }
+```
+
+## Matching Errors
+
+### Exhaustive Match
+
+Compiler ensures all error types handled:
+
+```typescript
+import { matchError } from "better-result";
+
+const message = matchError(error, {
+  NotFoundError: (e) => `Missing: ${e.id}`,
+  ValidationError: (e) => `Invalid: ${e.field}`,
+  AuthError: (e) => `Unauthorized: ${e.reason}`,
+});
+```
+
+### Partial Match with Fallback
+
+Handle subset, catch-all for rest:
+
+```typescript
+import { matchErrorPartial } from "better-result";
+
+const message = matchErrorPartial(
+  error,
+  { NotFoundError: (e) => `Missing: ${e.id}` },
+  (e) => `Error: ${e.message}`  // fallback for ValidationError, AuthError
+);
+```
+
+### Type Guards
+
+```typescript
+import { isTaggedError, TaggedError } from "better-result";
+
+// Check any tagged error
+if (isTaggedError(value)) {
+  console.log(value._tag);
+}
+
+// Check specific error class
+if (NotFoundError.is(value)) {
+  console.log(value.id);  // narrowed to NotFoundError
+}
+
+// Also available
+TaggedError.is(value);  // same as isTaggedError
+```
+
+### In Result.match
+
+```typescript
+result.match({
+  ok: (value) => handleSuccess(value),
+  err: (e) => matchError(e, {
+    NotFoundError: (e) => handleNotFound(e),
+    ValidationError: (e) => handleValidation(e),
+  })
+});
+```
+
+## Pipeable Style
+
+matchError/matchErrorPartial support data-last for pipelines:
+
+```typescript
+const handler = matchError({
+  NotFoundError: (e) => `Missing: ${e.id}`,
+  ValidationError: (e) => `Invalid: ${e.field}`,
+});
+pipe(error, handler);
+```
+
+## Converting Existing Errors
+
+```typescript
+// FROM: class hierarchy
+class NotFoundError extends AppError {
+  constructor(public id: string) { super(`Not found: ${id}`); }
+}
+// TO: TaggedError
+class NotFoundError extends TaggedError("NotFoundError")<{ id: string; message: string }>() {
+  constructor(args: { id: string }) {
+    super({ ...args, message: `Not found: ${args.id}` });
+  }
+}
+
+// FROM: string/generic errors
+throw "User not found";
+// TO: typed Result
+return Result.err(new NotFoundError({ id, message: "User not found" }));
+```

--- a/skills/migrations/v2/SKILL.md
+++ b/skills/migrations/v2/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: better-result-migrate-v2
+description: Migrate better-result TaggedError from v1 (class-based) to v2 (factory-based) API
+---
+
+# better-result-migrate
+
+Migrate `better-result` TaggedError classes from v1 (class-based) to v2 (factory-based) API.
+
+## When to Use
+
+- Upgrading `better-result` from v1 to v2
+- User asks to migrate TaggedError classes
+- User mentions TaggedError v1/v2 migration
+
+## V1 API (old)
+
+```typescript
+class FooError extends TaggedError {
+  readonly _tag = "FooError" as const;
+  constructor(readonly id: string) {
+    super(`Foo: ${id}`);
+  }
+}
+
+// Static methods on TaggedError
+TaggedError.match(err, { ... })
+TaggedError.matchPartial(err, { ... }, fallback)
+TaggedError.isTaggedError(value)
+```
+
+## V2 API (new)
+
+```typescript
+class FooError extends TaggedError("FooError")<{
+  id: string;
+  message: string;
+}>() {}
+
+// Standalone functions
+matchError(err, { ... })
+matchErrorPartial(err, { ... }, fallback)
+isTaggedError(value)
+TaggedError.is(value)  // also available
+FooError.is(value)     // class-specific check
+```
+
+## Migration Rules
+
+### 1. Simple class (no constructor logic)
+
+```typescript
+// BEFORE
+class FooError extends TaggedError {
+  readonly _tag = "FooError" as const;
+  constructor(readonly id: string) {
+    super(`Foo: ${id}`);
+  }
+}
+
+// AFTER
+class FooError extends TaggedError("FooError")<{
+  id: string;
+  message: string;
+}>() {}
+
+// Usage changes:
+// BEFORE: new FooError("123")
+// AFTER:  new FooError({ id: "123", message: "Foo: 123" })
+```
+
+### 2. Class with computed message
+
+Keep custom constructor to derive message:
+
+```typescript
+// BEFORE
+class NotFoundError extends TaggedError {
+  readonly _tag = "NotFoundError" as const;
+  constructor(readonly resource: string, readonly id: string) {
+    super(`${resource} not found: ${id}`);
+  }
+}
+
+// AFTER
+class NotFoundError extends TaggedError("NotFoundError")<{
+  resource: string;
+  id: string;
+  message: string;
+}>() {
+  constructor(args: { resource: string; id: string }) {
+    super({ ...args, message: `${args.resource} not found: ${args.id}` });
+  }
+}
+
+// Usage: new NotFoundError({ resource: "User", id: "123" })
+```
+
+### 3. Class with validation
+
+Keep validation in custom constructor:
+
+```typescript
+// BEFORE
+class ValidationError extends TaggedError {
+  readonly _tag = "ValidationError" as const;
+  constructor(readonly field: string) {
+    if (!field) throw new Error("field required");
+    super(`Invalid: ${field}`);
+  }
+}
+
+// AFTER
+class ValidationError extends TaggedError("ValidationError")<{
+  field: string;
+  message: string;
+}>() {
+  constructor(args: { field: string }) {
+    if (!args.field) throw new Error("field required");
+    super({ ...args, message: `Invalid: ${args.field}` });
+  }
+}
+```
+
+### 4. Class with additional runtime properties
+
+```typescript
+// BEFORE
+class TimestampedError extends TaggedError {
+  readonly _tag = "TimestampedError" as const;
+  readonly timestamp = Date.now();
+  constructor(readonly reason: string) {
+    super(reason);
+  }
+}
+
+// AFTER
+class TimestampedError extends TaggedError("TimestampedError")<{
+  reason: string;
+  timestamp: number;
+  message: string;
+}>() {
+  constructor(args: { reason: string }) {
+    super({ ...args, message: args.reason, timestamp: Date.now() });
+  }
+}
+```
+
+### 5. Static method migrations
+
+| V1 | V2 |
+|----|-----|
+| `TaggedError.match(err, handlers)` | `matchError(err, handlers)` |
+| `TaggedError.matchPartial(err, handlers, fallback)` | `matchErrorPartial(err, handlers, fallback)` |
+| `TaggedError.isTaggedError(x)` | `isTaggedError(x)` or `TaggedError.is(x)` |
+
+### 6. Import updates
+
+```typescript
+// BEFORE
+import { TaggedError } from "better-result";
+
+// AFTER
+import { TaggedError, matchError, matchErrorPartial, isTaggedError } from "better-result";
+```
+
+## Workflow
+
+1. **Find TaggedError classes**: Search for `extends TaggedError` in the codebase
+2. **Analyze each class**:
+   - Extract `_tag` value
+   - Identify constructor params and their types
+   - Check for constructor logic (validation, computed message, side effects)
+3. **Transform class**:
+   - Simple: Remove constructor, add props to type parameter
+   - Complex: Keep custom constructor, transform to object args
+4. **Update usages**: Change `new FooError(a, b)` to `new FooError({ a, b, message })`
+5. **Migrate static methods**: `TaggedError.match` → `matchError`, etc.
+6. **Update imports**: Add `matchError`, `matchErrorPartial`, `isTaggedError`
+
+## Example Full Migration
+
+**Input:**
+```typescript
+import { TaggedError } from "better-result";
+
+class NotFoundError extends TaggedError {
+  readonly _tag = "NotFoundError" as const;
+  constructor(readonly id: string) {
+    super(`Not found: ${id}`);
+  }
+}
+
+class NetworkError extends TaggedError {
+  readonly _tag = "NetworkError" as const;
+  constructor(readonly url: string, readonly status: number) {
+    super(`Request to ${url} failed with ${status}`);
+  }
+}
+
+type AppError = NotFoundError | NetworkError;
+
+const handleError = (err: AppError) =>
+  TaggedError.match(err, {
+    NotFoundError: (e) => `Missing: ${e.id}`,
+    NetworkError: (e) => `Failed: ${e.url}`,
+  });
+```
+
+**Output:**
+```typescript
+import { TaggedError, matchError } from "better-result";
+
+class NotFoundError extends TaggedError("NotFoundError")<{
+  id: string;
+  message: string;
+}>() {
+  constructor(args: { id: string }) {
+    super({ ...args, message: `Not found: ${args.id}` });
+  }
+}
+
+class NetworkError extends TaggedError("NetworkError")<{
+  url: string;
+  status: number;
+  message: string;
+}>() {
+  constructor(args: { url: string; status: number }) {
+    super({ ...args, message: `Request to ${args.url} failed with ${args.status}` });
+  }
+}
+
+type AppError = NotFoundError | NetworkError;
+
+const handleError = (err: AppError) =>
+  matchError(err, {
+    NotFoundError: (e) => `Missing: ${e.id}`,
+    NetworkError: (e) => `Failed: ${e.url}`,
+  });
+```

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,122 +1,211 @@
 import { describe, expect, it } from "bun:test";
-import { TaggedError, UnhandledException } from "./error";
+import { TaggedError, UnhandledException, matchError, matchErrorPartial, isTaggedError } from "./error";
 
-class NotFoundError extends TaggedError {
-  readonly _tag = "NotFoundError" as const;
-  constructor(readonly id: string) {
-    super(`Not found: ${id}`);
-  }
-}
+class NotFoundError extends TaggedError("NotFoundError")<{
+  id: string;
+  message: string;
+}>() {}
 
-class ValidationError extends TaggedError {
-  readonly _tag = "ValidationError" as const;
-  constructor(readonly field: string) {
-    super(`Invalid field: ${field}`);
-  }
-}
+class ValidationError extends TaggedError("ValidationError")<{
+  field: string;
+  message: string;
+}>() {}
 
-class NetworkError extends TaggedError {
-  readonly _tag = "NetworkError" as const;
-  constructor(readonly url: string) {
-    super(`Network error: ${url}`);
-  }
-}
+class NetworkError extends TaggedError("NetworkError")<{
+  url: string;
+  message: string;
+}>() {}
 
 type AppError = NotFoundError | ValidationError | NetworkError;
 
 describe("TaggedError", () => {
   describe("construction", () => {
-    it("sets name to constructor name", () => {
-      const error = new NotFoundError("123");
+    it("sets name to tag", () => {
+      const error = new NotFoundError({ id: "123", message: "Not found: 123" });
       expect(error.name).toBe("NotFoundError");
     });
 
     it("sets message", () => {
-      const error = new NotFoundError("123");
+      const error = new NotFoundError({ id: "123", message: "Not found: 123" });
       expect(error.message).toBe("Not found: 123");
     });
 
     it("has _tag discriminator", () => {
-      const error = new NotFoundError("123");
+      const error = new NotFoundError({ id: "123", message: "Not found" });
       expect(error._tag).toBe("NotFoundError");
     });
 
     it("preserves custom properties", () => {
-      const error = new NotFoundError("abc");
+      const error = new NotFoundError({ id: "abc", message: "Not found" });
       expect(error.id).toBe("abc");
     });
 
     it("chains cause in stack trace", () => {
       const cause = new Error("root cause");
-      class ErrorWithCause extends TaggedError {
-        readonly _tag = "ErrorWithCause" as const;
-        constructor() {
-          super("wrapper", { cause });
-        }
-      }
-      const error = new ErrorWithCause();
+
+      class ErrorWithCause extends TaggedError("ErrorWithCause")<{
+        message: string;
+        cause: unknown;
+      }>() {}
+
+      const error = new ErrorWithCause({ message: "wrapper", cause });
       expect(error.stack).toContain("Caused by:");
       expect(error.stack).toContain("root cause");
     });
-  });
 
-  describe("isError", () => {
-    it("returns true for Error", () => {
-      expect(TaggedError.isError(new Error())).toBe(true);
-    });
+    it("indents nested causes", () => {
+      const inner = new Error("inner");
+      class MiddleError extends TaggedError("MiddleError")<{
+        message: string;
+        cause: unknown;
+      }>() {}
+      class OuterError extends TaggedError("OuterError")<{
+        message: string;
+        cause: unknown;
+      }>() {}
 
-    it("returns true for TaggedError", () => {
-      expect(TaggedError.isError(new NotFoundError("x"))).toBe(true);
-    });
+      const middle = new MiddleError({ message: "middle", cause: inner });
+      const outer = new OuterError({ message: "outer", cause: middle });
 
-    it("returns false for non-errors", () => {
-      expect(TaggedError.isError("string")).toBe(false);
-      expect(TaggedError.isError(null)).toBe(false);
-      expect(TaggedError.isError({ message: "fake" })).toBe(false);
+      expect(outer.stack).toContain("Caused by:");
+      // Should have nested indentation
+      const lines = outer.stack?.split("\n") ?? [];
+      const causedByLines = lines.filter((l) => l.includes("Caused by:"));
+      expect(causedByLines.length).toBeGreaterThanOrEqual(1);
     });
   });
 
   describe("isTaggedError", () => {
     it("returns true for TaggedError", () => {
-      expect(TaggedError.isTaggedError(new NotFoundError("x"))).toBe(true);
+      expect(isTaggedError(new NotFoundError({ id: "x", message: "not found" }))).toBe(true);
     });
 
     it("returns false for plain Error", () => {
-      expect(TaggedError.isTaggedError(new Error())).toBe(false);
+      expect(isTaggedError(new Error())).toBe(false);
     });
 
     it("returns false for non-errors", () => {
-      expect(TaggedError.isTaggedError({ _tag: "fake" })).toBe(false);
+      expect(isTaggedError({ _tag: "fake" })).toBe(false);
     });
   });
 
-  describe("match", () => {
+  describe("static is() method", () => {
+    it("returns true for own instance", () => {
+      const err = new NotFoundError({ id: "123", message: "not found" });
+      expect(NotFoundError.is(err)).toBe(true);
+    });
+
+    it("returns false for different TaggedError", () => {
+      const err = new ValidationError({ field: "email", message: "invalid" });
+      expect(NotFoundError.is(err)).toBe(false);
+    });
+
+    it("returns false for plain Error", () => {
+      expect(NotFoundError.is(new Error())).toBe(false);
+    });
+
+    it("returns false for non-errors", () => {
+      expect(NotFoundError.is({ _tag: "NotFoundError" })).toBe(false);
+    });
+
+    it("FooError.is(fooError) is true", () => {
+      class FooError extends TaggedError("FooError")<{ message: string }>() {}
+      const fooError = new FooError({ message: "foo" });
+      expect(FooError.is(fooError)).toBe(true);
+    });
+
+    it("BarError.is(fooError) is false", () => {
+      class FooError extends TaggedError("FooError")<{ message: string }>() {}
+      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      const fooError = new FooError({ message: "foo" });
+      expect(BarError.is(fooError)).toBe(false);
+    });
+
+    it("isTaggedError(fooError) is true for any TaggedError", () => {
+      class FooError extends TaggedError("FooError")<{ message: string }>() {}
+      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      const fooError = new FooError({ message: "foo" });
+      const barError = new BarError({ message: "bar" });
+      expect(isTaggedError(fooError)).toBe(true);
+      expect(isTaggedError(barError)).toBe(true);
+    });
+
+    it("TaggedError.is(fooError) is true for any TaggedError", () => {
+      class FooError extends TaggedError("FooError")<{ message: string }>() {}
+      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      const fooError = new FooError({ message: "foo" });
+      const barError = new BarError({ message: "bar" });
+      expect(TaggedError.is(fooError)).toBe(true);
+      expect(TaggedError.is(barError)).toBe(true);
+    });
+
+    it("TaggedError.is returns false for plain Error", () => {
+      expect(TaggedError.is(new Error())).toBe(false);
+    });
+  });
+
+  describe("matchError", () => {
     const matchAppError = (error: AppError) =>
-      TaggedError.match(error, {
+      matchError(error, {
         NotFoundError: (e) => `missing: ${e.id}`,
         ValidationError: (e) => `invalid: ${e.field}`,
         NetworkError: (e) => `network: ${e.url}`,
       });
 
     it("matches NotFoundError", () => {
-      const error: AppError = new NotFoundError("123");
+      const error: AppError = new NotFoundError({ id: "123", message: "not found" });
       expect(matchAppError(error)).toBe("missing: 123");
     });
 
     it("matches ValidationError", () => {
-      const error: AppError = new ValidationError("email");
+      const error: AppError = new ValidationError({ field: "email", message: "invalid" });
       expect(matchAppError(error)).toBe("invalid: email");
     });
 
     it("matches NetworkError", () => {
-      const error: AppError = new NetworkError("https://api.example.com");
+      const error: AppError = new NetworkError({ url: "https://api.example.com", message: "failed" });
       expect(matchAppError(error)).toBe("network: https://api.example.com");
+    });
+
+    it("works data-last (pipeable)", () => {
+      const error: AppError = new NotFoundError({ id: "456", message: "not found" });
+      const matcher = matchError<AppError, string>({
+        NotFoundError: (e) => `missing: ${e.id}`,
+        ValidationError: (e) => `invalid: ${e.field}`,
+        NetworkError: (e) => `network: ${e.url}`,
+      });
+      expect(matcher(error)).toBe("missing: 456");
+    });
+
+    it("provides type narrowing in handlers", () => {
+      const error = new NotFoundError({ id: "789", message: "not found" }) as AppError;
+      const result = matchError(error, {
+        NotFoundError: (e) => {
+          // Type is narrowed: e.id exists, e.field would error
+          const id: string = e.id;
+          const tag: "NotFoundError" = e._tag;
+          return { id, tag };
+        },
+        ValidationError: (e) => {
+          // Type is narrowed: e.field exists
+          const field: string = e.field;
+          const tag: "ValidationError" = e._tag;
+          return { field, tag };
+        },
+        NetworkError: (e) => {
+          // Type is narrowed: e.url exists
+          const url: string = e.url;
+          const tag: "NetworkError" = e._tag;
+          return { url, tag };
+        },
+      });
+      expect(result).toEqual({ id: "789", tag: "NotFoundError" });
     });
   });
 
-  describe("matchPartial", () => {
+  describe("matchErrorPartial", () => {
     const matchPartialAppError = (error: AppError) =>
-      TaggedError.matchPartial(
+      matchErrorPartial(
         error,
         {
           NotFoundError: (e) => `missing: ${e.id}`,
@@ -125,12 +214,12 @@ describe("TaggedError", () => {
       );
 
     it("matches known tag", () => {
-      const error: AppError = new NotFoundError("123");
+      const error: AppError = new NotFoundError({ id: "123", message: "not found" });
       expect(matchPartialAppError(error)).toBe("missing: 123");
     });
 
     it("falls back for unhandled tag", () => {
-      const error: AppError = new NetworkError("https://api.example.com");
+      const error: AppError = new NetworkError({ url: "https://api.example.com", message: "failed" });
       expect(matchPartialAppError(error)).toBe("fallback: NetworkError");
     });
   });

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,115 +1,239 @@
+import { dual } from "./dual";
+
+/** Serialize cause for JSON output */
+const serializeCause = (cause: unknown): unknown => {
+  if (cause instanceof Error) {
+    return { name: cause.name, message: cause.message, stack: cause.stack };
+  }
+  return cause;
+};
+
+/** Any tagged error (for generic constraints) */
+type AnyTaggedError = Error & { readonly _tag: string };
+
+/** Type guard for any tagged error */
+const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
+  return value instanceof Error && "_tag" in value && typeof value._tag === "string";
+};
+
 /**
- * Base class for tagged errors.
- * Uses _tag discriminator for exhaustive pattern matching.
+ * Factory for tagged error classes.
  *
  * @example
- * class NotFoundError extends TaggedError {
- *   readonly _tag = "NotFoundError" as const;
- *   constructor(readonly id: string) {
- *     super(`Not found: ${id}`);
- *   }
- * }
+ * class NotFoundError extends TaggedError("NotFoundError")<{
+ *   id: string;
+ *   message: string;
+ * }> {}
+ *
+ * const err = new NotFoundError({ id: "123", message: "Not found: 123" });
+ * err._tag    // "NotFoundError"
+ * err.id      // "123"
+ * err.message // "Not found: 123"
+ *
+ * // Check if any tagged error
+ * TaggedError.is(err) // true
  */
-export abstract class TaggedError extends Error {
-  abstract readonly _tag: string;
+export const TaggedError: {
+  <Tag extends string>(tag: Tag): <Props extends Record<string, unknown> = {}>() => TaggedErrorClass<
+    Tag,
+    Props
+  >;
+  /** Type guard for any TaggedError instance */
+  is(value: unknown): value is AnyTaggedError;
+} = Object.assign(
+  <Tag extends string>(tag: Tag) =>
+  <Props extends Record<string, unknown> = {}>(): TaggedErrorClass<Tag, Props> => {
+    class Base extends Error {
+      readonly _tag: Tag = tag;
 
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
+      /** Type guard for this error class */
+      static is(value: unknown): value is Base {
+        return value instanceof Base;
+      }
 
-    Object.setPrototypeOf(this, new.target.prototype);
+      constructor(args?: Props) {
+        const message =
+          args && "message" in args && typeof args.message === "string" ? args.message : undefined;
+        const cause = args && "cause" in args ? args.cause : undefined;
 
-    this.name = this.constructor.name;
+        super(message, cause !== undefined ? { cause } : undefined);
 
-    if (options?.cause !== undefined && options.cause instanceof Error) {
-      this.stack = `${this.stack}\nCaused by: ${options.cause.stack}`;
+        if (args) {
+          Object.assign(this, args);
+        }
+
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = tag;
+
+        if (cause instanceof Error && cause.stack) {
+          const indented = cause.stack.replace(/\n/g, "\n  ");
+          this.stack = `${this.stack}\nCaused by: ${indented}`;
+        }
+      }
+
+      toJSON(): object {
+        return {
+          ...this,
+          _tag: this._tag,
+          name: this.name,
+          message: this.message,
+          cause: serializeCause(this.cause),
+          stack: this.stack,
+        };
+      }
     }
-  }
 
-  /**
-   * Type guard for any Error instance.
-   *
-   * @example
-   * if (TaggedError.isError(value)) { value.message }
-   */
-  static override isError(value: unknown): value is Error {
-    return value instanceof Error;
-  }
+    // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
+    return Base as unknown as TaggedErrorClass<Tag, Props>;
+  },
+  { is: isAnyTaggedError },
+);
 
-  /**
-   * Type guard for TaggedError instances.
-   *
-   * @example
-   * if (TaggedError.isTaggedError(value)) { value._tag }
-   */
-  static isTaggedError(value: unknown): value is TaggedError {
-    return value instanceof Error && "_tag" in value && typeof value._tag === "string";
-  }
+/** Instance type produced by TaggedError factory */
+export type TaggedErrorInstance<Tag extends string, Props> = Error & {
+  readonly _tag: Tag;
+  toJSON(): object;
+} & Readonly<Props>;
 
-  /**
-   * Exhaustive pattern match on tagged error union.
-   * Requires handlers for all _tag variants.
-   *
-   * @template E Tagged error union type.
-   * @template T Return type.
-   * @param error Error to match.
-   * @param handlers Object mapping _tag to handler function.
-   * @returns Result of matched handler.
-   *
-   * @example
-   * TaggedError.match(error, {
-   *   NotFoundError: (e) => `Missing: ${e.id}`,
-   *   ValidationError: (e) => `Invalid: ${e.field}`,
-   * });
-   */
-  static match<E extends TaggedError, T>(
-    error: E,
-    handlers: { [K in E["_tag"]]: (e: Extract<E, { _tag: K }>) => T },
-  ): T {
-    const tag = error._tag as E["_tag"];
-    const handler = handlers[tag];
-    if (!handler) {
-      throw new Error(`No handler for error tag: ${error._tag}`);
-    }
-    return handler(error as Extract<E, { _tag: typeof tag }>);
-  }
+/** Class type produced by TaggedError factory */
+export type TaggedErrorClass<Tag extends string, Props> = {
+  new (...args: keyof Props extends never ? [args?: {}] : [args: Props]): TaggedErrorInstance<
+    Tag,
+    Props
+  >;
+  /** Type guard for this error class */
+  is(value: unknown): value is TaggedErrorInstance<Tag, Props>;
+};
 
-  /**
-   * Partial pattern match with fallback for unhandled tags.
-   *
-   * @template E Tagged error union type.
-   * @template T Return type.
-   * @param error Error to match.
-   * @param handlers Partial object mapping _tag to handler function.
-   * @param otherwise Fallback handler for unmatched tags.
-   * @returns Result of matched handler or otherwise.
-   *
-   * @example
-   * TaggedError.matchPartial(error, {
-   *   NotFoundError: (e) => `Missing: ${e.id}`,
-   * }, (e) => `Unknown error: ${e.message}`);
-   */
-  static matchPartial<E extends TaggedError, T>(
-    error: E,
-    handlers: { [K in E["_tag"]]?: (e: Extract<E, { _tag: K }>) => T },
-    otherwise: (e: E) => T,
-  ): T {
-    const tag = error._tag as E["_tag"];
-    const handler = handlers[tag];
+/** Handler map for exhaustive matching */
+type MatchHandlers<E extends AnyTaggedError, R> = {
+  [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => R;
+};
+
+/**
+ * Exhaustive pattern match on tagged error union.
+ *
+ * @example
+ * // Data-first
+ * matchError(err, {
+ *   NotFoundError: (e) => `Missing: ${e.id}`,
+ *   ValidationError: (e) => `Invalid: ${e.field}`,
+ * });
+ *
+ * // Data-last (pipeable)
+ * pipe(err, matchError({
+ *   NotFoundError: (e) => `Missing: ${e.id}`,
+ *   ValidationError: (e) => `Invalid: ${e.field}`,
+ * }));
+ */
+export const matchError: {
+  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R;
+  <E extends AnyTaggedError, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
+} = dual(
+  2,
+  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R => {
+    const handler = handlers[err._tag as E["_tag"]];
+    // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
+    return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
+  },
+);
+
+/**
+ * Partial pattern match with fallback for unhandled tags.
+ *
+ * @example
+ * matchErrorPartial(err, {
+ *   NotFoundError: (e) => `Missing: ${e.id}`,
+ * }, (e) => `Unknown: ${e.message}`);
+ */
+export const matchErrorPartial: {
+  <E extends AnyTaggedError, R>(
+    err: E,
+    handlers: Partial<MatchHandlers<E, R>>,
+    fallback: (e: E) => R,
+  ): R;
+  <E extends AnyTaggedError, R>(
+    handlers: Partial<MatchHandlers<E, R>>,
+    fallback: (e: E) => R,
+  ): (err: E) => R;
+} = dual(
+  3,
+  <E extends AnyTaggedError, R>(
+    err: E,
+    handlers: Partial<MatchHandlers<E, R>>,
+    fallback: (e: E) => R,
+  ): R => {
+    const handler = handlers[err._tag as E["_tag"]];
     if (handler) {
-      return handler(error as Extract<E, { _tag: typeof tag }>);
+      // SAFETY: handler exists and matches the tag
+      return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
     }
-    return otherwise(error);
+    return fallback(err);
+  },
+);
+
+/**
+ * Type guard for tagged error instances.
+ *
+ * @example
+ * if (isTaggedError(value)) { value._tag }
+ */
+export const isTaggedError = isAnyTaggedError;
+
+/**
+ * Wraps exceptions caught by Result.try/tryPromise.
+ * Custom constructor derives message from cause.
+ */
+export class UnhandledException extends TaggedError("UnhandledException")<{
+  message: string;
+  cause: unknown;
+}>() {
+  constructor(args: { cause: unknown }) {
+    const message =
+      args.cause instanceof Error
+        ? `Unhandled exception: ${args.cause.message}`
+        : `Unhandled exception: ${String(args.cause)}`;
+    super({ message, cause: args.cause });
   }
 }
 
 /**
- * Wraps uncaught exceptions from Result.try/tryPromise.
+ * Unrecoverable error — user code threw inside Result operations.
+ *
+ * @example
+ * // Panic in generator cleanup:
+ * Result.gen(function* () {
+ *   try {
+ *     yield* Result.err("expected error");
+ *   } finally {
+ *     throw new Error("cleanup failed");  // Panic!
+ *   }
+ * });
+ *
+ * // Panic in combinator:
+ * Result.ok(1).map(() => { throw new Error("oops"); });  // Panic!
  */
-export class UnhandledException extends TaggedError {
-  readonly _tag = "UnhandledException" as const;
+export class Panic extends TaggedError("Panic")<{
+  message: string;
+  cause?: unknown;
+}>() {}
 
-  constructor(options: { cause: unknown }) {
-    const message = options.cause instanceof Error ? options.cause.message : String(options.cause);
-    super(`Unhandled exception: ${message}`, { cause: options.cause });
-  }
-}
+/**
+ * Type guard for Panic instances.
+ *
+ * @example
+ * if (isPanic(value)) { value.cause }
+ */
+export const isPanic = (value: unknown): value is Panic => {
+  return value instanceof Panic;
+};
+
+/**
+ * Throw an unrecoverable Panic.
+ *
+ * @example
+ * panic("something went wrong", cause);
+ */
+export const panic = (message: string, cause?: unknown): never => {
+  throw new Panic({ message, cause });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
 export { Result, Ok, Err } from "./result";
-export type { Result as ResultType } from "./result";
-export { TaggedError, UnhandledException } from "./error";
+export type { InferOk, InferErr } from "./result";
+export {
+  Panic,
+  panic,
+  isPanic,
+  TaggedError,
+  UnhandledException,
+  matchError,
+  matchErrorPartial,
+  isTaggedError,
+} from "./error";
+export type { TaggedErrorInstance, TaggedErrorClass } from "./error";


### PR DESCRIPTION
## Summary

- **BREAKING**: TaggedError API changed from class-based to factory pattern
- **NEW**: Panic for unrecoverable errors in callbacks
- **NEW**: CLI with `init` and `migrate` commands
- **NEW**: AI agent skills for adoption/migration

## Breaking Changes

| v1 | v2 |
|----|-----|
| `extends TaggedError` + `_tag` | `extends TaggedError("Tag")<Props>()` |
| `TaggedError.match()` | `matchError()` |
| `TaggedError.matchPartial()` | `matchErrorPartial()` |
| `TaggedError.isTaggedError()` | `isTaggedError()` |

## New Features

- `Panic` - thrown when user callbacks throw inside Result operations
- `npx better-result init` - interactive setup with AI agent skills
- `npx better-result migrate` - detects version, guides v1→v2 migration
- Agent skills for OpenCode/Claude/Codex

## Docs

- `MIGRATION.md` - comprehensive v1→v2 guide
- Updated README with v2 examples