### PR TITLE
fix: simplify TaggedError syntax by removing trailing call

### DIFF
--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -11,17 +11,17 @@ import { Result, type Result as ResultType } from "./result";
 class NotFoundError extends TaggedError("NotFoundError")<{
   id: string;
   message: string;
-}>() {}
+}> {}
 
 class ValidationError extends TaggedError("ValidationError")<{
   field: string;
   message: string;
-}>() {}
+}> {}
 
 class NetworkError extends TaggedError("NetworkError")<{
   url: string;
   message: string;
-}>() {}
+}> {}
 
 type AppError = NotFoundError | ValidationError | NetworkError;
 
@@ -53,7 +53,7 @@ describe("TaggedError", () => {
       class ErrorWithCause extends TaggedError("ErrorWithCause")<{
         message: string;
         cause: unknown;
-      }>() {}
+      }> {}
 
       const error = new ErrorWithCause({ message: "wrapper", cause });
       expect(error.stack).toContain("Caused by:");
@@ -65,11 +65,11 @@ describe("TaggedError", () => {
       class MiddleError extends TaggedError("MiddleError")<{
         message: string;
         cause: unknown;
-      }>() {}
+      }> {}
       class OuterError extends TaggedError("OuterError")<{
         message: string;
         cause: unknown;
-      }>() {}
+      }> {}
 
       const middle = new MiddleError({ message: "middle", cause: inner });
       const outer = new OuterError({ message: "outer", cause: middle });
@@ -116,21 +116,21 @@ describe("TaggedError", () => {
     });
 
     it("FooError.is(fooError) is true", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       expect(FooError.is(fooError)).toBe(true);
     });
 
     it("BarError.is(fooError) is false", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
-      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
+      class BarError extends TaggedError("BarError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       expect(BarError.is(fooError)).toBe(false);
     });
 
     it("isTaggedError(fooError) is true for any TaggedError", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
-      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
+      class BarError extends TaggedError("BarError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       const barError = new BarError({ message: "bar" });
       expect(isTaggedError(fooError)).toBe(true);
@@ -138,8 +138,8 @@ describe("TaggedError", () => {
     });
 
     it("TaggedError.is(fooError) is true for any TaggedError", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
-      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
+      class BarError extends TaggedError("BarError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       const barError = new BarError({ message: "bar" });
       expect(TaggedError.is(fooError)).toBe(true);

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   TaggedError,
   UnhandledException,
+  ResultDeserializationError,
   matchError,
   matchErrorPartial,
   isTaggedError,
@@ -113,6 +114,52 @@ describe("TaggedError", () => {
 
     it("returns false for non-errors", () => {
       expect(NotFoundError.is({ _tag: "NotFoundError" })).toBe(false);
+    });
+
+    it("narrows unknown to the concrete TaggedError subclass", () => {
+      const error: unknown = new NotFoundError({ id: "123", message: "not found" });
+
+      if (!NotFoundError.is(error)) {
+        throw new Error("Expected NotFoundError.is to recognize its own instance");
+      }
+
+      const _error: NotFoundError = error;
+      const id: string = error.id;
+      const tag: "NotFoundError" = error._tag;
+      // @ts-expect-error - narrowing must not add properties from another TaggedError subclass
+      void error.field;
+      void _error;
+      expect({ id, tag }).toEqual({ id: "123", tag: "NotFoundError" });
+    });
+
+    it("narrows built-in TaggedError subclasses with custom constructors", () => {
+      const invalidValue = { status: "invalid" };
+      const error: unknown = new ResultDeserializationError({ value: invalidValue });
+
+      if (!ResultDeserializationError.is(error)) {
+        throw new Error("Expected ResultDeserializationError.is to recognize its own instance");
+      }
+
+      const _error: ResultDeserializationError = error;
+      const value: unknown = error.value;
+      void _error;
+      expect(value).toBe(invalidValue);
+    });
+
+    it("distinguishes subclasses that share a TaggedError base class", () => {
+      const SharedError = TaggedError("SharedError");
+      class FooError extends SharedError<{ foo: string }> {}
+      class BarError extends SharedError<{ bar: string }> {}
+      class ChildFooError extends FooError {}
+
+      const fooError = new FooError({ foo: "foo" });
+      const barError = new BarError({ bar: "bar" });
+      const childFooError = new ChildFooError({ foo: "child" });
+
+      expect(FooError.is(fooError)).toBe(true);
+      expect(FooError.is(childFooError)).toBe(true);
+      expect(FooError.is(barError)).toBe(false);
+      expect(BarError.is(fooError)).toBe(false);
     });
 
     it("FooError.is(fooError) is true", () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -24,7 +24,7 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * class NotFoundError extends TaggedError("NotFoundError")<{
  *   id: string;
  *   message: string;
- * }>() {}
+ * }> {}
  *
  * const err = new NotFoundError({ id: "123", message: "Not found: 123" });
  * err._tag    // "NotFoundError"
@@ -34,71 +34,60 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * // Check if any tagged error
  * TaggedError.is(err) // true
  */
-export const TaggedError: {
-  <Tag extends string>(
-    tag: Tag,
-  ): <Props extends Record<string, unknown> = {}>() => TaggedErrorClass<Tag, Props>;
-  /** Type guard for any TaggedError instance */
-  is(value: unknown): value is AnyTaggedError;
-} = Object.assign(
-  <Tag extends string>(tag: Tag) =>
-    <Props extends Record<string, unknown> = {}>(): TaggedErrorClass<Tag, Props> => {
-      class Base extends Error {
-        readonly _tag: Tag = tag;
+export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag> => {
+  class Base<Props extends Record<string, unknown> = {}> extends Error {
+    readonly _tag: Tag = tag;
 
-        /** Type guard for this error class */
-        static is(value: unknown): value is Base {
-          return value instanceof Base;
-        }
+    constructor(args?: Props) {
+      const message =
+        args && "message" in args && typeof args.message === "string" ? args.message : undefined;
+      const cause = args && "cause" in args ? args.cause : undefined;
 
-        constructor(args?: Props) {
-          const message =
-            args && "message" in args && typeof args.message === "string"
-              ? args.message
-              : undefined;
-          const cause = args && "cause" in args ? args.cause : undefined;
+      super(message, cause !== undefined ? { cause } : undefined);
 
-          super(message, cause !== undefined ? { cause } : undefined);
-
-          if (args) {
-            Object.assign(this, args);
-          }
-
-          Object.setPrototypeOf(this, new.target.prototype);
-          this.name = tag;
-
-          if (cause instanceof Error && cause.stack) {
-            const indented = cause.stack.replace(/\n/g, "\n  ");
-            this.stack = `${this.stack}\nCaused by: ${indented}`;
-          }
-        }
-
-        toJSON(): object {
-          return {
-            ...this,
-            _tag: this._tag,
-            name: this.name,
-            message: this.message,
-            cause: serializeCause(this.cause),
-            stack: this.stack,
-          };
-        }
-
-        /**
-         * Makes this TaggedError yieldable in Result.gen blocks.
-         * Yielding short-circuits with this error, matching Err semantics.
-         */
-        *[Symbol.iterator](): Generator<Err<never, this>, never, unknown> {
-          yield* err(this);
-          return panic("Unreachable: Err yielded in TaggedError but generator continued", this);
-        }
+      if (args) {
+        Object.assign(this, args);
       }
 
-      // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
-      return Base as unknown as TaggedErrorClass<Tag, Props>;
-    },
-  { is: isAnyTaggedError },
-);
+      Object.setPrototypeOf(this, new.target.prototype);
+      this.name = tag;
+
+      if (cause instanceof Error && cause.stack) {
+        const indented = cause.stack.replace(/\n/g, "\n  ");
+        this.stack = `${this.stack}\nCaused by: ${indented}`;
+      }
+    }
+
+    toJSON(): object {
+      return {
+        ...this,
+        _tag: this._tag,
+        name: this.name,
+        message: this.message,
+        cause: serializeCause(this.cause),
+        stack: this.stack,
+      };
+    }
+
+    /**
+     * Makes this TaggedError yieldable in Result.gen blocks.
+     * Yielding short-circuits with this error, matching Err semantics.
+     */
+    *[Symbol.iterator](): Generator<Err<never, this>, never, unknown> {
+      yield* err(this);
+      return panic("Unreachable: Err yielded in TaggedError but generator continued", this);
+    }
+
+    /** Type guard for this error class */
+    static is(value: unknown): value is TaggedErrorInstance<Tag, unknown> {
+      return value instanceof Base;
+    }
+  }
+
+  // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
+  return Base as unknown as TaggedErrorClass<Tag>;
+};
+TaggedError.is = isAnyTaggedError;
 
 interface IterableError extends Error {
   /** Makes TaggedError instances yieldable in Result.gen blocks. */
@@ -112,12 +101,12 @@ export type TaggedErrorInstance<Tag extends string, Props> = IterableError & {
 } & Readonly<Props>;
 
 /** Class type produced by TaggedError factory */
-export type TaggedErrorClass<Tag extends string, Props> = {
-  new (
+export type TaggedErrorClass<Tag extends string> = {
+  new <Props extends Record<string, unknown> = {}>(
     ...args: keyof Props extends never ? [args?: {}] : [args: Props]
   ): TaggedErrorInstance<Tag, Props>;
   /** Type guard for this error class */
-  is(value: unknown): value is TaggedErrorInstance<Tag, Props>;
+  is(value: unknown): value is TaggedErrorInstance<Tag, unknown>;
 };
 
 /** Handler map for exhaustive matching */
@@ -211,7 +200,7 @@ export const isTaggedError = isAnyTaggedError;
 export class UnhandledException extends TaggedError("UnhandledException")<{
   message: string;
   cause: unknown;
-}>() {
+}> {
   constructor(args: { cause: unknown }) {
     const message =
       args.cause instanceof Error
@@ -233,7 +222,7 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
 export class ResultDeserializationError extends TaggedError("ResultDeserializationError")<{
   message: string;
   value: unknown;
-}>() {
+}> {
   constructor(args: { value: unknown }) {
     super({
       message: `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,

--- a/src/error.ts
+++ b/src/error.ts
@@ -78,9 +78,9 @@ export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag>
       return panic("Unreachable: Err yielded in TaggedError but generator continued", this);
     }
 
-    /** Type guard for this error class */
-    static is(value: unknown): value is TaggedErrorInstance<Tag, unknown> {
-      return value instanceof Base;
+    /** Type guard for the concrete error class on which this method is called. */
+    static is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C> {
+      return value instanceof this;
     }
   }
 
@@ -100,13 +100,16 @@ export type TaggedErrorInstance<Tag extends string, Props> = IterableError & {
   toJSON(): object;
 } & Readonly<Props>;
 
+/** Constructor used to infer the concrete class for static TaggedError guards. */
+type TaggedErrorConstructor = abstract new (...args: never[]) => object;
+
 /** Class type produced by TaggedError factory */
 export type TaggedErrorClass<Tag extends string> = {
   new <Props extends Record<string, unknown> = {}>(
     ...args: keyof Props extends never ? [args?: {}] : [args: Props]
   ): TaggedErrorInstance<Tag, Props>;
-  /** Type guard for this error class */
-  is(value: unknown): value is TaggedErrorInstance<Tag, unknown>;
+  /** Type guard for the concrete error class on which this method is called. */
+  is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C>;
 };
 
 /** Handler map for exhaustive matching */


### PR DESCRIPTION
## Summary

updates `TaggedError` so extending a tagged error class no longer requires an extra trailing `()`, which makes the api easier to understand and use.

> [!IMPORTANT]  
> This introduces a breaking change, intended for v3

this also aligns `TaggedError` more closely with Effect conventions, leading to less confusion when moving between libraries.

the factory now returns a generic class directly, keeps `TaggedError.is` as the cross-class guard, and updates docs and tests to use the new extension pattern.

for `TaggedError.is`, we don't actually need to use `Object.assign`, since TypeScript allows attaching properties to functions after declaration.

## Validation

- `bun run check`
- `bun run test`
- `bun run lint`
- `bun run fmt:check`