### PR TITLE
add intoOk/intoErr phantom type coercion helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ const result = Result.deserialize<User, ValidationError>(serialized);
 
 | Method                | Description                           |
 | --------------------- | ------------------------------------- |
+| `.intoOk()`           | Coerce phantom T type (Err only)      |
+| `.intoErr()`          | Coerce phantom E type (Ok only)       |
 | `.map(fn)`            | Transform success value               |
 | `.mapError(fn)`       | Transform error value                 |
 | `.andThen(fn)`        | Chain Result-returning function       |

--- a/src/result.ts
+++ b/src/result.ts
@@ -35,6 +35,17 @@ export class Ok<A, E = never> {
   constructor(readonly value: A) {}
 
   /**
+   * Coerces phantom error type. Useful for returning from typed functions.
+   * @example
+   * function getUser(): Result<User, AppError> {
+   *   return Result.ok(user).intoErr(); // infers AppError from return type
+   * }
+   */
+  intoErr<E2>(): Ok<A, E2> {
+    return this as unknown as Ok<A, E2>;
+  }
+
+  /**
    * Transforms success value.
    *
    * @template B Transformed type.
@@ -194,6 +205,17 @@ export class Ok<A, E = never> {
 export class Err<T, E> {
   readonly status = "error" as const;
   constructor(readonly error: E) {}
+
+  /**
+   * Coerces phantom success type. Useful for returning from typed functions.
+   * @example
+   * function getUser(): Result<User, NotFound> {
+   *   return Result.err(new NotFound()).intoOk(); // infers User from return type
+   * }
+   */
+  intoOk<T2>(): Err<T2, E> {
+    return this as unknown as Err<T2, E>;
+  }
 
   /**
    * No-op on Err, returns self with new phantom T.


### PR DESCRIPTION
Adds `intoOk()` and `intoErr()` methods for coercing phantom types when returning from typed functions.

## Summary
- `Ok.intoErr<E2>()` - coerces phantom error type `E` to `E2`
- `Err.intoOk<T2>()` - coerces phantom success type `T` to `T2`

These are zero-cost at runtime (same instance returned) and help TypeScript infer the correct type from function return signatures.

## Motivation
When returning early from a function with a typed `Result<T, E>` return type, TypeScript can't always infer the phantom type:

```typescript
function numberResult(): Result<number, number> {
  return Result.ok(42);
}

function stringOrNumberResult(): Result<string, number> {
  const result = numberResult();

  if (result.isErr()) {
    // Previously: return Result.err(result.error);
    // Now:
    return result.intoOk(); // Generic type can usually be inferred.
  }
  
  return Result.ok(result.value.toString());
}
```

The asymmetric naming (intoOk on Err, intoErr on Ok) ensures you can only call the method when you know the variant. I'm 50/50 on the names themselves, though. Happy to take suggestions.

Technically the same could be accomplished with `andThen` or `map`, but that would require passing a function that returns a value of the desired type. This is slightly more readable in those cases.

This becomes less needed with `Result.gen`, but it would enable us to migrate slowly more easily, especially in functions with many result checks.
