### PR TITLE
Fix object overload editor hints

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -148,8 +148,8 @@ type HandledTags<E extends AnyTaggedError, H> = Extract<keyof H, E["_tag"]>;
  * }));
  */
 export const matchError: {
-  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R;
   <E extends AnyTaggedError, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
+  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R;
 } = dual(2, <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R => {
   const handler = handlers[err._tag as E["_tag"]];
   // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
@@ -165,11 +165,6 @@ export const matchError: {
  * }, (e) => `Unknown: ${e.message}`);
  */
 export const matchErrorPartial: {
-  <E extends AnyTaggedError, R, const H extends PartialMatchHandlers<E, R>>(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): R;
   <
     E extends AnyTaggedError,
     R,
@@ -178,6 +173,11 @@ export const matchErrorPartial: {
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): (err: E) => R;
+  <E extends AnyTaggedError, R, const H extends PartialMatchHandlers<E, R>>(
+    err: E,
+    handlers: H,
+    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+  ): R;
 } = dual(
   3,
   <E extends AnyTaggedError, R, H extends PartialMatchHandlers<E, R>>(

--- a/src/result.ts
+++ b/src/result.ts
@@ -38,14 +38,14 @@ type InferYieldErr<Y> = Y extends Err<never, infer E> ? E : never;
 type NoInfer<T> = [T][T extends unknown ? 0 : never];
 
 const tryFn: {
-  <A>(
-    thunk: () => Awaited<A>,
-    config?: { retry?: { times: number; }; },
-  ): Result<A, UnhandledException>;
   <A, E>(
     options: { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E>; },
     config?: { retry?: { times: number; }; },
   ): Result<A, E>;
+  <A>(
+    thunk: () => Awaited<A>,
+    config?: { retry?: { times: number; }; },
+  ): Result<A, UnhandledException>;
 } = <A, E>(
   options: (() => Awaited<A>) | { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E>; },
   config?: { retry?: { times: number; }; },
@@ -91,14 +91,14 @@ type RetryConfig<E = unknown> = {
 };
 
 const tryPromise: {
-  <A>(
-    thunk: () => Promise<A>,
-    config?: RetryConfig<UnhandledException>,
-  ): Promise<Result<A, UnhandledException>>;
   <A, E>(
     options: { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E>; },
     config?: RetryConfig<E>,
   ): Promise<Result<A, E>>;
+  <A>(
+    thunk: () => Promise<A>,
+    config?: RetryConfig<UnhandledException>,
+  ): Promise<Result<A, UnhandledException>>;
 } = async <A, E>(
   options:
     | (() => Promise<A>)
@@ -243,8 +243,8 @@ const andThenAsync: {
 );
 
 const match: {
-  <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T;
   <A, E, T>(handlers: { ok: (a: A) => T; err: (e: E) => T; }): (result: Result<A, E>) => T;
+  <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T;
 } = dual(
   2,
   <A, E, T>(result: Result<A, E>, handlers: { ok: (a: A) => T; err: (e: E) => T; }): T => {
@@ -287,17 +287,17 @@ const tapErrorAsync: {
 );
 
 const tapBoth: {
-  <A, E>(result: Result<A, E>, handlers: TapBothHandlers<A, E>): Result<A, E>;
   <A, E>(handlers: TapBothHandlers<A, E>): (result: Result<A, E>) => Result<A, E>;
+  <A, E>(result: Result<A, E>, handlers: TapBothHandlers<A, E>): Result<A, E>;
 } = dual(2, <A, E>(result: Result<A, E>, handlers: TapBothHandlers<A, E>): Result<A, E> => {
   return result.tapBoth(handlers);
 });
 
 const tapBothAsync: {
-  <A, E>(result: Result<A, E>, handlers: TapBothAsyncHandlers<A, E>): Promise<Result<A, E>>;
   <A, E>(
     handlers: TapBothAsyncHandlers<A, E>,
   ): (result: Result<A, E>) => Promise<Result<A, E>>;
+  <A, E>(result: Result<A, E>, handlers: TapBothAsyncHandlers<A, E>): Promise<Result<A, E>>;
 } = dual(
   2,
   <A, E>(


### PR DESCRIPTION
## Summary
- Put object/data-last overloads before thunk/data-first overloads so TypeScript contextual typing gives useful object literal completions
- Fix `Result.try` / `Result.tryPromise` editor hints for `{ try, catch }` options
- Apply the same overload-order fix to handler-object combinators: `Result.match`, `Result.tapBoth`, `Result.tapBothAsync`, `matchError`, and `matchErrorPartial`

Closes #61.

## Notes
- Audited other overloads for the same issue; the remaining overloads take function/scalar first args and do not have object-literal completion conflicts.
- `dist/` is already ignored and no tracked `dist` files exist on current `main`, so there was nothing to remove from git.

## Validation
- `bun run check`
- `bun test`

`bun run fmt:check` currently reports pre-existing formatting issues in `src/error.ts` and `src/result.ts` on a clean checkout, so this PR intentionally avoids unrelated formatting churn.