### PR TITLE
fix: preserve Result.deserialize inference for known result shapes

### DIFF
--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1643,7 +1643,8 @@ describe("Result", () => {
       ];
 
       for (const input of testCases) {
-        const result = Result.deserialize(input);
+        const result = Result.deserialize<number, string>(input);
+        expectTypeOf(result).toEqualTypeOf<Result<number, string | ResultDeserializationError>>();
         expect(Result.isError(result)).toBe(true);
         if (Result.isError(result)) {
           expect(result.error).toBeInstanceOf(ResultDeserializationError);

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1592,21 +1592,44 @@ describe("Result", () => {
   });
 
   describe("deserialize", () => {
+    it("returns Result<T, E> for known Result-like input", () => {
+      const serialized1 =
+        Math.random() > 0.5
+          ? { status: "ok" as const, value: 42 }
+          : { status: "error" as const, error: "fail" };
+      const result1 = Result.deserialize(serialized1);
+      expectTypeOf(result1).toEqualTypeOf<Result<number, string>>();
+
+      const serialized2 = Math.random() > 0.5 ? Result.ok(42) : Result.err("fail");
+      const result2 = Result.deserialize(serialized2);
+      expectTypeOf(result2).toEqualTypeOf<Result<number, string>>();
+    });
+
+    it("returns Result<unknown, unknown> for unknown, non-Result-like input", () => {
+      const input = { foo: "bar" };
+      const result = Result.deserialize(input);
+      expectTypeOf(result).toEqualTypeOf<Result<unknown, unknown>>();
+    });
+
     it("deserializes Ok object to Ok instance", () => {
       const serialized = { status: "ok" as const, value: 42 };
-      const result = Result.deserialize<number, string>(serialized);
+      const result = Result.deserialize(serialized);
+      expectTypeOf(result).toEqualTypeOf<Result<number, never>>();
       expect(Result.isOk(result)).toBe(true);
       expect(result).toBeInstanceOf(Ok);
       expect(result.unwrap()).toBe(42);
     });
 
     it("deserializes Err object to Err instance", () => {
-      const serialized = { status: "error" as const, error: "fail" };
-      const result = Result.deserialize<number, string>(serialized);
-      expect(Result.isError(result)).toBe(true);
-      expect(result).toBeInstanceOf(Err);
-      if (Result.isError(result)) {
-        expect(result.error).toBe("fail");
+      {
+        const serialized = { status: "error" as const, error: "fail" };
+        const result = Result.deserialize(serialized);
+        expectTypeOf(result).toEqualTypeOf<Result<never, string>>();
+        expect(Result.isError(result)).toBe(true);
+        expect(result).toBeInstanceOf(Err);
+        if (Result.isError(result)) {
+          expect(result.error).toBe("fail");
+        }
       }
     });
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -447,20 +447,20 @@ const serialize = <T, E>(result: Result<T, E>): SerializedResult<T, E> => {
     : { status: "error", error: result.error };
 };
 
-const deserialize = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
+function deserialize<T = never, E = never>(x: SerializedResult<T, E>): Result<T, E>;
+function deserialize<T, E>(x: unknown): Result<T, E | ResultDeserializationError>;
+function deserialize(value: unknown) {
   if (isSerializedResult(value)) {
-    return value.status === "ok"
-      ? (new Ok(value.value) as Result<T, E>)
-      : (new Err(value.error) as Result<T, E>);
+    return value.status === "ok" ? ok(value.value) : err(value.error);
   }
   return err(new ResultDeserializationError({ value }));
-};
+}
 
 /**
  * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
  */
 const hydrate = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
-  return deserialize(value);
+  return deserialize(value as never);
 };
 
 const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -460,7 +460,7 @@ function deserialize(value: unknown) {
  * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
  */
 const hydrate = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
-  return deserialize(value as never);
+  return deserialize(value);
 };
 
 const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {


### PR DESCRIPTION
## Summary

`Result.deserialize` currently erases useful type information unless callers manually provide generics. that makes normal usage awkward and easy to get wrong, especially when deserializing known `{ status: "ok" | "error" }` payloads.

this change adds overloads so known serialized result shapes infer `Result<T, E>` directly, while unknown input still returns a `Result<T, E | ResultDeserializationError>` when explicit type params are passed, or `Result<unknown, unknown>` when not provided. tests now cover both inferred known-shape behavior and unknown-input fallback behavior, including `Ok` and `Err` inference cases.

since `hydrate` is legacy, it remains unchanged.

## Reproduction

- call `Result.deserialize({ status: "ok" as const, value: 42 })` before this change and inspect the inferred type
- call `Result.deserialize({ status: "error" as const, error: "fail" })` before this change and inspect the inferred type
- both cases required explicit generics to preserve expected `Result` typing

## Validation Steps

- run `bun test src/result.test.ts`
- confirm deserialize tests pass for known result-like input, unknown input, and concrete ok/error object cases
- run `bun run check` to verify type-level expectations compile cleanly