### PR TITLE
fix: make Err covariant in phantom T for ergonomic early returns

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -206,7 +206,7 @@ export class Err<T, E> {
   constructor(readonly error: E) {}
 
   /** Returns false, narrowing Result to Ok. */
-  isOk(): this is Ok<T, E> {
+  isOk(): this is Ok<never, E> {
     return false;
   }
 
@@ -222,7 +222,7 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Self.
    */
-  map<U>(_fn: (a: T) => U): Err<U, E> {
+  map<U>(_fn: (a: never) => U): Err<U, E> {
     // SAFETY: T is phantom (not used at runtime). Err only holds `error: E`.
     return this as unknown as Err<U, E>;
   }
@@ -250,7 +250,7 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Self.
    */
-  andThen<U, E2>(_fn: (a: T) => Result<U, E2>): Err<U, E | E2> {
+  andThen<U, E2>(_fn: (a: never) => Result<U, E2>): Err<U, E | E2> {
     // SAFETY: T is phantom, E⊂(E|E2) so error type widens safely.
     return this as unknown as Err<U, E | E2>;
   }
@@ -263,7 +263,7 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Promise of self.
    */
-  andThenAsync<U, E2>(_fn: (a: T) => Promise<Result<U, E2>>): Promise<Err<U, E | E2>> {
+  andThenAsync<U, E2>(_fn: (a: never) => Promise<Result<U, E2>>): Promise<Err<U, E | E2>> {
     // SAFETY: T is phantom, E⊂(E|E2) so error type widens safely.
     return Promise.resolve(this as unknown as Err<U, E | E2>);
   }
@@ -279,7 +279,7 @@ export class Err<T, E> {
    * @example
    * err("fail").match({ ok: x => x, err: e => e.length }) // 4
    */
-  match<R>(handlers: { ok: (a: T) => R; err: (e: E) => R }): R {
+  match<R>(handlers: { ok: (a: never) => R; err: (e: E) => R }): R {
     return tryOrPanic(() => handlers.err(this.error), "match err handler threw");
   }
 
@@ -317,7 +317,7 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Self.
    */
-  tap(_fn: (a: T) => void): Err<T, E> {
+  tap(_fn: (a: never) => void): Err<T, E> {
     return this;
   }
 
@@ -327,7 +327,7 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Promise of self.
    */
-  tapAsync(_fn: (a: T) => Promise<void>): Promise<Err<T, E>> {
+  tapAsync(_fn: (a: never) => Promise<void>): Promise<Err<T, E>> {
     return Promise.resolve(this);
   }
 
@@ -335,7 +335,7 @@ export class Err<T, E> {
    * Makes Err yieldable in Result.gen blocks.
    * Yields Err<never, E> for proper union inference across multiple yields.
    */
-  *[Symbol.iterator](): Generator<Err<never, E>, T, unknown> {
+  *[Symbol.iterator](): Generator<Err<never, E>, never, unknown> {
     // SAFETY: T is phantom (not used at runtime). Casting to Err<never, E>
     // ensures all yields have phantom T as `never`, enabling TypeScript to
     // unify: Err<never, E1> | Err<never, E2> extracts to E1 | E2


### PR DESCRIPTION
## Summary

Makes `Err<T, E>` covariant in its phantom success type `T`, enabling early returns without manual type coercion.

**Before:** Early returning an `Err` required workarounds because phantom `T` caused type mismatches:
```typescript
function stringOrNumberResult(): Result<string, number> {
  const result = numberResult(); // Result<number, number>
  if (result.isErr()) {
    return result; // ❌ Type error: Err<number, _> not assignable to Result<string, _>
  }
  return Result.ok(result.value.toString());
}
```

**After:** Early returns just work:
```typescript
function stringOrNumberResult(): Result<string, number> {
  const result = numberResult();
  if (result.isErr()) {
    return result; // ✅ Works!
  }
  return Result.ok(result.value.toString());
}
```

## The Problem

`Err<T, E>` carries a phantom type `T` for unification with `Ok<T, E>`. Methods like `map` had signatures that put `T` in contravariant (parameter) position:

```typescript
map<U>(_fn: (a: T) => U): Err<U, E>
```

This made `Err` **invariant** in `T`, preventing assignment even though `T` doesn't exist at runtime.

## The Solution

Change callback parameters from `T` to `never` for methods that are never invoked on `Err`:

```typescript
map<U>(_fn: (a: never) => U): Err<U, E>
```

This is semantically correct—these callbacks are never called on `Err`—and removes contravariance.

## Changes

| Method | Before | After |
|--------|--------|-------|
| `map` | `(a: T) => U` | `(a: never) => U` |
| `andThen` | `(a: T) => Result<U, E2>` | `(a: never) => Result<U, E2>` |
| `andThenAsync` | `(a: T) => Promise<...>` | `(a: never) => Promise<...>` |
| `match` | `{ ok: (a: T) => R }` | `{ ok: (a: never) => R }` |
| `tap` | `(a: T) => void` | `(a: never) => void` |
| `tapAsync` | `(a: T) => Promise<void>` | `(a: never) => Promise<void>` |
| `isOk` | `this is Ok<T, E>` | `this is Ok<never, E>` |
| `[Symbol.iterator]` | `Generator<..., T, ...>` | `Generator<..., never, ...>` |

## Breaking Change Assessment

**Non-breaking for practical purposes:**

1. **Normal usage unaffected** — When calling `.map()` on `Result<T, E>`, TypeScript uses the union's method signature where `Ok.map` still has `(a: T) => U`.

2. **Only affects dead code** — The only "breaking" case is explicitly calling methods on a narrowed `Err`:
   ```typescript
   const err: Err<number, string> = Result.err("fail");
   err.map((n) => n.toString()); // Now errors: n is `never`
   ```
   But this callback was never executed anyway—the new type correctly catches dead code.

## Supersedes #14

This solves the same problem as #14 (`intoOk`/`intoErr`) but at the type level with zero new API surface.