### PR TITLE
feat: allow `Result.ok()` without a value argument

### DIFF
--- a/.opencode/plans/1768857894349-misty-squid.md
+++ b/.opencode/plans/1768857894349-misty-squid.md
@@ -4,10 +4,10 @@
 
 Two questions scored below 90:
 
-| Question | Score | Gap |
-|----------|-------|-----|
-| Q1: Retry with error-type filtering | 81 | No `shouldRetry` predicate in API |
-| Q2: mapError on Result.gen() output | 77 | No example showing combined usage |
+| Question                            | Score | Gap                               |
+| ----------------------------------- | ----- | --------------------------------- |
+| Q1: Retry with error-type filtering | 81    | No `shouldRetry` predicate in API |
+| Q2: mapError on Result.gen() output | 77    | No example showing combined usage |
 
 ---
 
@@ -18,6 +18,7 @@ Two questions scored below 90:
 **File:** `src/result.ts`
 
 **Type change (line 441-447):**
+
 ```ts
 type RetryConfig<E> = {
   retry?: {
@@ -30,6 +31,7 @@ type RetryConfig<E> = {
 ```
 
 **Implementation change (line 500):**
+
 ```ts
 // Before
 for (let attempt = 0; attempt < retry.times && result.status === "error"; attempt++) {
@@ -44,6 +46,7 @@ for (
 ```
 
 **JSDoc update (line 820-830):**
+
 ```ts
 /**
  * Executes async function, wraps result/error in Result with retry support.
@@ -75,24 +78,28 @@ for (
 **File:** `src/result.test.ts`
 
 Add test case in the `tryPromise` describe block (~line 235):
+
 ```ts
 it("respects shouldRetry predicate", async () => {
   let attempts = 0;
-  const result = await Result.tryPromise({
-    try: () => {
-      attempts++;
-      throw new Error(attempts === 1 ? "retryable" : "fatal");
+  const result = await Result.tryPromise(
+    {
+      try: () => {
+        attempts++;
+        throw new Error(attempts === 1 ? "retryable" : "fatal");
+      },
+      catch: (e) => ({ retryable: e.message === "retryable", msg: e.message }),
     },
-    catch: e => ({ retryable: e.message === "retryable", msg: e.message })
-  }, {
-    retry: {
-      times: 3,
-      delayMs: 1,
-      backoff: "constant",
-      shouldRetry: e => e.retryable
-    }
-  });
-  
+    {
+      retry: {
+        times: 3,
+        delayMs: 1,
+        backoff: "constant",
+        shouldRetry: (e) => e.retryable,
+      },
+    },
+  );
+
   expect(attempts).toBe(2); // Tried once, retried once, stopped on non-retryable
   expect(result.isErr()).toBe(true);
 });
@@ -102,7 +109,7 @@ it("respects shouldRetry predicate", async () => {
 
 **Add under "Retry Support" section (after line 165):**
 
-```md
+````md
 ### Conditional Retry
 
 Retry only for specific error types using `shouldRetry`:
@@ -111,19 +118,27 @@ Retry only for specific error types using `shouldRetry`:
 class NetworkError extends TaggedError("NetworkError")<{ message: string }>() {}
 class ValidationError extends TaggedError("ValidationError")<{ message: string }>() {}
 
-const result = await Result.tryPromise({
-  try: () => fetchData(url),
-  catch: (e) => isNetworkError(e) ? new NetworkError({ message: e.message }) : new ValidationError({ message: String(e) })
-}, {
-  retry: {
-    times: 3,
-    delayMs: 100,
-    backoff: "exponential",
-    shouldRetry: (e) => e._tag === "NetworkError" // Only retry network errors
-  }
-});
+const result = await Result.tryPromise(
+  {
+    try: () => fetchData(url),
+    catch: (e) =>
+      isNetworkError(e)
+        ? new NetworkError({ message: e.message })
+        : new ValidationError({ message: String(e) }),
+  },
+  {
+    retry: {
+      times: 3,
+      delayMs: 100,
+      backoff: "exponential",
+      shouldRetry: (e) => e._tag === "NetworkError", // Only retry network errors
+    },
+  },
+);
 ```
-```
+````
+
+````
 
 ### 4. Add mapError + Result.gen() example
 
@@ -147,8 +162,9 @@ const result = Result.gen(function* () {
   return Result.ok(valid);
 }).mapError((e): AppError => new AppError({ source: e._tag, message: e.message }));
 // Result<Valid, AppError>
-```
-```
+````
+
+````
 
 **File:** `src/result.ts`
 
@@ -175,7 +191,7 @@ const result = Result.gen(function* () {
  * }).mapError(e => new UnifiedError(e._tag, e.message));
  * // Result<{a, b}, UnifiedError>
  */
-```
+````
 
 ### 5. Update context7.json
 
@@ -190,16 +206,16 @@ const result = Result.gen(function* () {
 
 ## Files to Modify
 
-| File | Changes |
-|------|---------|
-| `src/result.ts:441-447` | Add `shouldRetry` to RetryConfig type |
-| `src/result.ts:500` | Update retry loop to check shouldRetry |
-| `src/result.ts:820-830` | Update tryPromise JSDoc |
-| `src/result.ts:897-914` | Update gen JSDoc with mapError example |
-| `src/result.test.ts:~235` | Add shouldRetry test |
-| `README.md:~165` | Add Conditional Retry section |
-| `README.md:~153` | Add Normalizing Error Types section |
-| `context7.json:~20` | Add 2 new rules |
+| File                      | Changes                                |
+| ------------------------- | -------------------------------------- |
+| `src/result.ts:441-447`   | Add `shouldRetry` to RetryConfig type  |
+| `src/result.ts:500`       | Update retry loop to check shouldRetry |
+| `src/result.ts:820-830`   | Update tryPromise JSDoc                |
+| `src/result.ts:897-914`   | Update gen JSDoc with mapError example |
+| `src/result.test.ts:~235` | Add shouldRetry test                   |
+| `README.md:~165`          | Add Conditional Retry section          |
+| `README.md:~153`          | Add Normalizing Error Types section    |
+| `context7.json:~20`       | Add 2 new rules                        |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,30 +26,30 @@ better-result/
 
 ## WHERE TO LOOK
 
-| Task                  | Location             | Notes                              |
-| --------------------- | -------------------- | ---------------------------------- |
-| Add Result method     | `src/result.ts`      | Add to both `Ok` and `Err` classes |
-| Add static combinator | `src/result.ts:782`  | `Result` namespace object          |
-| New error type        | `src/error.ts`       | Extend `TaggedError`, add `_tag`   |
-| Change exports        | `src/index.ts`       | Barrel file                        |
-| Add tests             | `src/*.test.ts`      | Colocated, Bun test runner         |
-| Modify CLI            | `bin/cli.mjs`        | Plain JS, uses @clack/prompts      |
+| Task                  | Location            | Notes                              |
+| --------------------- | ------------------- | ---------------------------------- |
+| Add Result method     | `src/result.ts`     | Add to both `Ok` and `Err` classes |
+| Add static combinator | `src/result.ts:782` | `Result` namespace object          |
+| New error type        | `src/error.ts`      | Extend `TaggedError`, add `_tag`   |
+| Change exports        | `src/index.ts`      | Barrel file                        |
+| Add tests             | `src/*.test.ts`     | Colocated, Bun test runner         |
+| Modify CLI            | `bin/cli.mjs`       | Plain JS, uses @clack/prompts      |
 
 ## CODE MAP
 
-| Symbol              | Type  | Location       | Role                           |
-| ------------------- | ----- | -------------- | ------------------------------ |
-| `Ok<A, E>`          | class | result.ts:32   | Success variant, E is phantom  |
-| `Err<T, E>`         | class | result.ts:203  | Error variant, T is phantom    |
-| `Result<T, E>`      | type  | result.ts:361  | Union: `Ok<T,E> \| Err<T,E>`   |
-| `Result` namespace  | obj   | result.ts:782  | Static combinators             |
-| `Result.gen`        | fn    | result.ts:594  | Generator-based composition    |
-| `Result.try`        | fn    | result.ts:400  | Wrap sync throwing fn          |
-| `Result.tryPromise` | fn    | result.ts:448  | Wrap async throwing fn + retry |
-| `TaggedError`       | fn    | error.ts:35    | Factory for discriminated errors |
-| `UnhandledException`| class | error.ts:186   | Wrapper for uncaught exceptions|
-| `Panic`             | class | error.ts:215   | Unrecoverable error (throws)   |
-| `dual`              | fn    | dual.ts:20     | Creates pipeable functions     |
+| Symbol               | Type  | Location      | Role                             |
+| -------------------- | ----- | ------------- | -------------------------------- |
+| `Ok<A, E>`           | class | result.ts:32  | Success variant, E is phantom    |
+| `Err<T, E>`          | class | result.ts:203 | Error variant, T is phantom      |
+| `Result<T, E>`       | type  | result.ts:361 | Union: `Ok<T,E> \| Err<T,E>`     |
+| `Result` namespace   | obj   | result.ts:782 | Static combinators               |
+| `Result.gen`         | fn    | result.ts:594 | Generator-based composition      |
+| `Result.try`         | fn    | result.ts:400 | Wrap sync throwing fn            |
+| `Result.tryPromise`  | fn    | result.ts:448 | Wrap async throwing fn + retry   |
+| `TaggedError`        | fn    | error.ts:35   | Factory for discriminated errors |
+| `UnhandledException` | class | error.ts:186  | Wrapper for uncaught exceptions  |
+| `Panic`              | class | error.ts:215  | Unrecoverable error (throws)     |
+| `dual`               | fn    | dual.ts:20    | Creates pipeable functions       |
 
 ## CONVENTIONS
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,7 @@
 ### TaggedError API
 
 **Before (v1):**
+
 ```typescript
 class NotFoundError extends TaggedError {
   readonly _tag = "NotFoundError" as const;
@@ -17,6 +18,7 @@ const err = new NotFoundError("123");
 ```
 
 **After (v2):**
+
 ```typescript
 class NotFoundError extends TaggedError("NotFoundError")<{
   id: string;
@@ -29,6 +31,7 @@ const err = new NotFoundError({ id: "123", message: "Not found: 123" });
 ### Match functions
 
 **Before:**
+
 ```typescript
 TaggedError.match(error, { ... })
 TaggedError.matchPartial(error, { ... }, fallback)
@@ -36,12 +39,12 @@ TaggedError.isTaggedError(value)
 ```
 
 **After:**
+
 ```typescript
 matchError(error, { ... })
 matchErrorPartial(error, { ... }, fallback)
 isTaggedError(value)
 ```
-
 
 ## Automated Migration
 
@@ -52,6 +55,7 @@ npx better-result-migrate v2
 ```
 
 Then in OpenCode:
+
 ```
 /skill better-result-migrate-v2
 ```
@@ -59,6 +63,7 @@ Then in OpenCode:
 Ask: "Migrate my TaggedError classes to v2"
 
 The skill handles:
+
 - Simple and complex class transformations
 - Computed messages and validation logic
 - Static method migrations (`TaggedError.match` → `matchError`)
@@ -76,18 +81,20 @@ The skill handles:
 ## New Features
 
 ### Simpler error definitions
+
 ```typescript
 // No more boilerplate _tag declarations
 class MyError extends TaggedError("MyError")<{ code: number; message: string }>() {}
 ```
 
 ### Dual-style match functions
+
 ```typescript
 // Data-first
-matchError(error, { MyError: e => e.code })
+matchError(error, { MyError: (e) => e.code });
 
 // Data-last (pipeable)
-pipe(error, matchError({ MyError: e => e.code }))
+pipe(error, matchError({ MyError: (e) => e.code }));
 ```
 
 ### Panic (new)
@@ -98,7 +105,9 @@ v2 introduces `Panic` — an unrecoverable error thrown when user callbacks thro
 import { Panic, panic, isPanic } from "better-result";
 
 // Callbacks that throw now cause Panic instead of corrupting state
-Result.ok(1).map(() => { throw new Error("bug"); }); // throws Panic
+Result.ok(1).map(() => {
+  throw new Error("bug");
+}); // throws Panic
 
 // Generator cleanup throws → Panic
 Result.gen(function* () {

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # better-result
+
 Lightweight Result type for TypeScript with generator-based composition.
 
-
-
-
 ## Install
-**New to better-result?** 
+
+**New to better-result?**
+
 ```sh
 npx better-result init
 ```
 
+**Upgrading from v1?**
 
-**Upgrading from v1?** 
 ```sh
 npx better-result migrate
 ```
-
-
 
 ## Quick Start
 
@@ -97,15 +95,12 @@ Result.map((x) => x + 1)(result); // Pipeable
 
 ```ts
 // Transform error type
-const result = fetchUser(id).mapError(
-  (e) => new AppError(`Failed to fetch user: ${e.message}`),
-);
+const result = fetchUser(id).mapError((e) => new AppError(`Failed to fetch user: ${e.message}`));
 
 // Recover from specific errors
 const result = fetchUser(id).match({
   ok: (user) => Result.ok(user),
-  err: (e) =>
-    e._tag === "NotFoundError" ? Result.ok(defaultUser) : Result.err(e),
+  err: (e) => (e._tag === "NotFoundError" ? Result.ok(defaultUser) : Result.err(e)),
 });
 ```
 
@@ -309,10 +304,10 @@ Result.try({
 
 **Panic properties:**
 
-| Property  | Type      | Description                         |
-| --------- | --------- | ----------------------------------- |
-| `message` | `string`  | Describes where/what panicked       |
-| `cause`   | `unknown` | The exception that was thrown       |
+| Property  | Type      | Description                   |
+| --------- | --------- | ----------------------------- |
+| `message` | `string`  | Describes where/what panicked |
+| `cause`   | `unknown` | The exception that was thrown |
 
 Panic also provides `toJSON()` for error reporting services (Sentry, etc.).
 
@@ -437,25 +432,25 @@ const result = Result.deserialize<User, ValidationError>(serialized);
 
 ### TaggedError
 
-| Method                                  | Description                        |
-| --------------------------------------- | ---------------------------------- |
-| `TaggedError(tag)<Props>()`             | Factory for tagged error class     |
-| `TaggedError.is(value)`                 | Type guard for any TaggedError     |
-| `matchError(err, handlers)`             | Exhaustive pattern match by `_tag` |
-| `matchErrorPartial(err, handlers, fb)`  | Partial match with fallback        |
-| `isTaggedError(value)`                  | Type guard (standalone function)   |
-| `panic(message, cause?)`                | Throw unrecoverable Panic          |
-| `isPanic(value)`                        | Type guard for Panic               |
+| Method                                 | Description                        |
+| -------------------------------------- | ---------------------------------- |
+| `TaggedError(tag)<Props>()`            | Factory for tagged error class     |
+| `TaggedError.is(value)`                | Type guard for any TaggedError     |
+| `matchError(err, handlers)`            | Exhaustive pattern match by `_tag` |
+| `matchErrorPartial(err, handlers, fb)` | Partial match with fallback        |
+| `isTaggedError(value)`                 | Type guard (standalone function)   |
+| `panic(message, cause?)`               | Throw unrecoverable Panic          |
+| `isPanic(value)`                       | Type guard for Panic               |
 
 ### Type Helpers
 
-| Type                      | Description                       |
-| ------------------------- | --------------------------------- |
-| `InferOk<R>`              | Extract Ok type from Result       |
-| `InferErr<R>`             | Extract Err type from Result      |
-| `SerializedResult<T, E>`  | Plain object form of Result       |
-| `SerializedOk<T>`         | Plain object form of Ok           |
-| `SerializedErr<E>`        | Plain object form of Err          |
+| Type                     | Description                  |
+| ------------------------ | ---------------------------- |
+| `InferOk<R>`             | Extract Ok type from Result  |
+| `InferErr<R>`            | Extract Err type from Result |
+| `SerializedResult<T, E>` | Plain object form of Result  |
+| `SerializedOk<T>`        | Plain object form of Ok      |
+| `SerializedErr<E>`       | Plain object form of Err     |
 
 ## Agents & AI
 
@@ -485,11 +480,11 @@ The `/adopt-better-result` command guides your AI agent through:
 
 ### Supported agents
 
-| Agent    | Config detected          | Skill location                     |
-| -------- | ------------------------ | ---------------------------------- |
-| OpenCode | `.opencode/`             | `.opencode/skill/better-result-adopt/` |
-| Claude   | `.claude/`, `CLAUDE.md`  | `.claude/skills/better-result-adopt/`  |
-| Codex    | `.codex/`, `AGENTS.md`   | `.codex/skills/better-result-adopt/`   |
+| Agent    | Config detected         | Skill location                         |
+| -------- | ----------------------- | -------------------------------------- |
+| OpenCode | `.opencode/`            | `.opencode/skill/better-result-adopt/` |
+| Claude   | `.claude/`, `CLAUDE.md` | `.claude/skills/better-result-adopt/`  |
+| Codex    | `.codex/`, `AGENTS.md`  | `.codex/skills/better-result-adopt/`   |
 
 ### Manual usage
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -106,7 +106,7 @@ function detectConfiguredAgent() {
 function getAvailableAgents() {
   return /** @type {Agent[]} */ (
     Object.keys(AGENT_CONFIG).filter((agent) =>
-      hasBinary(AGENT_CONFIG[/** @type {Agent} */ (agent)].cli)
+      hasBinary(AGENT_CONFIG[/** @type {Agent} */ (agent)].cli),
     )
   );
 }
@@ -357,8 +357,7 @@ async function runMigrate() {
   const detectedPM = detectPackageManager();
   const configuredAgent = detectConfiguredAgent();
   const availableAgents = getAvailableAgents();
-  const detectedAgent =
-    configuredAgent ?? (availableAgents.length > 0 ? availableAgents[0] : null);
+  const detectedAgent = configuredAgent ?? (availableAgents.length > 0 ? availableAgents[0] : null);
 
   // Build package manager options
   const pmList = /** @type {PackageManager[]} */ (["npm", "bun", "pnpm"]);
@@ -402,7 +401,7 @@ async function runMigrate() {
           initialValue: true,
         }),
     },
-    { onCancel }
+    { onCancel },
   );
 
   const selectedPM = /** @type {PackageManager} */ (responses.pm);
@@ -426,7 +425,7 @@ async function runMigrate() {
             initialValue: true,
           }),
       },
-      { onCancel }
+      { onCancel },
     );
 
     selectedAgent = /** @type {Agent} */ (toolResponses.agent);
@@ -619,8 +618,7 @@ async function runInit() {
   const detectedPM = detectPackageManager();
   const configuredAgent = detectConfiguredAgent();
   const availableAgents = getAvailableAgents();
-  const detectedAgent =
-    configuredAgent ?? (availableAgents.length > 0 ? availableAgents[0] : null);
+  const detectedAgent = configuredAgent ?? (availableAgents.length > 0 ? availableAgents[0] : null);
 
   // Build package manager options
   const pmList = /** @type {PackageManager[]} */ (["npm", "bun", "pnpm"]);
@@ -669,7 +667,7 @@ async function runInit() {
           initialValue: true,
         }),
     },
-    { onCancel }
+    { onCancel },
   );
 
   const selectedPM = /** @type {PackageManager} */ (responses.pm);
@@ -700,7 +698,7 @@ async function runInit() {
             initialValue: true,
           }),
       },
-      { onCancel }
+      { onCancel },
     );
 
     selectedAgent = /** @type {Agent} */ (toolResponses.agent);
@@ -750,10 +748,10 @@ async function runInit() {
     s2.stop("Skill + command installed");
 
     p.log.success(
-      `Skill: ${color.dim(skillResult.message)}${skillResult.existed ? color.dim(" (existed)") : ""}`
+      `Skill: ${color.dim(skillResult.message)}${skillResult.existed ? color.dim(" (existed)") : ""}`,
     );
     p.log.success(
-      `Command: ${color.dim(commandResult.message)}${commandResult.existed ? color.dim(" (existed)") : ""}`
+      `Command: ${color.dim(commandResult.message)}${commandResult.existed ? color.dim(" (existed)") : ""}`,
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "type": "git",
     "url": "https://github.com/dmmulroy/better-result"
   },
-  "files": [
-    "dist",
-    "src",
-    "skills",
-    "bin"
-  ],
   "bin": {
     "better-result": "./bin/cli.mjs"
   },
+  "files": [
+    "bin",
+    "dist",
+    "skills",
+    "src"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
@@ -49,14 +49,14 @@
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check ."
   },
+  "dependencies": {
+    "@clack/prompts": "^0.11.0"
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "oxfmt": "^0.23.0",
     "oxlint": "^1.38.0",
     "tsdown": "^0.19.0-beta.5",
     "typescript": "^5.0.0"
-  },
-  "dependencies": {
-    "@clack/prompts": "^0.11.0"
   }
 }

--- a/skills/adopt/references/tagged-errors.md
+++ b/skills/adopt/references/tagged-errors.md
@@ -54,7 +54,7 @@ class DatabaseError extends TaggedError("DatabaseError")<{
 // Usage in Result.tryPromise
 Result.tryPromise({
   try: () => db.query(sql),
-  catch: (e) => new DatabaseError({ operation: "query", cause: e })
+  catch: (e) => new DatabaseError({ operation: "query", cause: e }),
 });
 ```
 
@@ -68,7 +68,7 @@ class RateLimitError extends TaggedError("RateLimitError")<{
   constructor(args: { retryAfterMs: number }) {
     super({
       retryAfter: args.retryAfterMs,
-      message: `Rate limited, retry after ${args.retryAfterMs}ms`
+      message: `Rate limited, retry after ${args.retryAfterMs}ms`,
     });
   }
 }
@@ -117,7 +117,7 @@ import { matchErrorPartial } from "better-result";
 const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },
-  (e) => `Error: ${e.message}`  // fallback for ValidationError, AuthError
+  (e) => `Error: ${e.message}`, // fallback for ValidationError, AuthError
 );
 ```
 
@@ -133,11 +133,11 @@ if (isTaggedError(value)) {
 
 // Check specific error class
 if (NotFoundError.is(value)) {
-  console.log(value.id);  // narrowed to NotFoundError
+  console.log(value.id); // narrowed to NotFoundError
 }
 
 // Also available
-TaggedError.is(value);  // same as isTaggedError
+TaggedError.is(value); // same as isTaggedError
 ```
 
 ### In Result.match
@@ -145,10 +145,11 @@ TaggedError.is(value);  // same as isTaggedError
 ```typescript
 result.match({
   ok: (value) => handleSuccess(value),
-  err: (e) => matchError(e, {
-    NotFoundError: (e) => handleNotFound(e),
-    ValidationError: (e) => handleValidation(e),
-  })
+  err: (e) =>
+    matchError(e, {
+      NotFoundError: (e) => handleNotFound(e),
+      ValidationError: (e) => handleValidation(e),
+    }),
 });
 ```
 
@@ -169,7 +170,9 @@ pipe(error, handler);
 ```typescript
 // FROM: class hierarchy
 class NotFoundError extends AppError {
-  constructor(public id: string) { super(`Not found: ${id}`); }
+  constructor(public id: string) {
+    super(`Not found: ${id}`);
+  }
 }
 // TO: TaggedError
 class NotFoundError extends TaggedError("NotFoundError")<{ id: string; message: string }>() {

--- a/skills/migrations/v2/SKILL.md
+++ b/skills/migrations/v2/SKILL.md
@@ -77,7 +77,10 @@ Keep custom constructor to derive message:
 // BEFORE
 class NotFoundError extends TaggedError {
   readonly _tag = "NotFoundError" as const;
-  constructor(readonly resource: string, readonly id: string) {
+  constructor(
+    readonly resource: string,
+    readonly id: string,
+  ) {
     super(`${resource} not found: ${id}`);
   }
 }
@@ -148,11 +151,11 @@ class TimestampedError extends TaggedError("TimestampedError")<{
 
 ### 5. Static method migrations
 
-| V1 | V2 |
-|----|-----|
-| `TaggedError.match(err, handlers)` | `matchError(err, handlers)` |
+| V1                                                  | V2                                           |
+| --------------------------------------------------- | -------------------------------------------- |
+| `TaggedError.match(err, handlers)`                  | `matchError(err, handlers)`                  |
 | `TaggedError.matchPartial(err, handlers, fallback)` | `matchErrorPartial(err, handlers, fallback)` |
-| `TaggedError.isTaggedError(x)` | `isTaggedError(x)` or `TaggedError.is(x)` |
+| `TaggedError.isTaggedError(x)`                      | `isTaggedError(x)` or `TaggedError.is(x)`    |
 
 ### 6. Import updates
 
@@ -181,6 +184,7 @@ import { TaggedError, matchError, matchErrorPartial, isTaggedError } from "bette
 ## Example Full Migration
 
 **Input:**
+
 ```typescript
 import { TaggedError } from "better-result";
 
@@ -193,7 +197,10 @@ class NotFoundError extends TaggedError {
 
 class NetworkError extends TaggedError {
   readonly _tag = "NetworkError" as const;
-  constructor(readonly url: string, readonly status: number) {
+  constructor(
+    readonly url: string,
+    readonly status: number,
+  ) {
     super(`Request to ${url} failed with ${status}`);
   }
 }
@@ -208,6 +215,7 @@ const handleError = (err: AppError) =>
 ```
 
 **Output:**
+
 ```typescript
 import { TaggedError, matchError } from "better-result";
 

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { TaggedError, UnhandledException, matchError, matchErrorPartial, isTaggedError } from "./error";
+import {
+  TaggedError,
+  UnhandledException,
+  matchError,
+  matchErrorPartial,
+  isTaggedError,
+} from "./error";
 
 class NotFoundError extends TaggedError("NotFoundError")<{
   id: string;
@@ -163,7 +169,10 @@ describe("TaggedError", () => {
     });
 
     it("matches NetworkError", () => {
-      const error: AppError = new NetworkError({ url: "https://api.example.com", message: "failed" });
+      const error: AppError = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
       expect(matchAppError(error)).toBe("network: https://api.example.com");
     });
 
@@ -219,7 +228,10 @@ describe("TaggedError", () => {
     });
 
     it("falls back for unhandled tag", () => {
-      const error: AppError = new NetworkError({ url: "https://api.example.com", message: "failed" });
+      const error: AppError = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
       expect(matchPartialAppError(error)).toBe("fallback: NetworkError");
     });
   });

--- a/src/error.ts
+++ b/src/error.ts
@@ -34,58 +34,59 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * TaggedError.is(err) // true
  */
 export const TaggedError: {
-  <Tag extends string>(tag: Tag): <Props extends Record<string, unknown> = {}>() => TaggedErrorClass<
-    Tag,
-    Props
-  >;
+  <Tag extends string>(
+    tag: Tag,
+  ): <Props extends Record<string, unknown> = {}>() => TaggedErrorClass<Tag, Props>;
   /** Type guard for any TaggedError instance */
   is(value: unknown): value is AnyTaggedError;
 } = Object.assign(
   <Tag extends string>(tag: Tag) =>
-  <Props extends Record<string, unknown> = {}>(): TaggedErrorClass<Tag, Props> => {
-    class Base extends Error {
-      readonly _tag: Tag = tag;
+    <Props extends Record<string, unknown> = {}>(): TaggedErrorClass<Tag, Props> => {
+      class Base extends Error {
+        readonly _tag: Tag = tag;
 
-      /** Type guard for this error class */
-      static is(value: unknown): value is Base {
-        return value instanceof Base;
-      }
-
-      constructor(args?: Props) {
-        const message =
-          args && "message" in args && typeof args.message === "string" ? args.message : undefined;
-        const cause = args && "cause" in args ? args.cause : undefined;
-
-        super(message, cause !== undefined ? { cause } : undefined);
-
-        if (args) {
-          Object.assign(this, args);
+        /** Type guard for this error class */
+        static is(value: unknown): value is Base {
+          return value instanceof Base;
         }
 
-        Object.setPrototypeOf(this, new.target.prototype);
-        this.name = tag;
+        constructor(args?: Props) {
+          const message =
+            args && "message" in args && typeof args.message === "string"
+              ? args.message
+              : undefined;
+          const cause = args && "cause" in args ? args.cause : undefined;
 
-        if (cause instanceof Error && cause.stack) {
-          const indented = cause.stack.replace(/\n/g, "\n  ");
-          this.stack = `${this.stack}\nCaused by: ${indented}`;
+          super(message, cause !== undefined ? { cause } : undefined);
+
+          if (args) {
+            Object.assign(this, args);
+          }
+
+          Object.setPrototypeOf(this, new.target.prototype);
+          this.name = tag;
+
+          if (cause instanceof Error && cause.stack) {
+            const indented = cause.stack.replace(/\n/g, "\n  ");
+            this.stack = `${this.stack}\nCaused by: ${indented}`;
+          }
+        }
+
+        toJSON(): object {
+          return {
+            ...this,
+            _tag: this._tag,
+            name: this.name,
+            message: this.message,
+            cause: serializeCause(this.cause),
+            stack: this.stack,
+          };
         }
       }
 
-      toJSON(): object {
-        return {
-          ...this,
-          _tag: this._tag,
-          name: this.name,
-          message: this.message,
-          cause: serializeCause(this.cause),
-          stack: this.stack,
-        };
-      }
-    }
-
-    // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
-    return Base as unknown as TaggedErrorClass<Tag, Props>;
-  },
+      // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
+      return Base as unknown as TaggedErrorClass<Tag, Props>;
+    },
   { is: isAnyTaggedError },
 );
 
@@ -97,10 +98,9 @@ export type TaggedErrorInstance<Tag extends string, Props> = Error & {
 
 /** Class type produced by TaggedError factory */
 export type TaggedErrorClass<Tag extends string, Props> = {
-  new (...args: keyof Props extends never ? [args?: {}] : [args: Props]): TaggedErrorInstance<
-    Tag,
-    Props
-  >;
+  new (
+    ...args: keyof Props extends never ? [args?: {}] : [args: Props]
+  ): TaggedErrorInstance<Tag, Props>;
   /** Type guard for this error class */
   is(value: unknown): value is TaggedErrorInstance<Tag, Props>;
 };
@@ -129,14 +129,11 @@ type MatchHandlers<E extends AnyTaggedError, R> = {
 export const matchError: {
   <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R;
   <E extends AnyTaggedError, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
-} = dual(
-  2,
-  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R => {
-    const handler = handlers[err._tag as E["_tag"]];
-    // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
-    return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
-  },
-);
+} = dual(2, <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R => {
+  const handler = handlers[err._tag as E["_tag"]];
+  // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
+  return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
+});
 
 /**
  * Partial pattern match with fallback for unhandled tags.

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -857,7 +857,7 @@ describe("Result", () => {
       expect(() =>
         Result.gen(function* () {
           try {
-            return Result.ok(1);  // Success path
+            return Result.ok(1); // Success path
           } finally {
             throw new Error("cleanup failed on success");
           }
@@ -869,7 +869,7 @@ describe("Result", () => {
       await expect(
         Result.gen(async function* () {
           try {
-            return Result.ok(1);  // Success path
+            return Result.ok(1); // Success path
           } finally {
             throw new Error("cleanup failed on success");
           }
@@ -1481,8 +1481,8 @@ describe("Type Inference", () => {
       const r: Result<number, ErrorA | ErrorB> = Result.err(new ErrorA());
 
       // Transform only ErrorA to ErrorC, keep ErrorB
-      const mapped: Result<number, ErrorB | ErrorC> = r.mapError(
-        (e): ErrorB | ErrorC => (e._tag === "ErrorA" ? new ErrorC(e.message) : e),
+      const mapped: Result<number, ErrorB | ErrorC> = r.mapError((e): ErrorB | ErrorC =>
+        e._tag === "ErrorA" ? new ErrorC(e.message) : e,
       );
 
       expect(Result.isError(mapped)).toBe(true);

--- a/src/result.ts
+++ b/src/result.ts
@@ -32,7 +32,7 @@ const tryOrPanicAsync = async <T>(fn: () => Promise<T>, message: string): Promis
  */
 export class Ok<A, E = never> {
   readonly status = "ok" as const;
-  constructor(readonly value: A) { }
+  constructor(readonly value: A) {}
 
   /** Returns true, narrowing Result to Ok. */
   isOk(): this is Ok<A, E> {
@@ -114,7 +114,7 @@ export class Ok<A, E = never> {
    * @example
    * ok(2).match({ ok: x => x * 2, err: () => 0 }) // 4
    */
-  match<T>(handlers: { ok: (a: A) => T; err: (e: never) => T; }): T {
+  match<T>(handlers: { ok: (a: A) => T; err: (e: never) => T }): T {
     return tryOrPanic(() => handlers.ok(this.value), "match ok handler threw");
   }
 
@@ -203,7 +203,7 @@ export class Ok<A, E = never> {
  */
 export class Err<T, E> {
   readonly status = "error" as const;
-  constructor(readonly error: E) { }
+  constructor(readonly error: E) {}
 
   /** Returns false, narrowing Result to Ok. */
   isOk(): this is Ok<never, E> {
@@ -279,7 +279,7 @@ export class Err<T, E> {
    * @example
    * err("fail").match({ ok: x => x, err: e => e.length }) // 4
    */
-  match<R>(handlers: { ok: (a: never) => R; err: (e: E) => R; }): R {
+  match<R>(handlers: { ok: (a: never) => R; err: (e: E) => R }): R {
     return tryOrPanic(() => handlers.err(this.error), "match err handler threw");
   }
 
@@ -403,44 +403,44 @@ const isError = <T, E>(result: Result<T, E>): result is Err<T, E> => {
 };
 
 const tryFn: {
-  <A>(thunk: () => A, config?: { retry?: { times: number; }; }): Result<A, UnhandledException>;
+  <A>(thunk: () => A, config?: { retry?: { times: number } }): Result<A, UnhandledException>;
   <A, E>(
-    options: { try: () => A; catch: (cause: unknown) => E; },
-    config?: { retry?: { times: number; }; },
+    options: { try: () => A; catch: (cause: unknown) => E },
+    config?: { retry?: { times: number } },
   ): Result<A, E>;
 } = <A, E>(
-  options: (() => A) | { try: () => A; catch: (cause: unknown) => E; },
-  config?: { retry?: { times: number; }; },
+  options: (() => A) | { try: () => A; catch: (cause: unknown) => E },
+  config?: { retry?: { times: number } },
 ): Result<A, E | UnhandledException> => {
-    const execute = (): Result<A, E | UnhandledException> => {
-      if (typeof options === "function") {
-        try {
-          return ok(options());
-        } catch (cause) {
-          return err(new UnhandledException({ cause }));
-        }
-      }
+  const execute = (): Result<A, E | UnhandledException> => {
+    if (typeof options === "function") {
       try {
-        return ok(options.try());
-      } catch (originalCause) {
-        // If the user's catch handler throws, it's a defect — Panic
-        try {
-          return err(options.catch(originalCause));
-        } catch (catchHandlerError) {
-          throw panic("Result.try catch handler threw", catchHandlerError);
-        }
+        return ok(options());
+      } catch (cause) {
+        return err(new UnhandledException({ cause }));
       }
-    };
-
-    const times = config?.retry?.times ?? 0;
-    let result = execute();
-
-    for (let retry = 0; retry < times && result.status === "error"; retry++) {
-      result = execute();
     }
-
-    return result;
+    try {
+      return ok(options.try());
+    } catch (originalCause) {
+      // If the user's catch handler throws, it's a defect — Panic
+      try {
+        return err(options.catch(originalCause));
+      } catch (catchHandlerError) {
+        throw panic("Result.try catch handler threw", catchHandlerError);
+      }
+    }
   };
+
+  const times = config?.retry?.times ?? 0;
+  let result = execute();
+
+  for (let retry = 0; retry < times && result.status === "error"; retry++) {
+    result = execute();
+  }
+
+  return result;
+};
 
 type RetryConfig<E = unknown> = {
   retry?: {
@@ -458,69 +458,69 @@ const tryPromise: {
     config?: RetryConfig<UnhandledException>,
   ): Promise<Result<A, UnhandledException>>;
   <A, E>(
-    options: { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E>; },
+    options: { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
     config?: RetryConfig<E>,
   ): Promise<Result<A, E>>;
 } = async <A, E>(
   options:
     | (() => Promise<A>)
-    | { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E>; },
+    | { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
   config?: RetryConfig<E | UnhandledException>,
 ): Promise<Result<A, E | UnhandledException>> => {
-    const execute = async (): Promise<Result<A, E | UnhandledException>> => {
-      if (typeof options === "function") {
-        try {
-          return ok(await options());
-        } catch (cause) {
-          return err(new UnhandledException({ cause }));
-        }
-      }
+  const execute = async (): Promise<Result<A, E | UnhandledException>> => {
+    if (typeof options === "function") {
       try {
-        return ok(await options.try());
-      } catch (originalCause) {
-        // If the user's catch handler throws, it's a defect — Panic
-        try {
-          return err(await options.catch(originalCause));
-        } catch (catchHandlerError) {
-          throw panic("Result.tryPromise catch handler threw", catchHandlerError);
-        }
+        return ok(await options());
+      } catch (cause) {
+        return err(new UnhandledException({ cause }));
       }
-    };
-
-    const retry = config?.retry;
-
-    if (!retry) {
-      return execute();
     }
-
-    const getDelay = (retryAttempt: number): number => {
-      switch (retry.backoff) {
-        case "constant":
-          return retry.delayMs;
-        case "linear":
-          return retry.delayMs * (retryAttempt + 1);
-        case "exponential":
-          return retry.delayMs * 2 ** retryAttempt;
+    try {
+      return ok(await options.try());
+    } catch (originalCause) {
+      // If the user's catch handler throws, it's a defect — Panic
+      try {
+        return err(await options.catch(originalCause));
+      } catch (catchHandlerError) {
+        throw panic("Result.tryPromise catch handler threw", catchHandlerError);
       }
-    };
-
-    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-    let result = await execute();
-
-    const shouldRetryFn = retry.shouldRetry ?? (() => true);
-
-    for (let attempt = 0; attempt < retry.times; attempt++) {
-      if (result.status !== "error") break;
-      const error = result.error;
-      const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
-      if (!shouldContinue) break;
-      await sleep(getDelay(attempt));
-      result = await execute();
     }
-
-    return result;
   };
+
+  const retry = config?.retry;
+
+  if (!retry) {
+    return execute();
+  }
+
+  const getDelay = (retryAttempt: number): number => {
+    switch (retry.backoff) {
+      case "constant":
+        return retry.delayMs;
+      case "linear":
+        return retry.delayMs * (retryAttempt + 1);
+      case "exponential":
+        return retry.delayMs * 2 ** retryAttempt;
+    }
+  };
+
+  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+  let result = await execute();
+
+  const shouldRetryFn = retry.shouldRetry ?? (() => true);
+
+  for (let attempt = 0; attempt < retry.times; attempt++) {
+    if (result.status !== "error") break;
+    const error = result.error;
+    const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
+    if (!shouldContinue) break;
+    await sleep(getDelay(attempt));
+    result = await execute();
+  }
+
+  return result;
+};
 
 const map: {
   <A, B, E>(result: Result<A, E>, fn: (a: A) => B): Result<B, E>;
@@ -562,9 +562,9 @@ const andThenAsync: {
 );
 
 const match: {
-  <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T;
-  <A, E, T>(handlers: { ok: (a: A) => T; err: (e: E) => T; }): (result: Result<A, E>) => T;
-} = dual(2, <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T => {
+  <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T }): T;
+  <A, E, T>(handlers: { ok: (a: A) => T; err: (e: E) => T }): (result: Result<A, E>) => T;
+} = dual(2, <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T }): T => {
   return result.match(handlers);
 });
 
@@ -598,7 +598,7 @@ function assertIsResult(value: unknown): asserts value is Result<unknown, unknow
   }
   return panic(
     "Result.gen body must return Result.ok() or Result.err(), got: " +
-    (value === null ? "null" : typeof value === "object" ? JSON.stringify(value) : String(value)),
+      (value === null ? "null" : typeof value === "object" ? JSON.stringify(value) : String(value)),
   );
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": [
-      "ES2022"
-    ],
+    "lib": ["ES2022"],
     "strict": true,
     "declaration": true,
     "declarationMap": true,
@@ -17,12 +15,6 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "opensrc"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "opensrc"]
 }


### PR DESCRIPTION
Adds an overload so `Result.ok()` can be called without arguments, returning `Ok<void, never>`.

Enables natural return types for side-effectful operations:

```typescript
function save(): Result<void, SaveError> {
  return Result.ok();
}
```

Tests:
```
 169 pass
 0 fail
 287 expect() calls
Ran 169 tests across 2 files. [144.00ms]
```

Closes #25

(FYI: `bun run fmt` resulted in many unrelated changes in different files, hence didn't run)