### PR TITLE
add isOk/isErr type-narrowing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ const result = Result.deserialize<User, ValidationError>(serialized);
 
 | Method                | Description                           |
 | --------------------- | ------------------------------------- |
+| `.isOk()`             | Type guard, narrows to Ok             |
+| `.isErr()`            | Type guard, narrows to Err            |
 | `.map(fn)`            | Transform success value               |
 | `.mapError(fn)`       | Transform error value                 |
 | `.andThen(fn)`        | Chain Result-returning function       |

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -57,6 +57,72 @@ describe("Result", () => {
     });
   });
 
+  describe("Ok.isOk / Ok.isErr methods", () => {
+    it("Ok.isOk() returns true", () => {
+      const ok = Result.ok(42);
+      expect(ok.isOk()).toBe(true);
+    });
+
+    it("Ok.isErr() returns false", () => {
+      const ok = Result.ok(42);
+      expect(ok.isErr()).toBe(false);
+    });
+
+    it("Err.isOk() returns false", () => {
+      const err = Result.err("fail");
+      expect(err.isOk()).toBe(false);
+    });
+
+    it("Err.isErr() returns true", () => {
+      const err = Result.err("fail");
+      expect(err.isErr()).toBe(true);
+    });
+
+    it("narrows Result to Ok when isOk() returns true", () => {
+      const result: Result<number, string> = Result.ok(42);
+      if (result.isOk()) {
+        // Type should be narrowed to Ok<number, string>
+        const value: number = result.value;
+        expect(value).toBe(42);
+      } else {
+        expect.unreachable("should be Ok");
+      }
+    });
+
+    it("narrows Result to Err when isOk() returns false", () => {
+      const result: Result<number, string> = Result.err("fail");
+      if (!result.isOk()) {
+        // Type should be narrowed to Err<number, string>
+        const error: string = result.error;
+        expect(error).toBe("fail");
+      } else {
+        expect.unreachable("should be Err");
+      }
+    });
+
+    it("narrows Result to Err when isErr() returns true", () => {
+      const result: Result<number, string> = Result.err("fail");
+      if (result.isErr()) {
+        // Type should be narrowed to Err<number, string>
+        const error: string = result.error;
+        expect(error).toBe("fail");
+      } else {
+        expect.unreachable("should be Err");
+      }
+    });
+
+    it("narrows Result to Ok when isErr() returns false", () => {
+      const result: Result<number, string> = Result.ok(42);
+      if (!result.isErr()) {
+        // Type should be narrowed to Ok<number, string>
+        const value: number = result.value;
+        expect(value).toBe(42);
+      } else {
+        expect.unreachable("should be Ok");
+      }
+    });
+  });
+
   describe("try", () => {
     it("returns Ok when function succeeds", () => {
       const result = Result.try(() => 42);
@@ -1046,6 +1112,7 @@ describe("Result", () => {
       expect(Result.hydrate(42)).toBe(null);
     });
   });
+
 });
 
 describe("Monad Laws", () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -34,6 +34,16 @@ export class Ok<A, E = never> {
   readonly status = "ok" as const;
   constructor(readonly value: A) {}
 
+  /** Returns true, narrowing Result to Ok. */
+  isOk(): this is Ok<A, E> {
+    return true;
+  }
+
+  /** Returns false, narrowing Result to Err. */
+  isErr(): this is Err<A, E> {
+    return false;
+  }
+
   /**
    * Transforms success value.
    *
@@ -194,6 +204,16 @@ export class Ok<A, E = never> {
 export class Err<T, E> {
   readonly status = "error" as const;
   constructor(readonly error: E) {}
+
+  /** Returns false, narrowing Result to Ok. */
+  isOk(): this is Ok<T, E> {
+    return false;
+  }
+
+  /** Returns true, narrowing Result to Err. */
+  isErr(): this is Err<T, E> {
+    return true;
+  }
 
   /**
    * No-op on Err, returns self with new phantom T.


### PR DESCRIPTION
Adds `isOk()` and `isErr()` instance methods to `Ok` and `Err` classes for convenient type narrowing.

## Summary
- `Ok.isOk()` returns `true` and narrows type to `Ok<A, E>`
- `Ok.isErr()` returns `false` and narrows type to `Err<A, E>`
- `Err.isOk()` returns `false` and narrows type to `Ok<T, E>`
- `Err.isErr()` returns `true` and narrows type to `Err<T, E>`

## Example
```typescript
const result: Result<number, string> = getResult();

if (result.isOk()) {
  console.log(result.value); // type narrowed, .value accessible
}

if (result.isErr()) {
  console.log(result.error); // type narrowed, .error accessible
}
```