### PR TITLE
add jitter option to retry config

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,23 +355,23 @@ const result = await Result.tryPromise(() => fetch(url), {
     times: 3,
     delayMs: 100,
     backoff: "exponential",
-    jitter: true, // full jitter: delay is uniform in [0, baseDelay]
+    jitter: true, // full jitter: delay is uniform in [0, baseDelay)
   },
 });
 ```
 
-Pass a number between `0` and `1` to control how much of the base delay is randomized:
+Pass a number from `0` through `1` to control how much of the base delay is randomized:
 
 ```ts
 retry: {
   times: 3,
   delayMs: 100,
   backoff: "exponential",
-  jitter: 0.3, // delay uniform in [0.7 * baseDelay, baseDelay]
+  jitter: 0.3, // delay uniform in [0.7 * baseDelay, baseDelay)
 }
 ```
 
-`jitter: true` is equivalent to `jitter: 1`.
+`jitter: true` is equivalent to `jitter: 1`. Values outside the inclusive range from `0` to `1`, including `NaN` and infinities, throw a `Panic` before the first attempt.
 
 ## UnhandledException
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,34 @@ const result = await Result.tryPromise(
 );
 ```
 
+### Jitter
+
+To avoid thundering-herd retries when many callers fail at the same time, randomize each delay with `jitter`:
+
+```ts
+const result = await Result.tryPromise(() => fetch(url), {
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "exponential",
+    jitter: true, // full jitter: delay is uniform in [0, baseDelay]
+  },
+});
+```
+
+Pass a number between `0` and `1` to control how much of the base delay is randomized:
+
+```ts
+retry: {
+  times: 3,
+  delayMs: 100,
+  backoff: "exponential",
+  jitter: 0.3, // delay uniform in [0.7 * baseDelay, baseDelay]
+}
+```
+
+`jitter: true` is equivalent to `jitter: 1`.
+
 ## UnhandledException
 
 When `Result.try()` or `Result.tryPromise()` catches an exception without a custom handler, the error type is `UnhandledException`:

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -730,6 +730,32 @@ describe("Result", () => {
         },
       );
 
+      it.each([
+        { random: 0, expectedDelay: 0 },
+        { random: 0.999_999, expectedDelay: 99.999_9 },
+      ])(
+        "keeps full jitter within its lower and upper bounds for random=$random",
+        async ({ random, expectedDelay }) => {
+          const delays = recordRetryDelays();
+          vi.spyOn(Math, "random").mockReturnValue(random);
+          let attempts = 0;
+
+          const pending = Result.tryPromise(
+            () => {
+              attempts++;
+              return attempts === 1
+                ? Promise.reject(new Error("fail"))
+                : Promise.resolve("success");
+            },
+            { retry: { times: 1, delayMs: 100, backoff: "constant", jitter: true } },
+          );
+
+          await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+          expect(delays).toHaveLength(1);
+          expect(delays[0]).toBeCloseTo(expectedDelay, 8);
+        },
+      );
+
       it("uses a numeric jitter factor as the maximum delay reduction", async () => {
         const delays = recordRetryDelays();
         vi.spyOn(Math, "random").mockReturnValue(0.5);
@@ -746,6 +772,29 @@ describe("Result", () => {
         await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
         expect(attempts).toBe(2);
         expect(delays).toEqual([75]);
+      });
+
+      it.each([
+        { backoff: "constant" as const, expectedDelays: [50, 50, 50] },
+        { backoff: "linear" as const, expectedDelays: [50, 100, 150] },
+        { backoff: "exponential" as const, expectedDelays: [50, 100, 200] },
+      ])("applies jitter after $backoff backoff", async ({ backoff, expectedDelays }) => {
+        const delays = recordRetryDelays();
+        const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+        let attempts = 0;
+
+        const pending = Result.tryPromise(
+          () => {
+            attempts++;
+            return attempts <= 3 ? Promise.reject(new Error("fail")) : Promise.resolve("success");
+          },
+          { retry: { times: 3, delayMs: 100, backoff, jitter: true } },
+        );
+
+        await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+        expect(attempts).toBe(4);
+        expect(delays).toEqual(expectedDelays);
+        expect(random).toHaveBeenCalledTimes(3);
       });
 
       it.each([false, 0] as const)("disables jitter for %s", async (jitter) => {
@@ -767,7 +816,7 @@ describe("Result", () => {
         expect(random).not.toHaveBeenCalled();
       });
 
-      it.each([-0.1, 1.1, Number.NaN, Number.POSITIVE_INFINITY])(
+      it.each([-0.1, 1.1, Number.NaN, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY])(
         "panics before execution when jitter is outside [0, 1]: %s",
         async (jitter) => {
           let attempts = 0;
@@ -780,6 +829,7 @@ describe("Result", () => {
             { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
           );
 
+          await expect(pending).rejects.toBeInstanceOf(Panic);
           await expect(pending).rejects.toThrow(
             "Result.tryPromise retry jitter must be a finite number between 0 and 1",
           );
@@ -2908,6 +2958,74 @@ describe("Type Inference", () => {
   class ErrorC extends Error {
     readonly _tag = "ErrorC" as const;
   }
+
+  describe("tryPromise retry jitter config", () => {
+    it("preserves return and callback inference through both overloads", () => {
+      const compileTimeOnly = () => {
+        const automatic = Result.tryPromise(() => Promise.resolve(42), {
+          retry: { times: 1, delayMs: 100, backoff: "constant", jitter: true },
+        });
+        expectTypeOf(automatic).toEqualTypeOf<Promise<ResultType<number, UnhandledException>>>();
+
+        const custom = Result.tryPromise(
+          {
+            try: () => Promise.resolve("success"),
+            catch: () => new ErrorA(),
+          },
+          {
+            retry: {
+              times: 1,
+              delayMs: 100,
+              backoff: "exponential",
+              jitter: 0.5,
+              shouldRetry: (error, context) => {
+                expectTypeOf(error).toEqualTypeOf<ErrorA>();
+                expectTypeOf(context).toEqualTypeOf<TryPromiseContext>();
+                return true;
+              },
+            },
+          },
+        );
+        expectTypeOf(custom).toEqualTypeOf<Promise<ResultType<string, ErrorA>>>();
+      };
+
+      expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();
+    });
+
+    it("rejects unsupported jitter config types", () => {
+      const compileTimeOnly = () => {
+        // @ts-expect-error jitter accepts only booleans and numbers.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: 100,
+            backoff: "constant",
+            jitter: "full",
+          },
+        });
+        // @ts-expect-error null does not disable jitter; use false or omit the field.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: 100,
+            backoff: "constant",
+            jitter: null,
+          },
+        });
+        // @ts-expect-error jitter does not accept an options object.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: 100,
+            backoff: "constant",
+            jitter: { factor: 0.5 },
+          },
+        });
+      };
+
+      expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();
+    });
+  });
 
   describe("Result instance callback inference", () => {
     type Expect<T extends true> = T;

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,5 +1,5 @@
 import fc from "fast-check";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   Result,
   Ok,
@@ -688,6 +688,104 @@ describe("Result", () => {
       expect(attempts).toBe(3);
       // exponential: 10ms + 20ms = 30ms minimum
       expect(elapsed).toBeGreaterThanOrEqual(25);
+    });
+
+    describe("retry jitter", () => {
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      const recordRetryDelays = (): number[] => {
+        const delays: number[] = [];
+        const clearedTimeout = setTimeout(() => {}, 0);
+        clearTimeout(clearedTimeout);
+        vi.spyOn(globalThis, "setTimeout").mockImplementation((handler, delay) => {
+          delays.push(delay ?? 0);
+          if (typeof handler === "function") handler();
+          return clearedTimeout;
+        });
+        return delays;
+      };
+
+      it.each([true, 1] as const)(
+        "applies full jitter for %s without exceeding the base delay",
+        async (jitter) => {
+          const delays = recordRetryDelays();
+          vi.spyOn(Math, "random").mockReturnValue(0.25);
+          let attempts = 0;
+
+          const pending = Result.tryPromise(
+            () => {
+              attempts++;
+              return attempts === 1
+                ? Promise.reject(new Error("fail"))
+                : Promise.resolve("success");
+            },
+            { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
+          );
+
+          await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+          expect(attempts).toBe(2);
+          expect(delays).toEqual([25]);
+        },
+      );
+
+      it("uses a numeric jitter factor as the maximum delay reduction", async () => {
+        const delays = recordRetryDelays();
+        vi.spyOn(Math, "random").mockReturnValue(0.5);
+        let attempts = 0;
+
+        const pending = Result.tryPromise(
+          () => {
+            attempts++;
+            return attempts === 1 ? Promise.reject(new Error("fail")) : Promise.resolve("success");
+          },
+          { retry: { times: 1, delayMs: 100, backoff: "constant", jitter: 0.5 } },
+        );
+
+        await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+        expect(attempts).toBe(2);
+        expect(delays).toEqual([75]);
+      });
+
+      it.each([false, 0] as const)("disables jitter for %s", async (jitter) => {
+        const delays = recordRetryDelays();
+        const random = vi.spyOn(Math, "random");
+        let attempts = 0;
+
+        const pending = Result.tryPromise(
+          () => {
+            attempts++;
+            return attempts === 1 ? Promise.reject(new Error("fail")) : Promise.resolve("success");
+          },
+          { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
+        );
+
+        await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+        expect(attempts).toBe(2);
+        expect(delays).toEqual([100]);
+        expect(random).not.toHaveBeenCalled();
+      });
+
+      it.each([-0.1, 1.1, Number.NaN, Number.POSITIVE_INFINITY])(
+        "panics before execution when jitter is outside [0, 1]: %s",
+        async (jitter) => {
+          let attempts = 0;
+
+          const pending = Result.tryPromise(
+            () => {
+              attempts++;
+              return Promise.resolve("success");
+            },
+            { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
+          );
+
+          await expect(pending).rejects.toThrow(
+            "Result.tryPromise retry jitter must be a finite number between 0 and 1",
+          );
+          expect(attempts).toBe(0);
+        },
+      );
     });
 
     it("passes 1-based attempt context to function overload", async () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -113,6 +113,12 @@ type RetryConfig<E = unknown> = {
     backoff: "linear" | "constant" | "exponential";
     /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
     shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
+    /**
+     * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
+     * The number is the maximum reduction — e.g. `0.3` may shave up to 30% off each delay.
+     * `true` allows full reduction (down to 0). Defaults to no jitter.
+     */
+    jitter?: boolean | number;
   };
 };
 
@@ -174,6 +180,13 @@ const tryPromise: {
       case "exponential":
         return retry.delayMs * 2 ** retryAttempt;
     }
+  };
+
+  const getDelay = (retryAttempt: number): number => {
+    const baseDelay = getBaseDelay(retryAttempt);
+    if (!retry.jitter) return baseDelay;
+    const factor = retry.jitter === true ? 1 : Math.max(0, Math.min(1, retry.jitter));
+    return baseDelay * (1 - factor + Math.random() * factor);
   };
 
   const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>

--- a/src/result.ts
+++ b/src/result.ts
@@ -115,8 +115,8 @@ type RetryConfig<E = unknown> = {
     shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
     /**
      * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
-     * The number is the maximum reduction — e.g. `0.3` may shave up to 30% off each delay.
-     * `true` allows full reduction (down to 0). Defaults to no jitter.
+     * A number from 0 through 1 is the maximum reduction — e.g. `0.3` may shave up to
+     * 30% off each delay. `true` allows full reduction (down to 0). Defaults to no jitter.
      */
     jitter?: boolean | number;
   };
@@ -171,7 +171,7 @@ const tryPromise: {
     return execute({ attempt: 1, signal: config?.signal });
   }
 
-  const getDelay = (retryAttempt: number): number => {
+  const getBaseDelay = (retryAttempt: number): number => {
     switch (retry.backoff) {
       case "constant":
         return retry.delayMs;
@@ -182,11 +182,16 @@ const tryPromise: {
     }
   };
 
+  const jitter = retry.jitter ?? false;
+  if (typeof jitter === "number" && (!Number.isFinite(jitter) || jitter < 0 || jitter > 1)) {
+    throw panic("Result.tryPromise retry jitter must be a finite number between 0 and 1");
+  }
+  const jitterFactor = jitter === true ? 1 : jitter === false ? 0 : jitter;
+
   const getDelay = (retryAttempt: number): number => {
     const baseDelay = getBaseDelay(retryAttempt);
-    if (!retry.jitter) return baseDelay;
-    const factor = retry.jitter === true ? 1 : Math.max(0, Math.min(1, retry.jitter));
-    return baseDelay * (1 - factor + Math.random() * factor);
+    if (jitterFactor === 0) return baseDelay;
+    return baseDelay * (1 - jitterFactor + Math.random() * jitterFactor);
   };
 
   const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>
@@ -938,6 +943,8 @@ export const Result = {
    * }, {
    *   retry: { times: 3, delayMs: 100, backoff: "exponential", shouldRetry: e => !e.rateLimited }
    * })
+   *
+   * @throws {Panic} When retry jitter is not a finite number between 0 and 1.
    */
   tryPromise,
   /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    restoreMocks: true,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    restoreMocks: true,
-  },
-});


### PR DESCRIPTION
Closes https://github.com/dmmulroy/better-result/issues/83

Retry delays are deterministic today, so simultaneous failures produce lockstep retry waves against the dependency. This adds an opt-in `jitter` field to spread them out.

```ts
retry: {
  times: 3,
  delayMs: 100,
  backoff: "exponential",
  jitter: true, // or 0.3
}
```

- `true` or `1` → full jitter: `delay = baseDelay * Math.random()`
- number from `0` through `1` → factor: `delay = baseDelay * (1 - factor + Math.random() * factor)`
- omitted, `false`, or `0` → unchanged deterministic delay
- non-finite or out-of-range numbers → `Panic` before the first attempt

Jitter is downward-only, so a randomized delay never exceeds the backoff delay configured for that attempt. Factor `1` is AWS-style full jitter; factor `0.5` is equal jitter.

### Changes

- `src/result.ts` — adds and validates `jitter`, then applies it to constant, linear, and exponential retry delays.
- `src/result.test.ts` — deterministically verifies exact full, partial, and disabled jitter delays plus invalid configuration, without wall-clock assertions.
- `README.md` — documents jitter factors, delay bounds, and invalid configuration behavior.
