### PR TITLE
add Result.serialize/deserialize, export SerializedResult types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Result, Ok, Err } from "./result";
-export type { InferOk, InferErr } from "./result";
+export type { InferOk, InferErr, SerializedResult, SerializedOk, SerializedErr } from "./result";
 export {
   Panic,
   panic,


### PR DESCRIPTION
## Summary

- Export `SerializedResult<T, E>`, `SerializedOk<T>`, `SerializedErr<E>` types
- Add `Result.serialize()` to convert Result to plain object
- Add `Result.deserialize()` to rehydrate serialized Results
- Deprecate `Result.hydrate` (removal in 3.0)

Enables typed serialization boundaries for better RPC capabilities.

closes #6 