### PR TITLE
Fix isTaggedError to expose toJSON

### DIFF
--- a/.agents/skills/audit-better-result-dependents/SKILL.md
+++ b/.agents/skills/audit-better-result-dependents/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: audit-better-result-dependents
+description: Audit better-result changes or PRs against known Prisma and Better T Stack downstream dependents. Use when working on better-result API/type/runtime changes and the user asks whether a change breaks Prisma dependents, Better T Stack dependents, npm dependents, or PR compatibility.
+---
+
+# Audit better-result dependents
+
+## Quick start
+
+From the `better-result` repo, run the audit script with identifiers touched by the change:
+
+```sh
+node .agents/skills/audit-better-result-dependents/scripts/audit-dependents.mjs isTaggedError 'TaggedError\.is' 'toJSON'
+```
+
+If no patterns are provided, the script searches common `better-result` usage patterns.
+
+## Scope
+
+Always check these npm dependents:
+
+- `@prisma/compute-sdk`
+- `@prisma/streams-server`
+- `@prisma/streams-local`
+- `create-better-t-stack`
+- `@better-t-stack/template-generator`
+
+The script uses npm registry metadata to resolve latest versions and commits. For public GitHub repos it checks out the published `gitHead`; if a repo is private/unavailable, it falls back to `npm pack` and audits the published source/package.
+
+## Workflow
+
+1. **Identify risk surface**
+   - List changed public exports, guards, types, class methods, overloads, and runtime semantics.
+   - Convert them into grep patterns, escaping regex metacharacters when needed.
+
+2. **Run local validation first**
+   - `bun run fmt`
+   - `bun run check`
+   - `bun run test`
+   - `bun run lint`
+
+3. **Audit dependents**
+   - Run the script with risk patterns.
+   - Inspect actual matching files with `read`; do not rely only on counts.
+   - Distinguish generic guards (e.g. `isTaggedError`) from class-specific guards (e.g. `FooError.is`).
+
+4. **Assess breakage**
+   - Runtime breaking: dependent passes values that no longer satisfy a changed guard/shape.
+   - Type breaking: dependent references narrowed types, overloads, exported names, or structural constraints that changed.
+   - Safe: dependent only creates `TaggedError(...)` instances or uses class-specific `.is()` unaffected by the change.
+
+5. **Report clearly**
+   - Include package name, version, source audited (GitHub commit or npm package), relevant matches, and risk conclusion.
+   - If opening a PR, include the dependent audit summary in the PR body.
+
+## Notes
+
+- `@prisma/compute-sdk` may point at a private/404 GitHub repo; audit the npm package source when cloning fails.
+- `@prisma/streams-server` and `@prisma/streams-local` share the `prisma/streams` repo and usually the same `gitHead`.
+- `create-better-t-stack` and `@better-t-stack/template-generator` share the `AmanVarshney01/create-better-t-stack` repo and usually the same `gitHead`.
+- Never modify cloned dependent repositories during audit; use temp directories only.

--- a/.agents/skills/audit-better-result-dependents/scripts/audit-dependents.mjs
+++ b/.agents/skills/audit-better-result-dependents/scripts/audit-dependents.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const DEPENDENTS = [
+  "@prisma/compute-sdk",
+  "@prisma/streams-server",
+  "@prisma/streams-local",
+  "create-better-t-stack",
+  "@better-t-stack/template-generator",
+];
+
+const DEFAULT_PATTERNS = [
+  "isTaggedError",
+  "TaggedError\\.is",
+  "extends TaggedError\\(",
+  "from [\"']better-result",
+  "\\b_tag\\b",
+  "\\.toJSON\\(",
+];
+
+const patterns = process.argv.slice(2);
+const regex = patterns.length > 0 ? patterns.join("|") : DEFAULT_PATTERNS.join("|");
+const keep = process.env.KEEP_DEP_AUDIT === "1";
+const root = mkdtempSync(join(tmpdir(), "better-result-dependent-audit-"));
+
+function run(cmd, args, options = {}) {
+  return spawnSync(cmd, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+  });
+}
+
+function sanitize(name) {
+  return name.replace(/^@/, "").replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
+
+function normalizeRepoUrl(url) {
+  if (!url) return undefined;
+  return url
+    .replace(/^git\+/, "")
+    .replace(/^git@github.com:/, "https://github.com/")
+    .replace(/\.git$/, "");
+}
+
+async function npmMetadata(name) {
+  const encoded = name.startsWith("@") ? name.replace("/", "%2F") : name;
+  const response = await fetch(`https://registry.npmjs.org/${encoded}`);
+  if (!response.ok) throw new Error(`npm metadata failed for ${name}: ${response.status}`);
+  const json = await response.json();
+  const version = json["dist-tags"].latest;
+  const meta = json.versions[version];
+  return {
+    name,
+    version,
+    spec: `${name}@${version}`,
+    repo: normalizeRepoUrl(meta.repository?.url ?? json.repository?.url),
+    gitHead: meta.gitHead,
+    betterResult: meta.dependencies?.["better-result"],
+  };
+}
+
+function checkoutRepo(meta, key) {
+  if (!meta.repo || !meta.repo.includes("github.com")) return undefined;
+  const dir = join(root, `repo-${sanitize(key)}`);
+  const clone = run("git", ["clone", "--filter=blob:none", "--no-checkout", `${meta.repo}.git`, dir], {
+    capture: true,
+  });
+  if (clone.status !== 0) return undefined;
+  const target = meta.gitHead ?? "HEAD";
+  const fetch = run("git", ["fetch", "--depth=1", "origin", target], { cwd: dir, capture: true });
+  if (fetch.status === 0) {
+    const checkout = run("git", ["checkout", target], { cwd: dir, capture: true });
+    if (checkout.status !== 0) return undefined;
+  } else {
+    const checkout = run("git", ["checkout", "HEAD"], { cwd: dir, capture: true });
+    if (checkout.status !== 0) return undefined;
+  }
+  return dir;
+}
+
+function unpackNpm(meta) {
+  const dir = join(root, `npm-${sanitize(meta.name)}`);
+  mkdirSync(dir, { recursive: true });
+  const pack = run("npm", ["pack", meta.spec, "--silent"], { cwd: dir, capture: true });
+  if (pack.status !== 0) throw new Error(`npm pack failed for ${meta.spec}: ${pack.stderr}`);
+  const tgz = pack.stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
+  if (!tgz) throw new Error(`npm pack did not return a tarball for ${meta.spec}`);
+  const tar = run("tar", ["-xzf", tgz], { cwd: dir, capture: true });
+  if (tar.status !== 0) throw new Error(`tar failed for ${meta.spec}: ${tar.stderr}`);
+  return join(dir, "package");
+}
+
+function rgSearch(path) {
+  if (!existsSync(path)) return { count: 0, output: "" };
+  const args = [
+    "-n",
+    "--glob",
+    "!**/node_modules/**",
+    "--glob",
+    "!**/.git/**",
+    "--glob",
+    "!**/dist/**",
+    "--glob",
+    "!**/build/**",
+    regex,
+    path,
+  ];
+  const result = run("rg", args, { capture: true });
+  const output = result.stdout.trim();
+  return { count: output ? output.split(/\r?\n/).length : 0, output };
+}
+
+try {
+  console.log(`Audit dir: ${root}`);
+  console.log(`Regex: ${regex}`);
+
+  const metas = await Promise.all(DEPENDENTS.map(npmMetadata));
+  const checkedRepos = new Map();
+
+  for (const meta of metas) {
+    const repoKey = meta.repo && meta.gitHead ? `${meta.repo}#${meta.gitHead}` : undefined;
+    let sourcePath;
+    let sourceKind;
+
+    if (repoKey && checkedRepos.has(repoKey)) {
+      sourcePath = checkedRepos.get(repoKey);
+      sourceKind = "github-shared";
+    } else {
+      sourcePath = checkoutRepo(meta, repoKey ?? meta.name);
+      if (sourcePath) {
+        sourceKind = "github";
+        if (repoKey) checkedRepos.set(repoKey, sourcePath);
+      } else {
+        sourcePath = unpackNpm(meta);
+        sourceKind = "npm-pack";
+      }
+    }
+
+    const result = rgSearch(sourcePath);
+    console.log("\n---");
+    console.log(`${meta.name}@${meta.version}`);
+    console.log(`better-result: ${meta.betterResult ?? "(not in dependencies?)"}`);
+    console.log(`source: ${sourceKind} ${sourcePath}`);
+    if (meta.repo) console.log(`repo: ${meta.repo}`);
+    if (meta.gitHead) console.log(`gitHead: ${meta.gitHead}`);
+    console.log(`matches: ${result.count}`);
+    if (result.output) console.log(result.output);
+  }
+} finally {
+  if (keep) {
+    console.log(`\nKeeping audit dir because KEEP_DEP_AUDIT=1: ${root}`);
+  } else {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ matchErrorPartial(
 );
 
 // Type guards
-TaggedError.is(value); // any tagged error
+TaggedError.is(value); // any TaggedError instance, including toJSON()
 NotFoundError.is(value); // specific class
 ```
 
@@ -606,6 +606,7 @@ const result = Result.deserialize<User, ValidationError>(serialized);
 | ------------------------ | ---------------------------- |
 | `InferOk<R>`             | Extract Ok type from Result  |
 | `InferErr<R>`            | Extract Err type from Result |
+| `AnyTaggedError`         | Generic TaggedError instance |
 | `SerializedResult<T, E>` | Plain object form of Result  |
 | `SerializedOk<T>`        | Plain object form of Ok      |
 | `SerializedErr<E>`       | Plain object form of Err     |

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -87,8 +87,25 @@ describe("TaggedError", () => {
       expect(isTaggedError(new NotFoundError({ id: "x", message: "not found" }))).toBe(true);
     });
 
+    it("narrows TaggedError to include toJSON", () => {
+      const error: unknown = new NotFoundError({ id: "x", message: "not found" });
+
+      if (isTaggedError(error)) {
+        const json: object = error.toJSON();
+        expect(json).toMatchObject({ _tag: "NotFoundError", id: "x", message: "not found" });
+        return;
+      }
+
+      throw new Error("Expected isTaggedError to narrow TaggedError");
+    });
+
     it("returns false for plain Error", () => {
       expect(isTaggedError(new Error())).toBe(false);
+    });
+
+    it("returns false for Error with _tag but no toJSON", () => {
+      const error = Object.assign(new Error("fake"), { _tag: "FakeError" });
+      expect(isTaggedError(error)).toBe(false);
     });
 
     it("returns false for non-errors", () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -9,12 +9,21 @@ const serializeCause = (cause: unknown): unknown => {
   return cause;
 };
 
-/** Any tagged error (for generic constraints) */
-type AnyTaggedError = Error & { readonly _tag: string };
+/** Tagged error-like value (for generic constraints). */
+type TaggedErrorLike = Error & { readonly _tag: string };
 
-/** Type guard for any tagged error */
+/** Any TaggedError instance. */
+export type AnyTaggedError = TaggedErrorLike & { toJSON(): object };
+
+/** Type guard for any TaggedError instance. */
 const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
-  return value instanceof Error && "_tag" in value && typeof value._tag === "string";
+  return (
+    value instanceof Error &&
+    "_tag" in value &&
+    typeof value._tag === "string" &&
+    "toJSON" in value &&
+    typeof value.toJSON === "function"
+  );
 };
 
 /**
@@ -121,15 +130,15 @@ export type TaggedErrorClass<Tag extends string, Props> = {
 };
 
 /** Handler map for exhaustive matching */
-type MatchHandlers<E extends AnyTaggedError, R> = {
+type MatchHandlers<E extends TaggedErrorLike, R> = {
   [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => R;
 };
 
 /** Partial handler map for non-exhaustive matching */
-type PartialMatchHandlers<E extends AnyTaggedError, R> = Partial<MatchHandlers<E, R>>;
+type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlers<E, R>>;
 
 /** Extract handled tags from a handlers object */
-type HandledTags<E extends AnyTaggedError, H> = Extract<keyof H, E["_tag"]>;
+type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
 
 /**
  * Exhaustive pattern match on tagged error union.
@@ -148,9 +157,9 @@ type HandledTags<E extends AnyTaggedError, H> = Extract<keyof H, E["_tag"]>;
  * }));
  */
 export const matchError: {
-  <E extends AnyTaggedError, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
-  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R;
-} = dual(2, <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlers<E, R>): R => {
+  <E extends TaggedErrorLike, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
+  <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlers<E, R>): R;
+} = dual(2, <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlers<E, R>): R => {
   const handler = handlers[err._tag as E["_tag"]];
   // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
   return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
@@ -166,21 +175,21 @@ export const matchError: {
  */
 export const matchErrorPartial: {
   <
-    E extends AnyTaggedError,
+    E extends TaggedErrorLike,
     R,
     const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
   >(
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): (err: E) => R;
-  <E extends AnyTaggedError, R, const H extends PartialMatchHandlers<E, R>>(
+  <E extends TaggedErrorLike, R, const H extends PartialMatchHandlers<E, R>>(
     err: E,
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): R;
 } = dual(
   3,
-  <E extends AnyTaggedError, R, H extends PartialMatchHandlers<E, R>>(
+  <E extends TaggedErrorLike, R, H extends PartialMatchHandlers<E, R>>(
     err: E,
     handlers: H,
     fallback: (e: Exclude<E, { _tag: HandledTags<E, H> }>) => R,
@@ -200,7 +209,7 @@ export const matchErrorPartial: {
  * Type guard for tagged error instances.
  *
  * @example
- * if (isTaggedError(value)) { value._tag }
+ * if (isTaggedError(value)) { value._tag; value.toJSON(); }
  */
 export const isTaggedError = isAnyTaggedError;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,4 @@ export {
   matchErrorPartial,
   isTaggedError,
 } from "./error";
-export type { TaggedErrorInstance, TaggedErrorClass } from "./error";
+export type { AnyTaggedError, TaggedErrorInstance, TaggedErrorClass } from "./error";


### PR DESCRIPTION
## Summary

- tighten `isTaggedError` / `TaggedError.is` to identify serializable TaggedError instances with callable `toJSON()`
- export `AnyTaggedError` so consumers can name the narrowed generic TaggedError shape
- keep `matchError` / `matchErrorPartial` on a broader internal `_tag` constraint so pattern matching remains flexible
- add coverage that `isTaggedError(error)` narrows to allow `error.toJSON()`

Closes #85

## Validation

- `bun run fmt`
- `bun run check`
- `bun run test`
- `bun run lint`

## Dependent audit

Checked Prisma and Better-T-Stack dependents from npm dependents list:

- `@prisma/compute-sdk@0.19.0` via published npm source
- `@prisma/streams-server@0.1.9` / `@prisma/streams-local@0.1.9` at `prisma/streams@7e36f878`
- `create-better-t-stack@3.30.3` / `@better-t-stack/template-generator@3.30.3` at `AmanVarshney01/create-better-t-stack@1a4a761d`

None use generic `isTaggedError` or `TaggedError.is`; they either use class-specific `.is()` or errors created by `TaggedError(...)`, so this change should not break them.
