### PR TITLE
Add Result.partition to split array of Results into ok/error values

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ const result = Result.deserialize<User, ValidationError>(serialized);
 | `Result.await(promise)`          | Wrap Promise<Result> for generators     |
 | `Result.serialize(result)`       | Convert Result to plain object          |
 | `Result.deserialize(value)`      | Rehydrate serialized Result             |
+| `Result.partition(results)`      | Split array into [okValues, errValues]  |
 
 ### Instance Methods
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1349,4 +1349,28 @@ describe("Type Inference", () => {
       expect(process("good").unwrap()).toBe("GOOD");
     });
   });
+
+  describe("partition", () => {
+    it("returns empty arrays for empty input", () => {
+      expect(Result.partition([])).toEqual([[], []]);
+    });
+
+    it("collects all Ok values when no errors", () => {
+      const results = [Result.ok(1), Result.ok(2), Result.ok(3)];
+      expect(Result.partition(results)).toEqual([[1, 2, 3], []]);
+    });
+
+    it("collects all Err values when no successes", () => {
+      const results = [Result.err("a"), Result.err("b")];
+      expect(Result.partition(results)).toEqual([[], ["a", "b"]]);
+    });
+
+    it("splits mixed results preserving order", () => {
+      const results = [Result.ok(1), Result.err("a"), Result.ok(2), Result.err("b")];
+      expect(Result.partition(results)).toEqual([
+        [1, 2],
+        ["a", "b"],
+      ]);
+    });
+  });
 });

--- a/src/result.ts
+++ b/src/result.ts
@@ -725,6 +725,19 @@ const hydrate = <T, E>(value: unknown): Result<T, E> | null => {
   return deserialize(value);
 };
 
+const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {
+  const oks: T[] = [];
+  const errs: E[] = [];
+  for (const r of results) {
+    if (r.status === "ok") {
+      oks.push(r.value);
+    } else {
+      errs.push(r.error);
+    }
+  }
+  return [oks, errs];
+};
+
 /**
  * Utilities for creating and handling Result types.
  *
@@ -890,4 +903,11 @@ export const Result = {
    * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
    */
   hydrate,
+  /**
+   * Splits array of Results into tuple of [okValues, errorValues].
+   *
+   * @example
+   * partition([ok(1), err("a"), ok(2)]) // [[1, 2], ["a"]]
+   */
+  partition,
 } as const;


### PR DESCRIPTION
Splits an array of Results into a tuple of `[okValues[], errorValues[]]`, preserving order within each array. This is one I stole from Gleam ;)