### PR TITLE
Include source maps in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "files": [
     "dist/index.d.mts",
-    "dist/index.mjs"
+    "dist/index.d.mts.map",
+    "dist/index.mjs",
+    "dist/index.mjs.map"
   ],
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- include generated JS and declaration source maps in the published package
- fixes missing source map warnings from Vite

Fixes #75

## Verification
- bun run check
- bun pm pack --dry-run