### PR TITLE
Fix tryRecover success type inference

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "oxlint": "^1.38.0",
         "tsdown": "^0.19.0-beta.5",
         "typescript": "^5.0.0",
+        "vitest": "3.2.4",
       },
     },
   },
@@ -29,6 +30,58 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -104,13 +157,85 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.59", "", {}, "sha512-aoh6LAJRyhtazs98ydgpNOYstxUlsOV1KJXcpf/0c0vFcUA8uyd/hwKRhqE/AAPNqAho9RliGsvitCoOzREoVA=="],
 
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-kit": ["ast-kit@2.2.0", "", { "dependencies": { "@babel/parser": "^7.28.5", "pathe": "^2.0.3" } }, "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw=="],
 
@@ -120,13 +245,31 @@
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
@@ -134,7 +277,17 @@
 
     "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
 
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -144,7 +297,13 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
@@ -154,13 +313,31 @@
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.20.0", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ast-kit": "^2.2.0", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.0", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-beta.57", "typescript": "^5.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-cLAY1kN2ilTYMfZcFlGWbXnu6Nb+8uwUBsi+Mjbh4uIx7IN8uMOmJ7RxrrRgPsO4H7eSz3E+JwGoL1gyugiyUA=="],
 
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tinypool": ["tinypool@2.0.0", "", {}, "sha512-/RX9RzeH2xU5ADE7n2Ykvmi9ED3FBGPAjw9u3zucrNNaEBIO0HPSYgL0NT7+3p147ojeSdaVu08F6hjpv31HJg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -175,5 +352,17 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unrun": ["unrun@0.2.24", "", { "dependencies": { "rolldown": "1.0.0-beta.59" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-xa4/O5q2jmI6EqxweJ+sOy5cyORZWcsgmi8pmABVSUyg24Fh44qJrneUHavZEMsbJbghHYWKSraFy5hDCb/m4w=="],
+
+    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "vitest/tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "tsdown",
     "prepublishOnly": "bun run build",
-    "test": "bun test src/",
+    "test": "vitest --typecheck --run",
     "check": "tsc --noEmit",
     "lint": "oxlint .",
     "fmt": "oxfmt .",
@@ -48,6 +48,7 @@
     "oxfmt": "^0.23.0",
     "oxlint": "^1.38.0",
     "tsdown": "^0.19.0-beta.5",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "3.2.4"
   }
 }

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import {
   TaggedError,
   UnhandledException,

--- a/src/error.ts
+++ b/src/error.ts
@@ -9,10 +9,10 @@ const serializeCause = (cause: unknown): unknown => {
 };
 
 /** Prevents inference from a type position while supporting TypeScript 5.0. */
-type noinfer<T> = [T][T extends unknown ? 0 : never];
+type NoInfer<T> = [T][T extends unknown ? 0 : never];
 
 /** Any tagged error (for generic constraints) */
-type AnyTaggedError = Error & { readonly _tag: string };
+type AnyTaggedError = Error & { readonly _tag: string; };
 
 /** Type guard for any tagged error */
 const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
@@ -101,7 +101,7 @@ export type TaggedErrorInstance<Tag extends string, Props> = Error & {
 
 /** Class type produced by TaggedError factory */
 export type TaggedErrorClass<Tag extends string, Props> = {
-  new (
+  new(
     ...args: keyof Props extends never ? [args?: {}] : [args: Props]
   ): TaggedErrorInstance<Tag, Props>;
   /** Type guard for this error class */
@@ -110,7 +110,7 @@ export type TaggedErrorClass<Tag extends string, Props> = {
 
 /** Handler map for exhaustive matching */
 type MatchHandlers<E extends AnyTaggedError, R> = {
-  [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => R;
+  [K in E["_tag"]]: (err: Extract<E, { _tag: K; }>) => R;
 };
 
 /** Partial handler map for non-exhaustive matching */
@@ -141,7 +141,7 @@ export const matchError: {
 } = dual(2, <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R => {
   const handler = handlers[err._tag as E["_tag"]];
   // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
-  return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
+  return handler(err as Extract<E, { _tag: (typeof err)["_tag"]; }>);
 });
 
 /**
@@ -156,7 +156,7 @@ export const matchErrorPartial: {
   <E extends AnyTaggedError, R, const H extends PartialMatchHandlers<E, R>>(
     err: E,
     handlers: H,
-    fallback: (e: Exclude<E, { _tag: noinfer<HandledTags<E, H>> }>) => R,
+    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>>; }>) => R,
   ): R;
   <
     E extends AnyTaggedError,
@@ -164,14 +164,14 @@ export const matchErrorPartial: {
     const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
   >(
     handlers: H,
-    fallback: (e: Exclude<E, { _tag: noinfer<HandledTags<E, H>> }>) => R,
+    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>>; }>) => R,
   ): (err: E) => R;
 } = dual(
   3,
   <E extends AnyTaggedError, R, H extends PartialMatchHandlers<E, R>>(
     err: E,
     handlers: H,
-    fallback: (e: Exclude<E, { _tag: HandledTags<E, H> }>) => R,
+    fallback: (e: Exclude<E, { _tag: HandledTags<E, H>; }>) => R,
   ): R => {
     type K = HandledTags<E, H>;
     const handler = handlers[err._tag as K];
@@ -180,7 +180,7 @@ export const matchErrorPartial: {
       return handler(err as Parameters<NonNullable<typeof handler>>[0]);
     }
     // SAFETY: If no handler matched, err is in the Exclude type
-    return fallback(err as Exclude<E, { _tag: K }>);
+    return fallback(err as Exclude<E, { _tag: K; }>);
   },
 );
 
@@ -200,7 +200,7 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
   message: string;
   cause: unknown;
 }>() {
-  constructor(args: { cause: unknown }) {
+  constructor(args: { cause: unknown; }) {
     const message =
       args.cause instanceof Error
         ? `Unhandled exception: ${args.cause.message}`
@@ -228,7 +228,7 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
 export class Panic extends TaggedError("Panic")<{
   message: string;
   cause?: unknown;
-}>() {}
+}>() { }
 
 /**
  * Returned when Result.deserialize receives invalid input.
@@ -243,7 +243,7 @@ export class ResultDeserializationError extends TaggedError("ResultDeserializati
   message: string;
   value: unknown;
 }>() {
-  constructor(args: { value: unknown }) {
+  constructor(args: { value: unknown; }) {
     super({
       message: `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,
       value: args.value,

--- a/src/error.ts
+++ b/src/error.ts
@@ -8,6 +8,9 @@ const serializeCause = (cause: unknown): unknown => {
   return cause;
 };
 
+/** Prevents inference from a type position while supporting TypeScript 5.0. */
+type noinfer<T> = [T][T extends unknown ? 0 : never];
+
 /** Any tagged error (for generic constraints) */
 type AnyTaggedError = Error & { readonly _tag: string };
 
@@ -153,7 +156,7 @@ export const matchErrorPartial: {
   <E extends AnyTaggedError, R, const H extends PartialMatchHandlers<E, R>>(
     err: E,
     handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+    fallback: (e: Exclude<E, { _tag: noinfer<HandledTags<E, H>> }>) => R,
   ): R;
   <
     E extends AnyTaggedError,
@@ -161,7 +164,7 @@ export const matchErrorPartial: {
     const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
   >(
     handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+    fallback: (e: Exclude<E, { _tag: noinfer<HandledTags<E, H>> }>) => R,
   ): (err: E) => R;
 } = dual(
   3,

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { Result, Ok, Err } from "./result";
 import { Panic, ResultDeserializationError, UnhandledException } from "./error";
 
@@ -996,6 +996,7 @@ describe("Result", () => {
     });
   });
 
+  // oxlint-disable no-unsafe-finally require-yield -- Intentional cleanup/edge-case tests assert Panic behavior for throwing finally blocks and no-yield generators.
   describe("gen cleanup (finally/dispose)", () => {
     it("throws Panic when finally block throws (sync)", () => {
       expect(() =>
@@ -1292,6 +1293,7 @@ describe("Result", () => {
       }
     });
   });
+  // oxlint-enable no-unsafe-finally require-yield
 
   describe("combinator Panic", () => {
     it("Result.map throws Panic when callback throws", () => {
@@ -1998,6 +2000,75 @@ describe("Type Inference", () => {
         expect(recovered.error).toBeInstanceOf(ErrorB);
       }
     });
+
+    it("infers method recovery end to end without annotating the recovered result", () => {
+      const getNumber = (): Result<number, ErrorA> => Result.err(new ErrorA());
+      const r = getNumber();
+
+      const recoveredToErr = r.tryRecover((error) => {
+        expectTypeOf(error).toEqualTypeOf<ErrorA>();
+        expect(error).toBeInstanceOf(ErrorA);
+        return Result.err(new ErrorB());
+      });
+      const recoveredToOk = r.tryRecover((error) => {
+        expectTypeOf(error).toEqualTypeOf<ErrorA>();
+        return Result.ok(error.message.length);
+      });
+
+      expectTypeOf(recoveredToErr).toEqualTypeOf<Result<number, ErrorB>>();
+      expectTypeOf(recoveredToOk).toEqualTypeOf<Result<number, never>>();
+      expect(Result.isError(recoveredToErr)).toBe(true);
+      if (Result.isError(recoveredToErr)) {
+        expect(recoveredToErr.error).toBeInstanceOf(ErrorB);
+      }
+      expect(recoveredToOk.unwrap()).toBe(0);
+    });
+
+    it("infers data-first and data-last recovery end to end", () => {
+      const getNumber = (): Result<number, ErrorA> => Result.err(new ErrorA());
+      const r = getNumber();
+
+      const dataFirst = Result.tryRecover(r, (error) => {
+        expectTypeOf(error).toEqualTypeOf<ErrorA>();
+        return Result.err(new ErrorB());
+      });
+      const recoverToErr = Result.tryRecover(() => Result.err(new ErrorB()));
+      const recoverToOk = Result.tryRecover(() => Result.ok(0));
+      const dataLastErr = recoverToErr(r);
+      const dataLastOk = recoverToOk(r);
+
+      expectTypeOf(dataFirst).toEqualTypeOf<Result<number, ErrorB>>();
+      expectTypeOf(dataLastErr).toEqualTypeOf<Result<number, ErrorB>>();
+      expectTypeOf(dataLastOk).toEqualTypeOf<Result<number, never>>();
+      expect(Result.isError(dataFirst)).toBe(true);
+      expect(Result.isError(dataLastErr)).toBe(true);
+      expect(dataLastOk.unwrap()).toBe(0);
+    });
+
+    it("does not allow the success channel to change", () => {
+      const r: Result<string, ErrorA> = Result.err(new ErrorA());
+
+      const compileTimeOnly = () => {
+        // @ts-expect-error tryRecover matches Gleam semantics: it may change E, not T.
+        r.tryRecover(() => Result.ok(123));
+
+        // @ts-expect-error data-first tryRecover may not map the success channel.
+        Result.tryRecover(r, () => Result.ok(123));
+
+        // @ts-expect-error an unannotated Err has success type never; the callback cannot infer it.
+        Result.tryRecover(Result.err(new ErrorA()), () => Result.ok(123));
+
+        const recoverNumber = Result.tryRecover((_: ErrorA) => Result.ok(123));
+        const okString: Result<string, ErrorA> = Result.ok("ok");
+        // @ts-expect-error data-last tryRecover is fixed to the callback success type.
+        recoverNumber(okString);
+      };
+      expect(typeof compileTimeOnly).toBe("function");
+
+      const recovered = r.tryRecover(() => Result.ok("fallback"));
+      expectTypeOf(recovered).toEqualTypeOf<Result<string, never>>();
+      expect(recovered.unwrap()).toBe("fallback");
+    });
   });
 
   describe("tryRecoverAsync type preservation", () => {
@@ -2013,6 +2084,75 @@ describe("Type Inference", () => {
       if (Result.isError(recovered)) {
         expect(recovered.error).toBeInstanceOf(ErrorB);
       }
+    });
+
+    it("infers method recovery end to end without annotating the recovered result", async () => {
+      const getNumber = (): Result<number, ErrorA> => Result.err(new ErrorA());
+      const r = getNumber();
+
+      const recoveredToErr = await r.tryRecoverAsync(async (error) => {
+        expectTypeOf(error).toEqualTypeOf<ErrorA>();
+        expect(error).toBeInstanceOf(ErrorA);
+        return Result.err(new ErrorB());
+      });
+      const recoveredToOk = await r.tryRecoverAsync(async (error) => {
+        expectTypeOf(error).toEqualTypeOf<ErrorA>();
+        return Result.ok(error.message.length);
+      });
+
+      expectTypeOf(recoveredToErr).toEqualTypeOf<Result<number, ErrorB>>();
+      expectTypeOf(recoveredToOk).toEqualTypeOf<Result<number, never>>();
+      expect(Result.isError(recoveredToErr)).toBe(true);
+      if (Result.isError(recoveredToErr)) {
+        expect(recoveredToErr.error).toBeInstanceOf(ErrorB);
+      }
+      expect(recoveredToOk.unwrap()).toBe(0);
+    });
+
+    it("infers data-first and data-last recovery end to end", async () => {
+      const getNumber = (): Result<number, ErrorA> => Result.err(new ErrorA());
+      const r = getNumber();
+
+      const dataFirst = await Result.tryRecoverAsync(r, async (error) => {
+        expectTypeOf(error).toEqualTypeOf<ErrorA>();
+        return Result.err(new ErrorB());
+      });
+      const recoverToErr = Result.tryRecoverAsync(async () => Result.err(new ErrorB()));
+      const recoverToOk = Result.tryRecoverAsync(async () => Result.ok(0));
+      const dataLastErr = await recoverToErr(r);
+      const dataLastOk = await recoverToOk(r);
+
+      expectTypeOf(dataFirst).toEqualTypeOf<Result<number, ErrorB>>();
+      expectTypeOf(dataLastErr).toEqualTypeOf<Result<number, ErrorB>>();
+      expectTypeOf(dataLastOk).toEqualTypeOf<Result<number, never>>();
+      expect(Result.isError(dataFirst)).toBe(true);
+      expect(Result.isError(dataLastErr)).toBe(true);
+      expect(dataLastOk.unwrap()).toBe(0);
+    });
+
+    it("does not allow the success channel to change", async () => {
+      const r: Result<string, ErrorA> = Result.err(new ErrorA());
+
+      const compileTimeOnly = () => {
+        // @ts-expect-error tryRecoverAsync matches Gleam semantics: it may change E, not T.
+        r.tryRecoverAsync(async () => Result.ok(123));
+
+        // @ts-expect-error data-first tryRecoverAsync may not map the success channel.
+        Result.tryRecoverAsync(r, async () => Result.ok(123));
+
+        // @ts-expect-error an unannotated Err has success type never; the callback cannot infer it.
+        Result.tryRecoverAsync(Result.err(new ErrorA()), async () => Result.ok(123));
+
+        const recoverNumber = Result.tryRecoverAsync(async (_: ErrorA) => Result.ok(123));
+        const okString: Result<string, ErrorA> = Result.ok("ok");
+        // @ts-expect-error data-last tryRecoverAsync is fixed to the callback success type.
+        recoverNumber(okString);
+      };
+      expect(typeof compileTimeOnly).toBe("function");
+
+      const recovered = await r.tryRecoverAsync(async () => Result.ok("fallback"));
+      expectTypeOf(recovered).toEqualTypeOf<Result<string, never>>();
+      expect(recovered.unwrap()).toBe("fallback");
     });
   });
 
@@ -2069,6 +2209,7 @@ describe("Type Inference", () => {
   describe("multiple return Result.err inference (bug fix)", () => {
     it("infers union of all returned error types", () => {
       function process(input: string): Result<string, ErrorA | ErrorB | ErrorC> {
+        // oxlint-disable-next-line require-yield -- Intentional return-only generator regression test for Result.gen inference.
         return Result.gen(function* () {
           if (input.length === 0) {
             return Result.err(new ErrorA("empty"));
@@ -2118,6 +2259,54 @@ describe("Type Inference", () => {
     // These tests verify that Err is covariant in T (phantom success type)
     // and Ok is covariant in E (phantom error type), enabling early returns
     // without manual type coercion.
+
+    it("allows returning a narrowed Err with a different declared success type", () => {
+      function getName(): Result<string, ErrorA> {
+        return Result.err(new ErrorA());
+      }
+
+      function getLength(): Result<number, ErrorA> {
+        const result = getName();
+        if (result.isErr()) {
+          // Regression test for #59: Err<string, ErrorA> should be assignable to
+          // Result<number, ErrorA> because the success type is phantom on Err.
+          return result;
+        }
+        return Result.ok(result.value.length);
+      }
+
+      const r = getLength();
+      expect(Result.isError(r)).toBe(true);
+      if (Result.isError(r)) {
+        expect(r.error).toBeInstanceOf(ErrorA);
+      }
+    });
+
+    it("allows generic early return from refresh-style helper", async () => {
+      async function wrap<T>(
+        fn: () => Promise<Result<T, ErrorA>>,
+        refresh: () => Promise<Result<void, ErrorB>>,
+      ): Promise<Result<T, ErrorA | ErrorB>> {
+        const refreshed = await refresh();
+        if (refreshed.isErr()) {
+          // Regression test for #59: Err<void, ErrorB> should not constrain the
+          // caller-chosen T in the returned Result<T, ErrorA | ErrorB>.
+          return refreshed;
+        }
+        return fn();
+      }
+
+      const r = await wrap(
+        async () => Result.ok("ok"),
+        async () => Result.err(new ErrorB()),
+      );
+
+      expectTypeOf(r).toEqualTypeOf<Result<string, ErrorA | ErrorB>>();
+      expect(Result.isError(r)).toBe(true);
+      if (Result.isError(r)) {
+        expect(r.error).toBeInstanceOf(ErrorB);
+      }
+    });
 
     it("Err with different phantom T is assignable to Result with wider T", () => {
       function getNumber(): Result<number, "not_found"> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -19,6 +19,8 @@ const tryOrPanicAsync = async <T>(fn: () => Promise<T>, message: string): Promis
   }
 };
 
+type NoInfer<T> = [T][T extends unknown ? 0 : never];
+
 type TapBothHandlers<A, E> = {
   ok: (a: A) => void;
   err: (e: E) => void;
@@ -109,9 +111,9 @@ export class Ok<A, E = never> {
    * @returns Self with updated phantom E type.
    *
    * @example
-   * ok(42).tryRecover(e => ok(e.length)) // Ok(42)
+   * ok(42).tryRecover(() => err("fallback")) // Ok(42)
    */
-  tryRecover<E2>(_fn: (e: never) => Result<A, E2>): Ok<A, E2> {
+  tryRecover<E2>(_fn: (e: never) => Result<NoInfer<A>, E2>): Ok<A, E2> {
     // SAFETY: E is phantom on Ok (not used at runtime).
     return this as unknown as Ok<A, E2>;
   }
@@ -124,9 +126,9 @@ export class Ok<A, E = never> {
    * @returns Promise of self with updated phantom E type.
    *
    * @example
-   * await ok(42).tryRecoverAsync(async e => ok(e.length)) // Ok(42)
+   * await ok(42).tryRecoverAsync(async () => err("fallback")) // Ok(42)
    */
-  tryRecoverAsync<E2>(_fn: (e: never) => Promise<Result<A, E2>>): Promise<Ok<A, E2>> {
+  tryRecoverAsync<E2>(_fn: (e: never) => Promise<Result<NoInfer<A>, E2>>): Promise<Ok<A, E2>> {
     // SAFETY: E is phantom on Ok (not used at runtime).
     return Promise.resolve(this as unknown as Ok<A, E2>);
   }
@@ -359,9 +361,9 @@ export class Err<T, E> {
    * @throws {Panic} If fn throws.
    *
    * @example
-   * err("missing").tryRecover(e => e === "missing" ? ok(0) : err(new Error(e))) // Ok(0)
+   * err<number, string>("missing").tryRecover(e => e === "missing" ? ok(0) : err(new Error(e))) // Ok(0)
    */
-  tryRecover<E2>(fn: (e: E) => Result<T, E2>): Result<T, E2> {
+  tryRecover<E2>(fn: (e: E) => Result<NoInfer<T>, E2>): Result<T, E2> {
     return tryOrPanic(() => fn(this.error), "tryRecover callback threw");
   }
 
@@ -374,9 +376,9 @@ export class Err<T, E> {
    * @throws {Panic} If fn throws synchronously or rejects.
    *
    * @example
-   * await err("missing").tryRecoverAsync(async e => e === "missing" ? ok(0) : err(new Error(e))) // Ok(0)
+   * await err<number, string>("missing").tryRecoverAsync(async e => e === "missing" ? ok(0) : err(new Error(e))) // Ok(0)
    */
-  tryRecoverAsync<E2>(fn: (e: E) => Promise<Result<T, E2>>): Promise<Result<T, E2>> {
+  tryRecoverAsync<E2>(fn: (e: E) => Promise<Result<NoInfer<T>, E2>>): Promise<Result<T, E2>> {
     return tryOrPanicAsync(() => fn(this.error), "tryRecoverAsync callback threw");
   }
 
@@ -740,11 +742,15 @@ const mapError: {
 });
 
 const tryRecover: {
-  <A, E, E2>(result: Result<A, E>, fn: (e: E) => Result<A, E2>): Result<A, E2>;
+  <A, E, E2>(result: Result<A, E>, fn: (e: E) => Result<NoInfer<A>, E2>): Result<A, E2>;
+  <E, E2>(fn: (e: E) => Result<never, E2>): <A>(result: Result<A, E>) => Result<A, E2>;
   <E, A, E2>(fn: (e: E) => Result<A, E2>): (result: Result<A, E>) => Result<A, E2>;
-} = dual(2, <A, E, E2>(result: Result<A, E>, fn: (e: E) => Result<A, E2>): Result<A, E2> => {
-  return result.tryRecover(fn);
-});
+} = dual(
+  2,
+  <A, E, E2>(result: Result<A, E>, fn: (e: E) => Result<NoInfer<A>, E2>): Result<A, E2> => {
+    return result.tryRecover(fn);
+  },
+);
 
 const andThen: {
   <A, B, E, E2>(result: Result<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
@@ -754,7 +760,13 @@ const andThen: {
 });
 
 const tryRecoverAsync: {
-  <A, E, E2>(result: Result<A, E>, fn: (e: E) => Promise<Result<A, E2>>): Promise<Result<A, E2>>;
+  <A, E, E2>(
+    result: Result<A, E>,
+    fn: (e: E) => Promise<Result<NoInfer<A>, E2>>,
+  ): Promise<Result<A, E2>>;
+  <E, E2>(
+    fn: (e: E) => Promise<Result<never, E2>>,
+  ): <A>(result: Result<A, E>) => Promise<Result<A, E2>>;
   <E, A, E2>(
     fn: (e: E) => Promise<Result<A, E2>>,
   ): (result: Result<A, E>) => Promise<Result<A, E2>>;
@@ -762,7 +774,7 @@ const tryRecoverAsync: {
   2,
   <A, E, E2>(
     result: Result<A, E>,
-    fn: (e: E) => Promise<Result<A, E2>>,
+    fn: (e: E) => Promise<Result<NoInfer<A>, E2>>,
   ): Promise<Result<A, E2>> => {
     return result.tryRecoverAsync(fn);
   },
@@ -1146,8 +1158,8 @@ export const Result = {
    * Attempts to recover from an error into the same success type.
    *
    * @example
-   * Result.tryRecover(err("fail"), e => ok(e.length)) // Ok(4)
-   * Result.tryRecover(e => ok(e.length))(err("fail")) // Ok(4)
+   * Result.tryRecover(err<number, string>("fail"), e => ok(e.length)) // Ok(4)
+   * Result.tryRecover((e: string) => ok(e.length))(err<number, string>("fail")) // Ok(4)
    */
   tryRecover,
   /**
@@ -1161,8 +1173,8 @@ export const Result = {
    * Attempts to recover from an error into the same success type asynchronously.
    *
    * @example
-   * await Result.tryRecoverAsync(err("fail"), async e => ok(e.length)) // Ok(4)
-   * await Result.tryRecoverAsync(async e => ok(e.length))(err("fail")) // Ok(4)
+   * await Result.tryRecoverAsync(err<number, string>("fail"), async e => ok(e.length)) // Ok(4)
+   * await Result.tryRecoverAsync(async (e: string) => ok(e.length))(err<number, string>("fail")) // Ok(4)
    */
   tryRecoverAsync,
   /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -64,7 +64,7 @@ type TapBothAsyncErrHandlers<E> = {
  */
 export class Ok<A, E = never> {
   readonly status = "ok" as const;
-  constructor(readonly value: A) {}
+  constructor(readonly value: A) { }
 
   /** Returns true, narrowing Result to Ok. */
   isOk(): this is Ok<A, E> {
@@ -176,7 +176,7 @@ export class Ok<A, E = never> {
    * @example
    * ok(2).match({ ok: x => x * 2, err: () => 0 }) // 4
    */
-  match<T>(handlers: { ok: (a: A) => T; err: (e: never) => T }): T {
+  match<T>(handlers: { ok: (a: A) => T; err: (e: never) => T; }): T {
     return tryOrPanic(() => handlers.ok(this.value), "match ok handler threw");
   }
 
@@ -313,7 +313,7 @@ export class Ok<A, E = never> {
  */
 export class Err<T, E> {
   readonly status = "error" as const;
-  constructor(readonly error: E) {}
+  constructor(readonly error: E) { }
 
   /** Returns false, narrowing Result to Ok. */
   isOk(): this is Ok<never, E> {
@@ -419,7 +419,7 @@ export class Err<T, E> {
    * @example
    * err("fail").match({ ok: x => x, err: e => e.length }) // 4
    */
-  match<R>(handlers: { ok: (a: never) => R; err: (e: E) => R }): R {
+  match<R>(handlers: { ok: (a: never) => R; err: (e: E) => R; }): R {
     return tryOrPanic(() => handlers.err(this.error), "match err handler threw");
   }
 
@@ -607,45 +607,45 @@ const isError = <T, E>(result: Result<T, E>): result is Err<T, E> => {
 const tryFn: {
   <A>(
     thunk: () => Awaited<A>,
-    config?: { retry?: { times: number } },
+    config?: { retry?: { times: number; }; },
   ): Result<A, UnhandledException>;
   <A, E>(
-    options: { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
-    config?: { retry?: { times: number } },
+    options: { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E>; },
+    config?: { retry?: { times: number; }; },
   ): Result<A, E>;
 } = <A, E>(
-  options: (() => Awaited<A>) | { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
-  config?: { retry?: { times: number } },
+  options: (() => Awaited<A>) | { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E>; },
+  config?: { retry?: { times: number; }; },
 ): Result<A, E | UnhandledException> => {
-  const execute = (): Result<A, E | UnhandledException> => {
-    if (typeof options === "function") {
-      try {
-        return ok(options());
-      } catch (cause) {
-        return err(new UnhandledException({ cause }));
+    const execute = (): Result<A, E | UnhandledException> => {
+      if (typeof options === "function") {
+        try {
+          return ok(options());
+        } catch (cause) {
+          return err(new UnhandledException({ cause }));
+        }
       }
-    }
-    try {
-      return ok(options.try());
-    } catch (originalCause) {
-      // If the user's catch handler throws, it's a defect — Panic
       try {
-        return err(options.catch(originalCause));
-      } catch (catchHandlerError) {
-        throw panic("Result.try catch handler threw", catchHandlerError);
+        return ok(options.try());
+      } catch (originalCause) {
+        // If the user's catch handler throws, it's a defect — Panic
+        try {
+          return err(options.catch(originalCause));
+        } catch (catchHandlerError) {
+          throw panic("Result.try catch handler threw", catchHandlerError);
+        }
       }
+    };
+
+    const times = config?.retry?.times ?? 0;
+    let result = execute();
+
+    for (let retry = 0; retry < times && result.status === "error"; retry++) {
+      result = execute();
     }
+
+    return result;
   };
-
-  const times = config?.retry?.times ?? 0;
-  let result = execute();
-
-  for (let retry = 0; retry < times && result.status === "error"; retry++) {
-    result = execute();
-  }
-
-  return result;
-};
 
 type RetryConfig<E = unknown> = {
   retry?: {
@@ -663,69 +663,69 @@ const tryPromise: {
     config?: RetryConfig<UnhandledException>,
   ): Promise<Result<A, UnhandledException>>;
   <A, E>(
-    options: { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
+    options: { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E>; },
     config?: RetryConfig<E>,
   ): Promise<Result<A, E>>;
 } = async <A, E>(
   options:
     | (() => Promise<A>)
-    | { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
+    | { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E>; },
   config?: RetryConfig<E | UnhandledException>,
 ): Promise<Result<A, E | UnhandledException>> => {
-  const execute = async (): Promise<Result<A, E | UnhandledException>> => {
-    if (typeof options === "function") {
-      try {
-        return ok(await options());
-      } catch (cause) {
-        return err(new UnhandledException({ cause }));
+    const execute = async (): Promise<Result<A, E | UnhandledException>> => {
+      if (typeof options === "function") {
+        try {
+          return ok(await options());
+        } catch (cause) {
+          return err(new UnhandledException({ cause }));
+        }
       }
-    }
-    try {
-      return ok(await options.try());
-    } catch (originalCause) {
-      // If the user's catch handler throws, it's a defect — Panic
       try {
-        return err(await options.catch(originalCause));
-      } catch (catchHandlerError) {
-        throw panic("Result.tryPromise catch handler threw", catchHandlerError);
+        return ok(await options.try());
+      } catch (originalCause) {
+        // If the user's catch handler throws, it's a defect — Panic
+        try {
+          return err(await options.catch(originalCause));
+        } catch (catchHandlerError) {
+          throw panic("Result.tryPromise catch handler threw", catchHandlerError);
+        }
       }
+    };
+
+    const retry = config?.retry;
+
+    if (!retry) {
+      return execute();
     }
-  };
 
-  const retry = config?.retry;
+    const getDelay = (retryAttempt: number): number => {
+      switch (retry.backoff) {
+        case "constant":
+          return retry.delayMs;
+        case "linear":
+          return retry.delayMs * (retryAttempt + 1);
+        case "exponential":
+          return retry.delayMs * 2 ** retryAttempt;
+      }
+    };
 
-  if (!retry) {
-    return execute();
-  }
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-  const getDelay = (retryAttempt: number): number => {
-    switch (retry.backoff) {
-      case "constant":
-        return retry.delayMs;
-      case "linear":
-        return retry.delayMs * (retryAttempt + 1);
-      case "exponential":
-        return retry.delayMs * 2 ** retryAttempt;
+    let result = await execute();
+
+    const shouldRetryFn = retry.shouldRetry ?? (() => true);
+
+    for (let attempt = 0; attempt < retry.times; attempt++) {
+      if (result.status !== "error") break;
+      const error = result.error;
+      const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
+      if (!shouldContinue) break;
+      await sleep(getDelay(attempt));
+      result = await execute();
     }
+
+    return result;
   };
-
-  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-  let result = await execute();
-
-  const shouldRetryFn = retry.shouldRetry ?? (() => true);
-
-  for (let attempt = 0; attempt < retry.times; attempt++) {
-    if (result.status !== "error") break;
-    const error = result.error;
-    const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
-    if (!shouldContinue) break;
-    await sleep(getDelay(attempt));
-    result = await execute();
-  }
-
-  return result;
-};
 
 const map: {
   <A, B, E>(result: Result<A, E>, fn: (a: A) => B): Result<B, E>;
@@ -799,9 +799,9 @@ const andThenAsync: {
 );
 
 const match: {
-  <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T }): T;
-  <A, E, T>(handlers: { ok: (a: A) => T; err: (e: E) => T }): (result: Result<A, E>) => T;
-} = dual(2, <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T }): T => {
+  <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T;
+  <A, E, T>(handlers: { ok: (a: A) => T; err: (e: E) => T; }): (result: Result<A, E>) => T;
+} = dual(2, <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T => {
   return result.match(handlers);
 });
 
@@ -866,7 +866,7 @@ function assertIsResult(value: unknown): asserts value is Result<unknown, unknow
   }
   return panic(
     "Result.gen body must return Result.ok() or Result.err(), got: " +
-      (value === null ? "null" : typeof value === "object" ? JSON.stringify(value) : String(value)),
+    (value === null ? "null" : typeof value === "object" ? JSON.stringify(value) : String(value)),
   );
 }
 


### PR DESCRIPTION
## Summary
- preserve `tryRecover` / `tryRecoverAsync` success-channel type by using local no-infer helpers for TypeScript 5.0 compatibility
- add typechecking coverage for recovery inference and Err phantom success covariance
- switch tests to pinned Vitest typecheck runner and refresh lockfile
- suppress intentional test-only Oxlint warnings for throwing `finally` blocks / no-yield generator edge cases

## Validation
- `bun run fmt:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run lint`
- `git diff --check`