### PR TITLE
docs: fix TaggedError example in jsdoc

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -23,7 +23,7 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * class NotFoundError extends TaggedError("NotFoundError")<{
  *   id: string;
  *   message: string;
- * }> {}
+ * }>() {}
  *
  * const err = new NotFoundError({ id: "123", message: "Not found: 123" });
  * err._tag    // "NotFoundError"


### PR DESCRIPTION
fixes `TaggedError` example in jsdoc comment.