### PR TITLE
Add retry attempt context to try callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,18 @@ const result = await Result.tryPromise(() => fetch(url), {
 });
 ```
 
+The try callback receives a `TryContext` with a 0-based `attempt` number:
+
+```ts
+const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(url, attempt), {
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "constant",
+  },
+});
+```
+
 ### Conditional Retry
 
 Retry only for specific error types using `shouldRetry`:

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ const result = await Result.tryPromise(() => fetch(url), {
 });
 ```
 
-The try callback receives a `TryContext` with a 0-based `attempt` number:
+The try callback receives a `TryContext` with a 1-based `attempt` number:
 
 ```ts
 const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(url, attempt), {

--- a/context7.json
+++ b/context7.json
@@ -10,7 +10,7 @@
     "Extend TaggedError(\"YourError\") for discriminated error types - creates errors with _tag for exhaustive matching",
     "Return Result.ok() or Result.err() at the end of Result.gen blocks - generators must return a Result",
     "Use Result.try with catch handler to convert exceptions to typed errors - wrap throwing functions safely",
-    "Use Result.tryPromise for async ops with optional retry - supports times, delayMs, backoff, shouldRetry options",
+    "Use Result.tryPromise for async ops with optional retry - supports 0-based TryContext attempt plus times, delayMs, backoff, shouldRetry options",
     "For async retry decisions, enrich error in catch handler (can be async) then use shouldRetry synchronously",
     "Use .match({ ok, err }) for exhaustive handling of both Result variants - forces explicit error handling",
     "Use matchError for exhaustive pattern matching on TaggedError unions - compiler enforces all error variants",

--- a/context7.json
+++ b/context7.json
@@ -10,7 +10,7 @@
     "Extend TaggedError(\"YourError\") for discriminated error types - creates errors with _tag for exhaustive matching",
     "Return Result.ok() or Result.err() at the end of Result.gen blocks - generators must return a Result",
     "Use Result.try with catch handler to convert exceptions to typed errors - wrap throwing functions safely",
-    "Use Result.tryPromise for async ops with optional retry - supports 0-based TryContext attempt plus times, delayMs, backoff, shouldRetry options",
+    "Use Result.tryPromise for async ops with optional retry - supports 1-based TryContext attempt plus times, delayMs, backoff, shouldRetry options",
     "For async retry decisions, enrich error in catch handler (can be async) then use shouldRetry synchronously",
     "Use .match({ ok, err }) for exhaustive handling of both Result variants - forces explicit error handling",
     "Use matchError for exhaustive pattern matching on TaggedError unions - compiler enforces all error variants",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-result",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Lightweight Result type with generator-based composition",
   "keywords": [
     "error-handling",
@@ -21,7 +21,9 @@
   },
   "files": [
     "dist/index.d.mts",
-    "dist/index.mjs"
+    "dist/index.d.mts.map",
+    "dist/index.mjs",
+    "dist/index.mjs.map"
   ],
   "type": "module",
   "main": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 export { Result, Ok, Err } from "./result";
-export type { InferOk, InferErr, SerializedResult, SerializedOk, SerializedErr } from "./result";
+export type {
+  InferOk,
+  InferErr,
+  SerializedResult,
+  SerializedOk,
+  SerializedErr,
+  TryContext,
+} from "./result";
 export {
   Panic,
   panic,

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -219,12 +219,12 @@ describe("Result", () => {
       expect(attempts).toBe(3);
     });
 
-    it("passes 0-based attempt context to function overload", () => {
+    it("passes 1-based attempt context to function overload", () => {
       const receivedAttempts: number[] = [];
       const result = Result.try(
         ({ attempt }) => {
           receivedAttempts.push(attempt);
-          if (attempt < 2) throw new Error("fail");
+          if (attempt < 3) throw new Error("fail");
           return "success";
         },
         { retry: { times: 3 } },
@@ -232,16 +232,16 @@ describe("Result", () => {
 
       expect(Result.isOk(result)).toBe(true);
       expect(result.unwrap()).toBe("success");
-      expect(receivedAttempts).toEqual([0, 1, 2]);
+      expect(receivedAttempts).toEqual([1, 2, 3]);
     });
 
-    it("passes 0-based attempt context to object overload", () => {
+    it("passes 1-based attempt context to object overload", () => {
       const receivedAttempts: number[] = [];
       const result = Result.try(
         {
           try: ({ attempt }) => {
             receivedAttempts.push(attempt);
-            if (attempt < 2) throw new Error("fail");
+            if (attempt < 3) throw new Error("fail");
             return "success";
           },
           catch: (e) => ({ msg: (e as Error).message }),
@@ -251,7 +251,7 @@ describe("Result", () => {
 
       expect(Result.isOk(result)).toBe(true);
       expect(result.unwrap()).toBe("success");
-      expect(receivedAttempts).toEqual([0, 1, 2]);
+      expect(receivedAttempts).toEqual([1, 2, 3]);
     });
 
     it("throws Panic when catch handler throws", () => {
@@ -319,12 +319,12 @@ describe("Result", () => {
       expect(elapsed).toBeGreaterThanOrEqual(25);
     });
 
-    it("passes 0-based attempt context to function overload", async () => {
+    it("passes 1-based attempt context to function overload", async () => {
       const receivedAttempts: number[] = [];
       const result = await Result.tryPromise(
         ({ attempt }) => {
           receivedAttempts.push(attempt);
-          if (attempt < 2) return Promise.reject(new Error("fail"));
+          if (attempt < 3) return Promise.reject(new Error("fail"));
           return Promise.resolve("success");
         },
         { retry: { times: 3, delayMs: 1, backoff: "constant" } },
@@ -332,16 +332,16 @@ describe("Result", () => {
 
       expect(Result.isOk(result)).toBe(true);
       expect(result.unwrap()).toBe("success");
-      expect(receivedAttempts).toEqual([0, 1, 2]);
+      expect(receivedAttempts).toEqual([1, 2, 3]);
     });
 
-    it("passes 0-based attempt context to object overload", async () => {
+    it("passes 1-based attempt context to object overload", async () => {
       const receivedAttempts: number[] = [];
       const result = await Result.tryPromise(
         {
           try: ({ attempt }) => {
             receivedAttempts.push(attempt);
-            if (attempt < 2) return Promise.reject(new Error("fail"));
+            if (attempt < 3) return Promise.reject(new Error("fail"));
             return Promise.resolve("success");
           },
           catch: (e) => ({ msg: (e as Error).message }),
@@ -351,7 +351,7 @@ describe("Result", () => {
 
       expect(Result.isOk(result)).toBe(true);
       expect(result.unwrap()).toBe("success");
-      expect(receivedAttempts).toEqual([0, 1, 2]);
+      expect(receivedAttempts).toEqual([1, 2, 3]);
     });
 
     it("throws Panic when catch handler throws", async () => {

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -219,6 +219,41 @@ describe("Result", () => {
       expect(attempts).toBe(3);
     });
 
+    it("passes 0-based attempt context to function overload", () => {
+      const receivedAttempts: number[] = [];
+      const result = Result.try(
+        ({ attempt }) => {
+          receivedAttempts.push(attempt);
+          if (attempt < 2) throw new Error("fail");
+          return "success";
+        },
+        { retry: { times: 3 } },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(result.unwrap()).toBe("success");
+      expect(receivedAttempts).toEqual([0, 1, 2]);
+    });
+
+    it("passes 0-based attempt context to object overload", () => {
+      const receivedAttempts: number[] = [];
+      const result = Result.try(
+        {
+          try: ({ attempt }) => {
+            receivedAttempts.push(attempt);
+            if (attempt < 2) throw new Error("fail");
+            return "success";
+          },
+          catch: (e) => ({ msg: (e as Error).message }),
+        },
+        { retry: { times: 3 } },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(result.unwrap()).toBe("success");
+      expect(receivedAttempts).toEqual([0, 1, 2]);
+    });
+
     it("throws Panic when catch handler throws", () => {
       expect(() =>
         Result.try({
@@ -282,6 +317,41 @@ describe("Result", () => {
       expect(attempts).toBe(3);
       // exponential: 10ms + 20ms = 30ms minimum
       expect(elapsed).toBeGreaterThanOrEqual(25);
+    });
+
+    it("passes 0-based attempt context to function overload", async () => {
+      const receivedAttempts: number[] = [];
+      const result = await Result.tryPromise(
+        ({ attempt }) => {
+          receivedAttempts.push(attempt);
+          if (attempt < 2) return Promise.reject(new Error("fail"));
+          return Promise.resolve("success");
+        },
+        { retry: { times: 3, delayMs: 1, backoff: "constant" } },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(result.unwrap()).toBe("success");
+      expect(receivedAttempts).toEqual([0, 1, 2]);
+    });
+
+    it("passes 0-based attempt context to object overload", async () => {
+      const receivedAttempts: number[] = [];
+      const result = await Result.tryPromise(
+        {
+          try: ({ attempt }) => {
+            receivedAttempts.push(attempt);
+            if (attempt < 2) return Promise.reject(new Error("fail"));
+            return Promise.resolve("success");
+          },
+          catch: (e) => ({ msg: (e as Error).message }),
+        },
+        { retry: { times: 3, delayMs: 1, backoff: "constant" } },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(result.unwrap()).toBe("success");
+      expect(receivedAttempts).toEqual([0, 1, 2]);
     });
 
     it("throws Panic when catch handler throws", async () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -19,6 +19,10 @@ export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
 export type Result<T, E> = import("./core").Result<T, E>;
 
+export type TryContext = {
+  readonly attempt: number;
+};
+
 /** Executes fn, panics if it throws. */
 const tryOrPanic = <T>(fn: () => T, message: string): T => {
   try {
@@ -39,27 +43,29 @@ type NoInfer<T> = [T][T extends unknown ? 0 : never];
 
 const tryFn: {
   <A, E>(
-    options: { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
+    options: { try: (context: TryContext) => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
     config?: { retry?: { times: number } },
   ): Result<A, E>;
   <A>(
-    thunk: () => Awaited<A>,
+    thunk: (context: TryContext) => Awaited<A>,
     config?: { retry?: { times: number } },
   ): Result<A, UnhandledException>;
 } = <A, E>(
-  options: (() => Awaited<A>) | { try: () => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
+  options:
+    | ((context: TryContext) => Awaited<A>)
+    | { try: (context: TryContext) => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
   config?: { retry?: { times: number } },
 ): Result<A, E | UnhandledException> => {
-  const execute = (): Result<A, E | UnhandledException> => {
+  const execute = (context: TryContext): Result<A, E | UnhandledException> => {
     if (typeof options === "function") {
       try {
-        return ok(options());
+        return ok(options(context));
       } catch (cause) {
         return err(new UnhandledException({ cause }));
       }
     }
     try {
-      return ok(options.try());
+      return ok(options.try(context));
     } catch (originalCause) {
       // If the user's catch handler throws, it's a defect — Panic
       try {
@@ -71,10 +77,12 @@ const tryFn: {
   };
 
   const times = config?.retry?.times ?? 0;
-  let result = execute();
+  let attempt = 0;
+  let result = execute({ attempt });
 
   for (let retry = 0; retry < times && result.status === "error"; retry++) {
-    result = execute();
+    attempt++;
+    result = execute({ attempt });
   }
 
   return result;
@@ -92,29 +100,32 @@ type RetryConfig<E = unknown> = {
 
 const tryPromise: {
   <A, E>(
-    options: { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
+    options: {
+      try: (context: TryContext) => Promise<A>;
+      catch: (cause: unknown) => E | Promise<E>;
+    },
     config?: RetryConfig<E>,
   ): Promise<Result<A, E>>;
   <A>(
-    thunk: () => Promise<A>,
+    thunk: (context: TryContext) => Promise<A>,
     config?: RetryConfig<UnhandledException>,
   ): Promise<Result<A, UnhandledException>>;
 } = async <A, E>(
   options:
-    | (() => Promise<A>)
-    | { try: () => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
+    | ((context: TryContext) => Promise<A>)
+    | { try: (context: TryContext) => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
   config?: RetryConfig<E | UnhandledException>,
 ): Promise<Result<A, E | UnhandledException>> => {
-  const execute = async (): Promise<Result<A, E | UnhandledException>> => {
+  const execute = async (context: TryContext): Promise<Result<A, E | UnhandledException>> => {
     if (typeof options === "function") {
       try {
-        return ok(await options());
+        return ok(await options(context));
       } catch (cause) {
         return err(new UnhandledException({ cause }));
       }
     }
     try {
-      return ok(await options.try());
+      return ok(await options.try(context));
     } catch (originalCause) {
       // If the user's catch handler throws, it's a defect — Panic
       try {
@@ -128,7 +139,7 @@ const tryPromise: {
   const retry = config?.retry;
 
   if (!retry) {
-    return execute();
+    return execute({ attempt: 0 });
   }
 
   const getDelay = (retryAttempt: number): number => {
@@ -144,17 +155,19 @@ const tryPromise: {
 
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-  let result = await execute();
+  let attempt = 0;
+  let result = await execute({ attempt });
 
   const shouldRetryFn = retry.shouldRetry ?? (() => true);
 
-  for (let attempt = 0; attempt < retry.times; attempt++) {
+  for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
     if (result.status !== "error") break;
     const error = result.error;
     const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
     if (!shouldContinue) break;
-    await sleep(getDelay(attempt));
-    result = await execute();
+    await sleep(getDelay(retryAttempt));
+    attempt++;
+    result = await execute({ attempt });
   }
 
   return result;

--- a/src/result.ts
+++ b/src/result.ts
@@ -77,7 +77,7 @@ const tryFn: {
   };
 
   const times = config?.retry?.times ?? 0;
-  let attempt = 0;
+  let attempt = 1;
   let result = execute({ attempt });
 
   for (let retry = 0; retry < times && result.status === "error"; retry++) {
@@ -139,7 +139,7 @@ const tryPromise: {
   const retry = config?.retry;
 
   if (!retry) {
-    return execute({ attempt: 0 });
+    return execute({ attempt: 1 });
   }
 
   const getDelay = (retryAttempt: number): number => {
@@ -155,7 +155,7 @@ const tryPromise: {
 
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-  let attempt = 0;
+  let attempt = 1;
   let result = await execute({ attempt });
 
   const shouldRetryFn = retry.shouldRetry ?? (() => true);


### PR DESCRIPTION
## Summary

* Add a 0-based `TryContext` argument to `Result.try` and `Result.tryPromise` callbacks
* Document retry-attempt usage in `README.md` and update Context7 rules

Closes #55

## Validation

* `bun run check`
* `bun test`
* `bun run build`