### PR TITLE
Add Result.codec for 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,13 @@ new NetworkError({ url: "/api", status: 404 });
 Build Result-level codecs for RPC, storage, or server actions with Standard Schema-compatible serializers/deserializers:
 
 ```ts
-import { Result, ResultDeserializationError, type SerializedResult } from "better-result";
+import {
+  Result,
+  ResultDeserializationError,
+  ResultSerializationError,
+  type SerializedResult,
+  type Result as ResultType,
+} from "better-result";
 
 const UserResultCodec = Result.codec({
   serialize: {
@@ -544,9 +550,13 @@ const UserResultCodec = Result.codec({
 });
 
 const outbound = UserResultCodec.serialize(Result.ok(user));
-// { status: "ok", value: ...wire payload... }
+// Ok({ status: "ok", value: ...wire payload... })
 
-const inbound = UserResultCodec.deserialize(outbound);
+if (Result.isError(outbound) && ResultSerializationError.is(outbound.error)) {
+  console.log("Bad output:", outbound.error.value, outbound.error.issues);
+}
+
+const inbound = outbound.andThen((wire) => UserResultCodec.deserialize(wire));
 // Ok(user)
 
 const invalid = UserResultCodec.deserialize({ foo: "bar" });
@@ -556,7 +566,7 @@ if (Result.isError(invalid) && ResultDeserializationError.is(invalid.error)) {
 
 async function createUser(
   data: FormData,
-): Promise<SerializedResult<UserWire, ValidationErrorWire>> {
+): Promise<ResultType<SerializedResult<UserWire, ValidationErrorWire>, ResultSerializationError>> {
   const result = await validateAndCreate(data);
   return UserResultCodec.serialize(result);
 }

--- a/README.md
+++ b/README.md
@@ -527,41 +527,79 @@ new NetworkError({ url: "/api", status: 404 });
 
 ## Serialization
 
-Build Result-level codecs for RPC, storage, or server actions with Standard Schema-compatible serializers/deserializers:
+Build Result-level codecs for RPC, storage, or server actions with Standard Schema-compatible schemas. This example uses Zod, but any Standard Schema implementation works:
 
 ```ts
+import { z } from "zod";
 import {
   Result,
   ResultDeserializationError,
   ResultSerializationError,
-  type SerializedResult,
   type Result as ResultType,
+  type SerializedResult,
 } from "better-result";
+
+const UserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.date(),
+});
+const UserWireSchema = z.object({
+  id: z.string(),
+  display_name: z.string(),
+  created_at_iso: z.string(),
+});
+const ValidationErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+const ValidationErrorWireSchema = z.object({
+  type: z.string(),
+  message: z.string(),
+});
+type UserWire = z.output<typeof UserWireSchema>;
+type ValidationErrorWire = z.output<typeof ValidationErrorWireSchema>;
 
 const UserResultCodec = Result.codec({
   serialize: {
-    ok: UserToWireSchema,
-    err: ValidationErrorToWireSchema,
+    ok: UserSchema.transform((user) => ({
+      id: user.id,
+      display_name: user.name,
+      created_at_iso: user.createdAt.toISOString(),
+    })),
+    err: ValidationErrorSchema.transform((error) => ({
+      type: error.code,
+      message: error.message,
+    })),
   },
   deserialize: {
-    ok: WireToUserSchema,
-    err: WireToValidationErrorSchema,
+    ok: UserWireSchema.transform((wire) => ({
+      id: wire.id,
+      name: wire.display_name,
+      createdAt: new Date(wire.created_at_iso),
+    })),
+    err: ValidationErrorWireSchema.transform((wire) => ({
+      code: wire.type,
+      message: wire.message,
+    })),
   },
 });
 
-const outbound = UserResultCodec.serialize(Result.ok(user));
-// Ok({ status: "ok", value: ...wire payload... })
+const outbound = await UserResultCodec.serialize(Result.ok(user));
+// Ok({ status: "ok", value: { id, display_name, created_at_iso } })
 
 if (Result.isError(outbound) && ResultSerializationError.is(outbound.error)) {
-  console.log("Bad output:", outbound.error.value, outbound.error.issues);
+  console.log("Bad payload:", outbound.error.value, outbound.error.issues);
 }
 
-const inbound = outbound.andThen((wire) => UserResultCodec.deserialize(wire));
+const inbound = await outbound.andThenAsync(async (wire) => {
+  return await UserResultCodec.deserialize(wire);
+});
 // Ok(user)
 
-const invalid = UserResultCodec.deserialize({ foo: "bar" });
+const invalid = await UserResultCodec.deserialize({ foo: "bar" });
 if (Result.isError(invalid) && ResultDeserializationError.is(invalid.error)) {
-  console.log("Bad input:", invalid.error.value, invalid.error.issues);
+  console.log("Bad envelope or payload:", invalid.error.value, invalid.error.issues);
 }
 
 async function createUser(
@@ -572,24 +610,59 @@ async function createUser(
 }
 ```
 
-### Migrating from `Result.serialize` / `Result.deserialize`
+### Synchronous and asynchronous schemas
 
-`Result.serialize`, `Result.deserialize`, and `Result.hydrate` were removed in 3.0.
-
-Use a codec instead:
+Serialization and deserialization infer their return types independently. Within either direction, the selected `ok` or `err` schema determines whether a concrete branch returns a `Result` or a `Promise<Result>`—no runtime mode configuration is needed.
 
 ```ts
-const LegacyLikeCodec = Result.codec({
-  serialize: {
-    ok: IdentityOkSchema,
-    err: IdentityErrSchema,
-  },
-  deserialize: {
-    ok: IdentityOkSchema,
-    err: IdentityErrSchema,
-  },
-});
+const serializedOk = MixedCodec.serialize(Result.ok(user)); // Result when serialize.ok is sync
+const serializedErr = MixedCodec.serialize(Result.err(error)); // Promise<Result> when serialize.err is async
+
+const deserializedOk = MixedCodec.deserialize({ status: "ok", value: userWire });
+const deserializedErr = MixedCodec.deserialize({ status: "error", error: errorWire });
 ```
+
+When the input's branch is not statically known, mixed schemas honestly return `Result | Promise<Result>`. An `unknown` deserialization input also includes the synchronous `Result` case because an invalid outer envelope fails before a payload schema runs. `await` accepts both forms when callers want one control flow:
+
+```ts
+const decoded = await MixedCodec.deserialize(inputFromNetwork);
+```
+
+Schema validation issues are returned as `ResultSerializationError` or `ResultDeserializationError`. A schema that throws or returns a rejected Promise is a defect: the codec throws or rejects with `Panic` and preserves the original error as `cause`.
+
+### Migrating from `Result.serialize` / `Result.deserialize`
+
+`Result.serialize`, `Result.deserialize`, and `Result.hydrate` were removed in 3.0. The old helpers copied payloads without validating them:
+
+```ts
+// Before 3.0
+const wire = Result.serialize(result); // SerializedResult<User, ValidationError>
+const resultOrNull = Result.deserialize<User, ValidationError>(input); // Result | null
+```
+
+Create a codec once and let its schemas infer the payload types. For already serializable payloads, use the same validating schemas in both directions:
+
+```ts
+// 3.0
+const LegacyLikeCodec = Result.codec({
+  serialize: { ok: UserWireSchema, err: ValidationErrorWireSchema },
+  deserialize: { ok: UserWireSchema, err: ValidationErrorWireSchema },
+});
+
+const wirePayloadResult = Result.ok(userWire);
+const wireResult = await LegacyLikeCodec.serialize(wirePayloadResult);
+// Result<SerializedResult<UserWire, ValidationErrorWire>, ResultSerializationError>
+
+const decoded = await LegacyLikeCodec.deserialize(input);
+// Result<UserWire, ValidationErrorWire | ResultDeserializationError>
+```
+
+Migration differences:
+
+- Handle `ResultSerializationError` instead of assuming serialization always succeeds.
+- Handle `ResultDeserializationError` instead of checking for `null`; its `issues` preserve schema diagnostics when a payload is invalid.
+- Remove explicit `<User, ValidationError>` deserialization type arguments. The schemas provide those types.
+- Use `await` when a schema is async or when a schema library exposes a sync-or-async Standard Schema validator type.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -630,6 +630,8 @@ const decoded = await MixedCodec.deserialize(inputFromNetwork);
 
 Schema validation issues are returned as `ResultSerializationError` or `ResultDeserializationError`. A schema that throws or returns a rejected Promise is a defect: the codec throws or rejects with `Panic` and preserves the original error as `cause`.
 
+JSON transports omit object properties whose value is `undefined`. The codec therefore accepts `{ status: "ok" }` and `{ status: "error" }` as envelopes and passes the missing payload to the selected deserialization schema as `undefined`. A `void` or `undefined` schema can accept it; schemas requiring another payload return `ResultDeserializationError` with their validation issues.
+
 ### Migrating from `Result.serialize` / `Result.deserialize`
 
 `Result.serialize`, `Result.deserialize`, and `Result.hydrate` were removed in 3.0. The old helpers copied payloads without validating them:

--- a/README.md
+++ b/README.md
@@ -527,63 +527,85 @@ new NetworkError({ url: "/api", status: 404 });
 
 ## Serialization
 
-Convert Results to plain objects for RPC, storage, or server actions:
+Build Result-level codecs for RPC, storage, or server actions with Standard Schema-compatible serializers/deserializers:
 
 ```ts
-import { Result, SerializedResult, ResultDeserializationError } from "better-result";
+import { Result, ResultDeserializationError, type SerializedResult } from "better-result";
 
-// Serialize to plain object
-const result = Result.ok(42);
-const serialized = Result.serialize(result);
-// { status: "ok", value: 42 }
+const UserResultCodec = Result.codec({
+  serialize: {
+    ok: UserToWireSchema,
+    err: ValidationErrorToWireSchema,
+  },
+  deserialize: {
+    ok: WireToUserSchema,
+    err: WireToValidationErrorSchema,
+  },
+});
 
-// Deserialize back to Result instance
-const deserialized = Result.deserialize<number, never>(serialized);
-// Ok(42) - can use .map(), .andThen(), etc.
+const outbound = UserResultCodec.serialize(Result.ok(user));
+// { status: "ok", value: ...wire payload... }
 
-// Invalid input returns ResultDeserializationError
-const invalid = Result.deserialize({ foo: "bar" });
+const inbound = UserResultCodec.deserialize(outbound);
+// Ok(user)
+
+const invalid = UserResultCodec.deserialize({ foo: "bar" });
 if (Result.isError(invalid) && ResultDeserializationError.is(invalid.error)) {
-  console.log("Bad input:", invalid.error.value);
+  console.log("Bad input:", invalid.error.value, invalid.error.issues);
 }
 
-// Typed boundary for Next.js server actions
-async function createUser(data: FormData): Promise<SerializedResult<User, ValidationError>> {
+async function createUser(
+  data: FormData,
+): Promise<SerializedResult<UserWire, ValidationErrorWire>> {
   const result = await validateAndCreate(data);
-  return Result.serialize(result);
+  return UserResultCodec.serialize(result);
 }
+```
 
-// Client-side
-const serialized = await createUser(formData);
-const result = Result.deserialize<User, ValidationError>(serialized);
+### Migrating from `Result.serialize` / `Result.deserialize`
+
+`Result.serialize`, `Result.deserialize`, and `Result.hydrate` were removed in 3.0.
+
+Use a codec instead:
+
+```ts
+const LegacyLikeCodec = Result.codec({
+  serialize: {
+    ok: IdentityOkSchema,
+    err: IdentityErrSchema,
+  },
+  deserialize: {
+    ok: IdentityOkSchema,
+    err: IdentityErrSchema,
+  },
+});
 ```
 
 ## API Reference
 
 ### Result
 
-| Method                                  | Description                                                                              |
-| --------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `Result.ok(value)`                      | Create success                                                                           |
-| `Result.err(error)`                     | Create error                                                                             |
-| `Result.try(fn)`                        | Wrap throwing function                                                                   |
-| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                                  |
-| `Result.isOk(result)`                   | Type guard for Ok                                                                        |
-| `Result.isError(result)`                | Type guard for Err                                                                       |
-| `Result.gen(fn)`                        | Generator composition                                                                    |
-| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                     |
-| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                               |
-| `Result.tap(result, fn)`                | Run side effect on success and return original result                                    |
-| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                              |
-| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                      |
-| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                                |
-| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                              |
-| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                        |
-| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                      |
-| `Result.serialize(result)`              | Convert Result to plain object                                                           |
-| `Result.deserialize(value)`             | Rehydrate serialized Result (returns `Err<ResultDeserializationError>` on invalid input) |
-| `Result.partition(results)`             | Split array into [okValues, errValues]                                                   |
-| `Result.flatten(result)`                | Flatten nested Result                                                                    |
+| Method                                  | Description                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------ |
+| `Result.ok(value)`                      | Create success                                                                       |
+| `Result.err(error)`                     | Create error                                                                         |
+| `Result.try(fn)`                        | Wrap throwing function                                                               |
+| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                              |
+| `Result.isOk(result)`                   | Type guard for Ok                                                                    |
+| `Result.isError(result)`                | Type guard for Err                                                                   |
+| `Result.gen(fn)`                        | Generator composition                                                                |
+| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                 |
+| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                           |
+| `Result.tap(result, fn)`                | Run side effect on success and return original result                                |
+| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                          |
+| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                  |
+| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                            |
+| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                          |
+| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                    |
+| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                  |
+| `Result.codec(config)`                  | Build a Result-level codec from Standard Schema-compatible serializers/deserializers |
+| `Result.partition(results)`             | Split array into [okValues, errValues]                                               |
+| `Result.flatten(result)`                | Flatten nested Result                                                                |
 
 ### Instance Methods
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "tryhard",
       "devDependencies": {
         "@types/bun": "latest",
+        "fast-check": "^4.9.0",
         "oxfmt": "^0.23.0",
         "oxlint": "^1.38.0",
         "tsdown": "^0.19.0-beta.5",
@@ -267,6 +268,8 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -304,6 +307,8 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "fast-check": "^4.9.0",
     "oxfmt": "^0.23.0",
     "oxlint": "^1.38.0",
     "tsdown": "^0.19.0-beta.5",

--- a/src/error.ts
+++ b/src/error.ts
@@ -222,11 +222,17 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
   }
 }
 
+/** Shape of issues returned by Standard Schema-compatible validators. */
+export interface ResultDeserializationIssue {
+  readonly message: string;
+  readonly path?: readonly unknown[];
+}
+
 /**
- * Returned when Result.deserialize receives invalid input.
+ * Returned when Result codec deserialization receives invalid input.
  *
  * @example
- * const result = Result.deserialize(invalidData);
+ * const result = UserResultCodec.deserialize(invalidData);
  * if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
  *   console.log("Invalid input:", result.error.value);
  * }
@@ -234,11 +240,13 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
 export class ResultDeserializationError extends TaggedError("ResultDeserializationError")<{
   message: string;
   value: unknown;
+  issues?: readonly ResultDeserializationIssue[];
 }> {
-  constructor(args: { value: unknown }) {
+  constructor(args: { value: unknown; issues?: readonly ResultDeserializationIssue[] }) {
     super({
       message: `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,
       value: args.value,
+      issues: args.issues,
     });
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,6 @@
 import { dual } from "./dual";
 import { err, panic, type Err } from "./core";
+import { type StandardSchemaV1 } from "./standard-schema";
 
 /** Serialize cause for JSON output */
 const serializeCause = (cause: unknown): unknown => {
@@ -222,14 +223,11 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
   }
 }
 
-/** Shape of issues returned by Standard Schema-compatible validators. */
-export interface ResultDeserializationIssue {
-  readonly message: string;
-  readonly path?: readonly unknown[];
-}
+/** A Standard Schema validation issue reported while encoding or decoding a Result payload. */
+export type ResultCodecIssue = StandardSchemaV1.Issue;
 
 /**
- * Returned when Result codec deserialization receives invalid input.
+ * Returned when Result codec deserialization receives an invalid envelope or payload.
  *
  * @example
  * const result = UserResultCodec.deserialize(invalidData);
@@ -240,25 +238,21 @@ export interface ResultDeserializationIssue {
 export class ResultDeserializationError extends TaggedError("ResultDeserializationError")<{
   message: string;
   value: unknown;
-  issues?: readonly ResultDeserializationIssue[];
+  issues?: ReadonlyArray<ResultCodecIssue>;
 }> {
-  constructor(args: { value: unknown; issues?: readonly ResultDeserializationIssue[] }) {
+  constructor(args: { value: unknown; issues?: ReadonlyArray<ResultCodecIssue> }) {
     super({
-      message: `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,
+      message: args.issues
+        ? "Failed to deserialize Result payload"
+        : `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,
       value: args.value,
       issues: args.issues,
     });
   }
 }
 
-/** Shape of issues returned by Standard Schema-compatible serializers. */
-export interface ResultSerializationIssue {
-  readonly message: string;
-  readonly path?: readonly unknown[];
-}
-
 /**
- * Returned when Result codec serialization receives invalid input.
+ * Returned when a Result codec cannot serialize an Ok or Err payload.
  *
  * @example
  * const result = UserResultCodec.serialize(Result.ok(value));
@@ -269,11 +263,11 @@ export interface ResultSerializationIssue {
 export class ResultSerializationError extends TaggedError("ResultSerializationError")<{
   message: string;
   value: unknown;
-  issues?: readonly ResultSerializationIssue[];
-}>() {
-  constructor(args: { value: unknown; issues?: readonly ResultSerializationIssue[] }) {
+  issues?: ReadonlyArray<ResultCodecIssue>;
+}> {
+  constructor(args: { value: unknown; issues?: ReadonlyArray<ResultCodecIssue> }) {
     super({
-      message: "Failed to serialize Result value",
+      message: "Failed to serialize Result payload",
       value: args.value,
       issues: args.issues,
     });

--- a/src/error.ts
+++ b/src/error.ts
@@ -251,4 +251,33 @@ export class ResultDeserializationError extends TaggedError("ResultDeserializati
   }
 }
 
+/** Shape of issues returned by Standard Schema-compatible serializers. */
+export interface ResultSerializationIssue {
+  readonly message: string;
+  readonly path?: readonly unknown[];
+}
+
+/**
+ * Returned when Result codec serialization receives invalid input.
+ *
+ * @example
+ * const result = UserResultCodec.serialize(Result.ok(value));
+ * if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+ *   console.log("Invalid output:", result.error.value);
+ * }
+ */
+export class ResultSerializationError extends TaggedError("ResultSerializationError")<{
+  message: string;
+  value: unknown;
+  issues?: readonly ResultSerializationIssue[];
+}>() {
+  constructor(args: { value: unknown; issues?: readonly ResultSerializationIssue[] }) {
+    super({
+      message: "Failed to serialize Result value",
+      value: args.value,
+      issues: args.issues,
+    });
+  }
+}
+
 export { Panic, isPanic, panic } from "./core";

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ export {
 } from "./error";
 export type {
   AnyTaggedError,
-  ResultDeserializationIssue,
-  ResultSerializationIssue,
+  ResultCodecIssue,
   TaggedErrorInstance,
   TaggedErrorClass,
 } from "./error";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,17 @@ export { Result, Ok, Err } from "./result";
 export type {
   InferOk,
   InferErr,
+  ResultCodec,
+  ResultCodecConfig,
   SerializedResult,
   SerializedOk,
   SerializedErr,
+  StandardSchemaInput,
+  StandardSchemaIssue,
+  StandardSchemaOutput,
+  StandardSchemaPathSegment,
+  StandardSchemaResult,
+  StandardSchemaV1,
   TryContext,
   TryPromiseContext,
 } from "./result";
@@ -19,4 +27,9 @@ export {
   matchErrorPartial,
   isTaggedError,
 } from "./error";
-export type { AnyTaggedError, TaggedErrorInstance, TaggedErrorClass } from "./error";
+export type {
+  AnyTaggedError,
+  ResultDeserializationIssue,
+  TaggedErrorInstance,
+  TaggedErrorClass,
+} from "./error";

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
   TaggedError,
   UnhandledException,
   ResultDeserializationError,
+  ResultSerializationError,
   matchError,
   matchErrorPartial,
   isTaggedError,
@@ -30,6 +31,7 @@ export {
 export type {
   AnyTaggedError,
   ResultDeserializationIssue,
+  ResultSerializationIssue,
   TaggedErrorInstance,
   TaggedErrorClass,
 } from "./error";

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,3 +1,4 @@
+import fc from "fast-check";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   Result,
@@ -2140,6 +2141,7 @@ describe("Result", () => {
       const result = RejectingOkCodec.serialize(Result.ok({ createdAt: "nope" }));
       expect(Result.isError(result)).toBe(true);
       if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to serialize Result payload");
         expect(result.error.value).toEqual({ createdAt: "nope" });
         expect(result.error.issues).toEqual([
           { message: "Expected serializable user", path: ["createdAt"] },
@@ -2206,6 +2208,9 @@ describe("Result", () => {
       const result = UserResultCodec.deserialize({ foo: "bar" });
       expect(Result.isError(result)).toBe(true);
       if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe(
+          'Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }',
+        );
         expect(result.error.value).toEqual({ foo: "bar" });
       }
     });
@@ -2217,6 +2222,7 @@ describe("Result", () => {
       });
       expect(Result.isError(result)).toBe(true);
       if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to deserialize Result payload");
         expect(result.error.issues).toEqual([
           { message: "Expected string", path: ["display_name"] },
         ]);
@@ -2254,6 +2260,41 @@ describe("Result", () => {
         name: "Ada",
         createdAt: new Date("2026-05-28T12:00:00.000Z"),
       });
+    });
+
+    it("roundtrips arbitrary Ok and Err payloads through JSON", () => {
+      fc.assert(
+        fc.property(
+          fc.record({
+            id: fc.string(),
+            name: fc.string(),
+            createdAt: fc.date({ noInvalidDate: true }),
+          }),
+          (user) => {
+            const serialized = UserResultCodec.serialize(Result.ok(user)).unwrap();
+            const deserialized = UserResultCodec.deserialize(
+              JSON.parse(JSON.stringify(serialized)),
+            );
+            expect(deserialized).toEqual(Result.ok(user));
+          },
+        ),
+      );
+      fc.assert(
+        fc.property(
+          fc.record({
+            code: fc.constantFrom("NOT_FOUND" as const, "BAD_INPUT" as const),
+            message: fc.string(),
+            retryable: fc.boolean(),
+          }),
+          (appError) => {
+            const serialized = UserResultCodec.serialize(Result.err(appError)).unwrap();
+            const deserialized = UserResultCodec.deserialize(
+              JSON.parse(JSON.stringify(serialized)),
+            );
+            expect(deserialized).toEqual(Result.err(appError));
+          },
+        ),
+      );
     });
 
     it("supports async Standard Schema validators and infers Promise return types", async () => {
@@ -2311,6 +2352,181 @@ describe("Result", () => {
       await expect(deserialized).resolves.toBeInstanceOf(Ok);
     });
 
+    it("infers serialization and deserialization async behavior independently", async () => {
+      const SyncSerializeAsyncDeserializeCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<string>("sync-ok-serializer"),
+          err: identitySchema<number>("sync-err-serializer"),
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, string>("async-ok-deserializer", async (value) => ({
+            value: String(value),
+          })),
+          err: makeAsyncSchema<unknown, number>("async-err-deserializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+      });
+      const AsyncSerializeSyncDeserializeCodec = Result.codec({
+        serialize: {
+          ok: makeAsyncSchema<string, string>("async-ok-serializer", async (value) => ({
+            value: String(value),
+          })),
+          err: makeAsyncSchema<number, number>("async-err-serializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+        deserialize: {
+          ok: identitySchema<string>("sync-ok-deserializer"),
+          err: identitySchema<number>("sync-err-deserializer"),
+        },
+      });
+
+      const syncSerialized = SyncSerializeAsyncDeserializeCodec.serialize(Result.ok("value"));
+      const asyncDeserialized = SyncSerializeAsyncDeserializeCodec.deserialize({
+        status: "ok",
+        value: "value",
+      });
+      const asyncSerialized = AsyncSerializeSyncDeserializeCodec.serialize(Result.err(42));
+      const syncDeserialized = AsyncSerializeSyncDeserializeCodec.deserialize({
+        status: "error",
+        error: 42,
+      });
+
+      expectTypeOf(syncSerialized).toEqualTypeOf<
+        ResultType<SerializedResult<string, number>, ResultSerializationError>
+      >();
+      expectTypeOf(asyncDeserialized).toEqualTypeOf<
+        Promise<ResultType<string, number | ResultDeserializationError>>
+      >();
+      expectTypeOf(asyncSerialized).toEqualTypeOf<
+        Promise<ResultType<SerializedResult<string, number>, ResultSerializationError>>
+      >();
+      expectTypeOf(syncDeserialized).toEqualTypeOf<
+        ResultType<string, number | ResultDeserializationError>
+      >();
+      expect(syncSerialized).toEqual(Result.ok({ status: "ok", value: "value" }));
+      await expect(asyncDeserialized).resolves.toEqual(Result.ok("value"));
+      await expect(asyncSerialized).resolves.toEqual(Result.ok({ status: "error", error: 42 }));
+      expect(syncDeserialized).toEqual(Result.err(42));
+    });
+
+    it("infers mixed Result branches without runtime mode configuration", async () => {
+      const MixedBranchCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<string>("sync-ok-serializer"),
+          err: makeAsyncSchema<number, number>("async-err-serializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+        deserialize: {
+          ok: identitySchema<string>("sync-ok-deserializer"),
+          err: makeAsyncSchema<unknown, number>("async-err-deserializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+      });
+      const getResult = (): ResultType<string, number> => Result.ok("value");
+      const unknownEnvelope: unknown = { status: "error", error: 42 };
+
+      const serializedOk = MixedBranchCodec.serialize(Result.ok("value"));
+      const serializedErr = MixedBranchCodec.serialize(Result.err(42));
+      const serializedUnknownBranch = MixedBranchCodec.serialize(getResult());
+      const deserializedOk = MixedBranchCodec.deserialize({ status: "ok", value: "value" });
+      const deserializedErr = MixedBranchCodec.deserialize({ status: "error", error: 42 });
+      const deserializedUnknownEnvelope = MixedBranchCodec.deserialize(unknownEnvelope);
+
+      type Serialized = ResultType<SerializedResult<string, number>, ResultSerializationError>;
+      type Deserialized = ResultType<string, number | ResultDeserializationError>;
+      expectTypeOf(serializedOk).toEqualTypeOf<Serialized>();
+      expectTypeOf(serializedErr).toEqualTypeOf<Promise<Serialized>>();
+      expectTypeOf(serializedUnknownBranch).toEqualTypeOf<Serialized | Promise<Serialized>>();
+      expectTypeOf(deserializedOk).toEqualTypeOf<Deserialized>();
+      expectTypeOf(deserializedErr).toEqualTypeOf<Promise<Deserialized>>();
+      expectTypeOf(deserializedUnknownEnvelope).toEqualTypeOf<
+        Deserialized | Promise<Deserialized>
+      >();
+      expect(serializedOk).toEqual(Result.ok({ status: "ok", value: "value" }));
+      await expect(serializedErr).resolves.toEqual(Result.ok({ status: "error", error: 42 }));
+      expect(deserializedOk).toEqual(Result.ok("value"));
+      await expect(deserializedErr).resolves.toEqual(Result.err(42));
+      await expect(deserializedUnknownEnvelope).resolves.toEqual(Result.err(42));
+    });
+
+    it("returns a synchronous envelope error even when payload schemas are async", () => {
+      const AsyncCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<string>("sync-ok-serializer"),
+          err: identitySchema<number>("sync-err-serializer"),
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, string>("async-ok-deserializer", async (value) => ({
+            value: String(value),
+          })),
+          err: makeAsyncSchema<unknown, number>("async-err-deserializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+      });
+      const invalidEnvelope: unknown = { nope: true };
+
+      const result = AsyncCodec.deserialize(invalidEnvelope);
+
+      expectTypeOf(result).toEqualTypeOf<
+        | ResultType<string, number | ResultDeserializationError>
+        | Promise<ResultType<string, number | ResultDeserializationError>>
+      >();
+      expect(result).toBeInstanceOf(Err);
+    });
+
+    it("panics when an async serialization schema rejects", async () => {
+      const cause = new Error("async serialization failed");
+      const RejectingSerializationCodec = Result.codec({
+        serialize: {
+          ok: makeAsyncSchema<unknown, unknown>("rejecting-serializer", async () => {
+            throw cause;
+          }),
+          err: identitySchema<never>("identity-error-serializer"),
+        },
+        deserialize: {
+          ok: identitySchema<unknown>("identity-ok-deserializer"),
+          err: identitySchema<never>("identity-error-deserializer"),
+        },
+      });
+
+      await expect(RejectingSerializationCodec.serialize(Result.ok("value"))).rejects.toMatchObject(
+        {
+          _tag: "Panic",
+          message: "Result.codec serialize schema threw",
+          cause,
+        },
+      );
+    });
+
+    it("panics when an async deserialization schema rejects", async () => {
+      const cause = new Error("async deserialization failed");
+      const RejectingDeserializationCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<unknown>("identity-ok-serializer"),
+          err: identitySchema<never>("identity-error-serializer"),
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, unknown>("rejecting-deserializer", async () => {
+            throw cause;
+          }),
+          err: identitySchema<never>("identity-error-deserializer"),
+        },
+      });
+
+      await expect(
+        RejectingDeserializationCodec.deserialize({ status: "ok", value: "value" }),
+      ).rejects.toMatchObject({
+        _tag: "Panic",
+        message: "Result.codec deserialize schema threw",
+        cause,
+      });
+    });
+
     it("preserves strong type inference for serialize and deserialize", () => {
       const outbound = UserResultCodec.serialize(
         Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
@@ -2326,6 +2542,12 @@ describe("Result", () => {
       expectTypeOf(inbound).toEqualTypeOf<
         ResultType<User, AppError | ResultDeserializationError>
       >();
+
+      const serializeInvalidUser = (): void => {
+        // @ts-expect-error -- The Ok serializer requires the complete User input type.
+        UserResultCodec.serialize(Result.ok({ id: "missing-name-and-date" }));
+      };
+      expectTypeOf(serializeInvalidUser).toEqualTypeOf<() => void>();
     });
   });
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { Result, Ok, Err, type TryContext, type TryPromiseContext } from "./result";
+import {
+  Result,
+  Ok,
+  Err,
+  type Result as ResultType,
+  type SerializedResult,
+  type StandardSchemaResult,
+  type StandardSchemaV1,
+  type TryContext,
+  type TryPromiseContext,
+} from "./result";
 import { Panic, ResultDeserializationError, UnhandledException } from "./error";
 
 const longConstantRetryConfig = {
@@ -14,6 +24,52 @@ const createDeferred = () => {
     resolve = resolvePromise;
   });
   return { promise, resolve } as const;
+};
+
+type SchemaResult<T> = StandardSchemaResult<T>;
+type SyncSchema<Input, Output> = StandardSchemaV1<Input, Output> & {
+  readonly "~standard": StandardSchemaV1.Props<Input, Output> & {
+    readonly validate: (value: unknown) => SchemaResult<Output>;
+  };
+};
+type AsyncSchema<Input, Output> = StandardSchemaV1<Input, Output> & {
+  readonly "~standard": StandardSchemaV1.Props<Input, Output> & {
+    readonly validate: (value: unknown) => Promise<SchemaResult<Output>>;
+  };
+};
+
+const makeSchema = <Input, Output>(
+  vendor: string,
+  validate: (value: unknown) => SchemaResult<Output>,
+): SyncSchema<Input, Output> => ({
+  "~standard": {
+    version: 1,
+    vendor,
+    types: undefined as unknown as {
+      input: Input;
+      output: Output;
+    },
+    validate,
+  },
+});
+
+const makeAsyncSchema = <Input, Output>(
+  vendor: string,
+  validate: (value: unknown) => Promise<SchemaResult<Output>>,
+): AsyncSchema<Input, Output> => ({
+  "~standard": {
+    version: 1,
+    vendor,
+    types: undefined as unknown as {
+      input: Input;
+      output: Output;
+    },
+    validate,
+  },
+});
+
+const identitySchema = <T>(vendor: string): SyncSchema<T, T> => {
+  return makeSchema<T, T>(vendor, (value) => ({ value: value as T }));
 };
 
 describe("Result", () => {
@@ -81,8 +137,15 @@ describe("Result", () => {
       expect(matched).toBe("matched");
     });
 
-    it("Ok<void> serializes correctly", () => {
-      expect(Result.serialize(Result.ok())).toEqual({ status: "ok", value: undefined });
+    it("Ok<void> serializes correctly through a codec", () => {
+      const VoidCodec = Result.codec({
+        serialize: { ok: identitySchema<void>("void-ok"), err: identitySchema<never>("void-err") },
+        deserialize: {
+          ok: identitySchema<void>("void-ok-in"),
+          err: identitySchema<never>("void-err-in"),
+        },
+      });
+      expect(VoidCodec.serialize(Result.ok())).toEqual({ status: "ok", value: undefined });
     });
   });
 
@@ -1909,138 +1972,303 @@ describe("Result", () => {
     });
   });
 
-  describe("serialize", () => {
-    it("serializes Ok to plain object", () => {
-      const result = Result.ok(42);
-      const serialized = Result.serialize(result);
-      expect(serialized).toEqual({ status: "ok", value: 42 });
+  describe("codec", () => {
+    type User = {
+      id: string;
+      name: string;
+      createdAt: Date;
+    };
+
+    type UserWire = {
+      id: string;
+      display_name: string;
+      created_at_iso: string;
+    };
+
+    type AppError = {
+      code: "NOT_FOUND" | "BAD_INPUT";
+      message: string;
+      retryable: boolean;
+    };
+
+    type AppErrorWire = {
+      type: AppError["code"];
+      message: string;
+      retryable: boolean;
+    };
+
+    const userToWire = makeSchema<User, UserWire>("user-to-wire", (value) => {
+      const user = value as User;
+      return {
+        value: {
+          id: user.id,
+          display_name: user.name,
+          created_at_iso: user.createdAt.toISOString(),
+        },
+      };
     });
 
-    it("serializes Err to plain object", () => {
-      const result = Result.err("fail");
-      const serialized = Result.serialize(result);
-      expect(serialized).toEqual({ status: "error", error: "fail" });
+    const errorToWire = makeSchema<AppError, AppErrorWire>("error-to-wire", (value) => {
+      const error = value as AppError;
+      return {
+        value: {
+          type: error.code,
+          message: error.message,
+          retryable: error.retryable,
+        },
+      };
     });
 
-    it("serializes complex values", () => {
-      const result = Result.ok({ id: 1, name: "test", nested: { a: [1, 2, 3] } });
-      const serialized = Result.serialize(result);
+    const wireToUser = makeSchema<unknown, User>("wire-to-user", (value) => {
+      if (value === null || typeof value !== "object") {
+        return { issues: [{ message: "Expected object" }] };
+      }
+
+      const input = value as Record<string, unknown>;
+      if (
+        typeof input.id !== "string" ||
+        typeof input.display_name !== "string" ||
+        typeof input.created_at_iso !== "string"
+      ) {
+        return {
+          issues: [
+            ...(typeof input.id !== "string" ? [{ message: "Expected string", path: ["id"] }] : []),
+            ...(typeof input.display_name !== "string"
+              ? [{ message: "Expected string", path: ["display_name"] }]
+              : []),
+            ...(typeof input.created_at_iso !== "string"
+              ? [{ message: "Expected string", path: ["created_at_iso"] }]
+              : []),
+          ],
+        };
+      }
+
+      const createdAt = new Date(input.created_at_iso);
+      if (Number.isNaN(createdAt.getTime())) {
+        return { issues: [{ message: "Expected valid ISO timestamp", path: ["created_at_iso"] }] };
+      }
+
+      return {
+        value: {
+          id: input.id,
+          name: input.display_name,
+          createdAt,
+        },
+      };
+    });
+
+    const wireToError = makeSchema<unknown, AppError>("wire-to-error", (value) => {
+      if (value === null || typeof value !== "object") {
+        return { issues: [{ message: "Expected object" }] };
+      }
+
+      const input = value as Record<string, unknown>;
+      const code = input.type;
+      const validCode = code === "NOT_FOUND" || code === "BAD_INPUT";
+      if (!validCode || typeof input.message !== "string" || typeof input.retryable !== "boolean") {
+        return {
+          issues: [
+            ...(!validCode
+              ? [{ message: 'Expected "NOT_FOUND" | "BAD_INPUT"', path: ["type"] }]
+              : []),
+            ...(typeof input.message !== "string"
+              ? [{ message: "Expected string", path: ["message"] }]
+              : []),
+            ...(typeof input.retryable !== "boolean"
+              ? [{ message: "Expected boolean", path: ["retryable"] }]
+              : []),
+          ],
+        };
+      }
+
+      return {
+        value: {
+          code,
+          message: input.message,
+          retryable: input.retryable,
+        },
+      };
+    });
+
+    const UserResultCodec = Result.codec({
+      serialize: { ok: userToWire, err: errorToWire },
+      deserialize: { ok: wireToUser, err: wireToError },
+    });
+
+    it("serializes Ok with outbound schema", () => {
+      const serialized = UserResultCodec.serialize(
+        Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
+      );
       expect(serialized).toEqual({
         status: "ok",
-        value: { id: 1, name: "test", nested: { a: [1, 2, 3] } },
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
       });
     });
 
-    it("serializes null and undefined values", () => {
-      expect(Result.serialize(Result.ok(null))).toEqual({ status: "ok", value: null });
-      expect(Result.serialize(Result.ok(undefined))).toEqual({ status: "ok", value: undefined });
+    it("serializes Err with outbound schema", () => {
+      const serialized = UserResultCodec.serialize(
+        Result.err({ code: "NOT_FOUND", message: "missing", retryable: false }),
+      );
+      expect(serialized).toEqual({
+        status: "error",
+        error: { type: "NOT_FOUND", message: "missing", retryable: false },
+      });
     });
-  });
 
-  describe("deserialize", () => {
-    it("deserializes Ok object to Ok instance", () => {
-      const serialized = { status: "ok" as const, value: 42 };
-      const result = Result.deserialize<number, string>(serialized);
-      expect(Result.isOk(result)).toBe(true);
+    it("deserializes Ok payload with inbound schema", () => {
+      const result = UserResultCodec.deserialize({
+        status: "ok",
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
+      });
+
       expect(result).toBeInstanceOf(Ok);
-      expect(result.unwrap()).toBe(42);
+      expect(result.unwrap()).toEqual({
+        id: "1",
+        name: "Ada",
+        createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      });
     });
 
-    it("deserializes Err object to Err instance", () => {
-      const serialized = { status: "error" as const, error: "fail" };
-      const result = Result.deserialize<number, string>(serialized);
-      expect(Result.isError(result)).toBe(true);
+    it("deserializes Err payload with inbound schema", () => {
+      const result = UserResultCodec.deserialize({
+        status: "error",
+        error: {
+          type: "BAD_INPUT",
+          message: "bad email",
+          retryable: false,
+        },
+      });
+
       expect(result).toBeInstanceOf(Err);
       if (Result.isError(result)) {
-        expect(result.error).toBe("fail");
+        expect(result.error).toEqual({ code: "BAD_INPUT", message: "bad email", retryable: false });
       }
     });
 
-    it("returns ResultDeserializationError for non-Result objects", () => {
-      const testCases = [
-        { foo: "bar" },
-        null,
-        42,
-        { status: "ok" }, // missing value
-        { status: "error" }, // missing error
-      ];
-
-      for (const input of testCases) {
-        const result = Result.deserialize(input);
-        expect(Result.isError(result)).toBe(true);
-        if (Result.isError(result)) {
-          expect(result.error).toBeInstanceOf(ResultDeserializationError);
-          expect((result.error as ResultDeserializationError).value).toBe(input);
-        }
+    it("returns ResultDeserializationError for invalid outer shape", () => {
+      const result = UserResultCodec.deserialize({ foo: "bar" });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.value).toEqual({ foo: "bar" });
       }
     });
 
-    it("deserializes complex values", () => {
-      const serialized = { status: "ok" as const, value: { id: 1, items: [1, 2] } };
-      const result = Result.deserialize<{ id: number; items: number[] }, string>(serialized);
-      expect(result.unwrap()).toEqual({ id: 1, items: [1, 2] });
-    });
-  });
-
-  describe("serialize/deserialize roundtrip", () => {
-    it("roundtrips Ok", () => {
-      const original = Result.ok({ id: 42, name: "test" });
-      const serialized = Result.serialize(original);
-      const deserialized = Result.deserialize<{ id: number; name: string }, never>(serialized);
-
-      expect(deserialized).toBeInstanceOf(Ok);
-      expect(deserialized.unwrap()).toEqual({ id: 42, name: "test" });
-    });
-
-    it("roundtrips Err", () => {
-      const original = Result.err({ code: "NOT_FOUND", message: "User not found" });
-      const serialized = Result.serialize(original);
-      const deserialized = Result.deserialize<never, { code: string; message: string }>(serialized);
-
-      expect(deserialized).toBeInstanceOf(Err);
-      if (Result.isError(deserialized)) {
-        expect(deserialized.error).toEqual({ code: "NOT_FOUND", message: "User not found" });
+    it("returns ResultDeserializationError with ok payload issues", () => {
+      const result = UserResultCodec.deserialize({
+        status: "ok",
+        value: { id: "1", display_name: 42, created_at_iso: "nope" },
+      });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.issues).toEqual([
+          { message: "Expected string", path: ["display_name"] },
+        ]);
       }
     });
 
-    it("roundtrips through JSON.stringify/parse", () => {
-      const original = Result.ok({ id: 1, data: [1, 2, 3] });
-      const json = JSON.stringify(Result.serialize(original));
+    it("returns ResultDeserializationError with err payload issues", () => {
+      const result = UserResultCodec.deserialize({
+        status: "error",
+        error: { type: "NOPE", message: 123, retryable: "sometimes" },
+      });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.issues).toEqual([
+          { message: 'Expected "NOT_FOUND" | "BAD_INPUT"', path: ["type"] },
+          { message: "Expected string", path: ["message"] },
+          { message: "Expected boolean", path: ["retryable"] },
+        ]);
+      }
+    });
+
+    it("roundtrips through JSON stringify/parse", () => {
+      const original = Result.ok({
+        id: "1",
+        name: "Ada",
+        createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      });
+      const json = JSON.stringify(UserResultCodec.serialize(original));
       const parsed = JSON.parse(json);
-      const deserialized = Result.deserialize<{ id: number; data: number[] }, never>(parsed);
+      const deserialized = UserResultCodec.deserialize(parsed);
 
-      expect(deserialized?.unwrap()).toEqual({ id: 1, data: [1, 2, 3] });
-    });
-  });
-
-  describe("hydrate (deprecated)", () => {
-    it("hydrates serialized Ok", () => {
-      const serialized = { status: "ok" as const, value: 42 };
-      const result = Result.hydrate<number, string>(serialized);
-      expect(Result.isOk(result)).toBe(true);
-      expect(result).toBeInstanceOf(Ok);
-      expect(result.unwrap()).toBe(42);
+      expect(deserialized.unwrap()).toEqual({
+        id: "1",
+        name: "Ada",
+        createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      });
     });
 
-    it("hydrates serialized Err", () => {
-      const serialized = { status: "error" as const, error: "fail" };
-      const result = Result.hydrate<number, string>(serialized);
-      expect(Result.isError(result)).toBe(true);
-      expect(result).toBeInstanceOf(Err);
-      if (Result.isError(result)) {
-        expect(result.error).toBe("fail");
-      }
+    it("supports async Standard Schema validators and infers Promise return types", async () => {
+      const AsyncUserResultCodec = Result.codec({
+        serialize: {
+          ok: makeAsyncSchema<User, UserWire>("async-user-to-wire", async (value) => {
+            const user = value as User;
+            return {
+              value: {
+                id: user.id,
+                display_name: user.name,
+                created_at_iso: user.createdAt.toISOString(),
+              },
+            };
+          }),
+          err: errorToWire,
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, User>("async-wire-to-user", async (value) => {
+            return wireToUser["~standard"].validate(value);
+          }),
+          err: wireToError,
+        },
+      });
+
+      const serialized = AsyncUserResultCodec.serialize(
+        Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
+      );
+      const deserialized = AsyncUserResultCodec.deserialize({
+        status: "ok",
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
+      });
+
+      expectTypeOf(serialized).toEqualTypeOf<Promise<SerializedResult<UserWire, AppErrorWire>>>();
+      expectTypeOf(deserialized).toEqualTypeOf<
+        Promise<ResultType<User, AppError | ResultDeserializationError>>
+      >();
+      await expect(serialized).resolves.toEqual({
+        status: "ok",
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
+      });
+      await expect(deserialized).resolves.toBeInstanceOf(Ok);
     });
 
-    it("returns ResultDeserializationError for non-Result objects", () => {
-      const testCases = [{ foo: "bar" }, null, 42];
-      for (const input of testCases) {
-        const result = Result.hydrate(input);
-        expect(Result.isError(result)).toBe(true);
-        if (Result.isError(result)) {
-          expect(result.error).toBeInstanceOf(ResultDeserializationError);
-        }
-      }
+    it("preserves strong type inference for serialize and deserialize", () => {
+      const outbound = UserResultCodec.serialize(
+        Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
+      );
+      const inbound = UserResultCodec.deserialize({
+        status: "error",
+        error: { type: "NOT_FOUND", message: "missing", retryable: false },
+      });
+
+      expectTypeOf(outbound).toEqualTypeOf<SerializedResult<UserWire, AppErrorWire>>();
+      expectTypeOf(inbound).toEqualTypeOf<
+        ResultType<User, AppError | ResultDeserializationError>
+      >();
     });
   });
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -143,7 +143,7 @@ describe("Result", () => {
       expect(matched).toBe("matched");
     });
 
-    it("Ok<void> serializes correctly through a codec", () => {
+    it("Ok<void> roundtrips through a JSON transport with a codec", () => {
       const VoidCodec = Result.codec({
         serialize: { ok: identitySchema<void>("void-ok"), err: identitySchema<never>("void-err") },
         deserialize: {
@@ -151,7 +151,13 @@ describe("Result", () => {
           err: identitySchema<never>("void-err-in"),
         },
       });
-      expect(VoidCodec.serialize(Result.ok()).unwrap()).toEqual({ status: "ok", value: undefined });
+      const serialized = VoidCodec.serialize(Result.ok()).unwrap();
+      const json = JSON.stringify(serialized);
+      const received: unknown = JSON.parse(json);
+
+      expect(serialized).toEqual({ status: "ok", value: undefined });
+      expect(json).toBe('{"status":"ok"}');
+      expect(VoidCodec.deserialize(received)).toEqual(Result.ok());
     });
   });
 
@@ -167,6 +173,26 @@ describe("Result", () => {
       const error = new Error("oops");
       const result = Result.err(error);
       expect(result.error).toBe(error);
+    });
+
+    it("Err<undefined> roundtrips through a JSON transport with a codec", () => {
+      const UndefinedErrorCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<never>("never-ok"),
+          err: identitySchema<undefined>("undefined-err"),
+        },
+        deserialize: {
+          ok: identitySchema<never>("never-ok-in"),
+          err: identitySchema<undefined>("undefined-err-in"),
+        },
+      });
+      const serialized = UndefinedErrorCodec.serialize(Result.err(undefined)).unwrap();
+      const json = JSON.stringify(serialized);
+      const received: unknown = JSON.parse(json);
+
+      expect(serialized).toEqual({ status: "error", error: undefined });
+      expect(json).toBe('{"status":"error"}');
+      expect(UndefinedErrorCodec.deserialize(received)).toEqual(Result.err(undefined));
     });
   });
 
@@ -2212,6 +2238,28 @@ describe("Result", () => {
           'Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }',
         );
         expect(result.error.value).toEqual({ foo: "bar" });
+      }
+    });
+
+    it("passes a missing Ok payload to its schema as undefined", () => {
+      const result = UserResultCodec.deserialize({ status: "ok" });
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to deserialize Result payload");
+        expect(result.error.value).toBe(undefined);
+        expect(result.error.issues).toEqual([{ message: "Expected object" }]);
+      }
+    });
+
+    it("passes a missing Err payload to its schema as undefined", () => {
+      const result = UserResultCodec.deserialize({ status: "error" });
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to deserialize Result payload");
+        expect(result.error.value).toBe(undefined);
+        expect(result.error.issues).toEqual([{ message: "Expected object" }]);
       }
     });
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -10,7 +10,12 @@ import {
   type TryContext,
   type TryPromiseContext,
 } from "./result";
-import { Panic, ResultDeserializationError, UnhandledException } from "./error";
+import {
+  Panic,
+  ResultDeserializationError,
+  ResultSerializationError,
+  UnhandledException,
+} from "./error";
 
 const longConstantRetryConfig = {
   times: 3,
@@ -145,7 +150,7 @@ describe("Result", () => {
           err: identitySchema<never>("void-err-in"),
         },
       });
-      expect(VoidCodec.serialize(Result.ok())).toEqual({ status: "ok", value: undefined });
+      expect(VoidCodec.serialize(Result.ok()).unwrap()).toEqual({ status: "ok", value: undefined });
     });
   });
 
@@ -2099,7 +2104,8 @@ describe("Result", () => {
       const serialized = UserResultCodec.serialize(
         Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
       );
-      expect(serialized).toEqual({
+      expect(serialized).toBeInstanceOf(Ok);
+      expect(serialized.unwrap()).toEqual({
         status: "ok",
         value: {
           id: "1",
@@ -2113,10 +2119,53 @@ describe("Result", () => {
       const serialized = UserResultCodec.serialize(
         Result.err({ code: "NOT_FOUND", message: "missing", retryable: false }),
       );
-      expect(serialized).toEqual({
+      expect(serialized).toBeInstanceOf(Ok);
+      expect(serialized.unwrap()).toEqual({
         status: "error",
         error: { type: "NOT_FOUND", message: "missing", retryable: false },
       });
+    });
+
+    it("returns ResultSerializationError with ok payload issues", () => {
+      const RejectingOkCodec = Result.codec({
+        serialize: {
+          ok: makeSchema<unknown, UserWire>("reject-ok-to-wire", () => ({
+            issues: [{ message: "Expected serializable user", path: ["createdAt"] }],
+          })),
+          err: errorToWire,
+        },
+        deserialize: { ok: wireToUser, err: wireToError },
+      });
+
+      const result = RejectingOkCodec.serialize(Result.ok({ createdAt: "nope" }));
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+        expect(result.error.value).toEqual({ createdAt: "nope" });
+        expect(result.error.issues).toEqual([
+          { message: "Expected serializable user", path: ["createdAt"] },
+        ]);
+      }
+    });
+
+    it("returns ResultSerializationError with err payload issues", () => {
+      const RejectingErrCodec = Result.codec({
+        serialize: {
+          ok: userToWire,
+          err: makeSchema<unknown, AppErrorWire>("reject-error-to-wire", () => ({
+            issues: [{ message: "Expected serializable app error", path: ["code"] }],
+          })),
+        },
+        deserialize: { ok: wireToUser, err: wireToError },
+      });
+
+      const result = RejectingErrCodec.serialize(Result.err({ code: "NOPE" }));
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+        expect(result.error.value).toEqual({ code: "NOPE" });
+        expect(result.error.issues).toEqual([
+          { message: "Expected serializable app error", path: ["code"] },
+        ]);
+      }
     });
 
     it("deserializes Ok payload with inbound schema", () => {
@@ -2195,7 +2244,8 @@ describe("Result", () => {
         name: "Ada",
         createdAt: new Date("2026-05-28T12:00:00.000Z"),
       });
-      const json = JSON.stringify(UserResultCodec.serialize(original));
+      const serialized = UserResultCodec.serialize(original).unwrap();
+      const json = JSON.stringify(serialized);
       const parsed = JSON.parse(json);
       const deserialized = UserResultCodec.deserialize(parsed);
 
@@ -2241,18 +2291,23 @@ describe("Result", () => {
         },
       });
 
-      expectTypeOf(serialized).toEqualTypeOf<Promise<SerializedResult<UserWire, AppErrorWire>>>();
+      expectTypeOf(serialized).toEqualTypeOf<
+        Promise<ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>>
+      >();
       expectTypeOf(deserialized).toEqualTypeOf<
         Promise<ResultType<User, AppError | ResultDeserializationError>>
       >();
-      await expect(serialized).resolves.toEqual({
-        status: "ok",
-        value: {
-          id: "1",
-          display_name: "Ada",
-          created_at_iso: "2026-05-28T12:00:00.000Z",
-        },
-      });
+      await expect(serialized).resolves.toBeInstanceOf(Ok);
+      await expect(serialized).resolves.toEqual(
+        Result.ok({
+          status: "ok",
+          value: {
+            id: "1",
+            display_name: "Ada",
+            created_at_iso: "2026-05-28T12:00:00.000Z",
+          },
+        }),
+      );
       await expect(deserialized).resolves.toBeInstanceOf(Ok);
     });
 
@@ -2265,7 +2320,9 @@ describe("Result", () => {
         error: { type: "NOT_FOUND", message: "missing", retryable: false },
       });
 
-      expectTypeOf(outbound).toEqualTypeOf<SerializedResult<UserWire, AppErrorWire>>();
+      expectTypeOf(outbound).toEqualTypeOf<
+        ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>
+      >();
       expectTypeOf(inbound).toEqualTypeOf<
         ResultType<User, AppError | ResultDeserializationError>
       >();

--- a/src/result.ts
+++ b/src/result.ts
@@ -489,6 +489,18 @@ export interface SerializedErr<E> {
 /** Shape of a serialized Result over RPC. */
 export type SerializedResult<T, E> = SerializedOk<T> | SerializedErr<E>;
 
+type SerializedOkEnvelope = {
+  readonly status: "ok";
+  readonly value?: unknown;
+};
+
+type SerializedErrEnvelope = {
+  readonly status: "error";
+  readonly error?: unknown;
+};
+
+type SerializedResultEnvelope = SerializedOkEnvelope | SerializedErrEnvelope;
+
 /** Infers the input accepted by a Standard Schema-compatible schema. */
 export type StandardSchemaInput<TSchema extends StandardSchemaV1> =
   StandardSchemaV1.InferInput<TSchema>;
@@ -602,16 +614,16 @@ export interface ResultCodec<
   >(
     result: TResult,
   ) => SerializedCodecOperationResult<TResult, TOkSerialize, TErrSerialize>;
-  /** Deserializes a known branch precisely; unknown envelopes include sync failure and async schema outcomes. */
+  /** Deserializes a known branch precisely, including status-only envelopes produced when JSON omits undefined payloads. */
   readonly deserialize: {
     (
-      value: SerializedOk<unknown>,
+      value: SerializedOkEnvelope,
     ): StandardSchemaOperationResult<
       DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
       TOkDeserialize
     >;
     (
-      value: SerializedErr<unknown>,
+      value: SerializedErrEnvelope,
     ): StandardSchemaOperationResult<
       DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
       TErrDeserialize
@@ -620,12 +632,13 @@ export interface ResultCodec<
   };
 }
 
-function isSerializedResult(value: unknown): value is SerializedResult<unknown, unknown> {
+/** Checks only the Result envelope; the selected codec schema validates its optional payload. */
+function isSerializedResultEnvelope(value: unknown): value is SerializedResultEnvelope {
   return (
     value !== null &&
     typeof value === "object" &&
     "status" in value &&
-    ((value.status === "ok" && "value" in value) || (value.status === "error" && "error" in value))
+    (value.status === "ok" || value.status === "error")
   );
 }
 
@@ -774,16 +787,16 @@ const codec = <
   };
 
   function deserializeResult(
-    value: SerializedOk<unknown>,
+    value: SerializedOkEnvelope,
   ): StandardSchemaOperationResult<DeserializeResult, TOkDeserialize>;
   function deserializeResult(
-    value: SerializedErr<unknown>,
+    value: SerializedErrEnvelope,
   ): StandardSchemaOperationResult<DeserializeResult, TErrDeserialize>;
   function deserializeResult(
     value: unknown,
   ): UnknownDeserializationResult<TOkDeserialize, TErrDeserialize>;
   function deserializeResult(value: unknown): DeserializeResult | Promise<DeserializeResult> {
-    if (!isSerializedResult(value)) {
+    if (!isSerializedResultEnvelope(value)) {
       return err(new ResultDeserializationError({ value }));
     }
     if (value.status === "ok") {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,5 @@
 import { dual } from "./dual";
-import { ResultDeserializationError, UnhandledException } from "./error";
+import { ResultDeserializationError, ResultSerializationError, UnhandledException } from "./error";
 import { type StandardSchemaV1 } from "./standard-schema";
 import {
   Err,
@@ -538,7 +538,10 @@ export interface ResultCodec<
   serialize: (
     result: Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
   ) => MaybePromise<
-    SerializedResult<StandardSchemaOutput<TOkSerialize>, StandardSchemaOutput<TErrSerialize>>,
+    Result<
+      SerializedResult<StandardSchemaOutput<TOkSerialize>, StandardSchemaOutput<TErrSerialize>>,
+      ResultSerializationError
+    >,
     CodecSerializeIsAsync<TOkSerialize, TErrSerialize>
   >;
   deserialize: (
@@ -581,31 +584,28 @@ const validateStandardSchema = <TSchema extends StandardSchemaV1<any, any>>(
 };
 
 const unwrapSerializedValue = <TSchema extends StandardSchemaV1<any, any>>(
-  schema: TSchema,
   value: StandardSchemaInput<TSchema>,
   result: StandardSchemaV1.Result<StandardSchemaOutput<TSchema>>,
-): StandardSchemaOutput<TSchema> => {
+): Result<StandardSchemaOutput<TSchema>, ResultSerializationError> => {
   if ("issues" in result && result.issues) {
-    throw panic("Result.codec serialize schema rejected value", {
-      vendor: schema["~standard"].vendor,
-      value,
-      issues: result.issues,
-    });
+    return err(new ResultSerializationError({ value, issues: result.issues }));
   }
-  return result.value;
+  return ok(result.value);
 };
 
 const serializeWithSchema = <TSchema extends StandardSchemaV1<any, any>>(
   schema: TSchema,
   value: StandardSchemaInput<TSchema>,
-): StandardSchemaOutput<TSchema> | Promise<StandardSchemaOutput<TSchema>> => {
+):
+  | Result<StandardSchemaOutput<TSchema>, ResultSerializationError>
+  | Promise<Result<StandardSchemaOutput<TSchema>, ResultSerializationError>> => {
   const result = validateStandardSchema(schema, value, "Result.codec serialize schema threw");
   if (isPromiseLike(result)) {
     return Promise.resolve(result).then((resolved) =>
-      unwrapSerializedValue(schema, value, resolved),
+      unwrapSerializedValue<TSchema>(value, resolved),
     );
   }
-  return unwrapSerializedValue(schema, value, result);
+  return unwrapSerializedValue<TSchema>(value, result);
 };
 
 const unwrapDeserializedValue = <TSchema extends StandardSchemaV1<any, any>>(
@@ -645,15 +645,41 @@ const codec = <
     result: Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
   ) => {
     if (result.status === "ok") {
-      const value = serializeWithSchema(config.serialize.ok, result.value);
-      return isPromiseLike(value)
-        ? Promise.resolve(value).then((resolved) => ({ status: "ok" as const, value: resolved }))
-        : { status: "ok" as const, value };
+      const serialized = serializeWithSchema(config.serialize.ok, result.value);
+      const finish = (
+        resolved: Result<StandardSchemaOutput<TOkSerialize>, ResultSerializationError>,
+      ) =>
+        resolved.status === "ok"
+          ? ok({ status: "ok" as const, value: resolved.value })
+          : // SAFETY: Ok payload encode failed, widening Ok payload phantom type is safe.
+            (resolved as unknown as Err<
+              SerializedResult<
+                StandardSchemaOutput<TOkSerialize>,
+                StandardSchemaOutput<TErrSerialize>
+              >,
+              ResultSerializationError
+            >);
+      return isPromiseLike(serialized)
+        ? Promise.resolve(serialized).then(finish)
+        : finish(serialized);
     }
-    const error = serializeWithSchema(config.serialize.err, result.error);
-    return isPromiseLike(error)
-      ? Promise.resolve(error).then((resolved) => ({ status: "error" as const, error: resolved }))
-      : { status: "error" as const, error };
+    const serialized = serializeWithSchema(config.serialize.err, result.error);
+    const finish = (
+      resolved: Result<StandardSchemaOutput<TErrSerialize>, ResultSerializationError>,
+    ) =>
+      resolved.status === "ok"
+        ? ok({ status: "error" as const, error: resolved.value })
+        : // SAFETY: Err payload encode failed, widening Ok payload phantom type is safe.
+          (resolved as unknown as Err<
+            SerializedResult<
+              StandardSchemaOutput<TOkSerialize>,
+              StandardSchemaOutput<TErrSerialize>
+            >,
+            ResultSerializationError
+          >);
+    return isPromiseLike(serialized)
+      ? Promise.resolve(serialized).then(finish)
+      : finish(serialized);
   };
 
   const deserializeResult = (value: unknown) => {
@@ -965,7 +991,7 @@ export const Result = {
    * });
    *
    * const outbound = UserResultCodec.serialize(Result.ok(user));
-   * const inbound = UserResultCodec.deserialize(outbound);
+   * const inbound = outbound.andThen((wire) => UserResultCodec.deserialize(wire));
    */
   codec,
   /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,6 @@
 import { dual } from "./dual";
 import { ResultDeserializationError, UnhandledException } from "./error";
+import { type StandardSchemaV1 } from "./standard-schema";
 import {
   Err,
   Ok,
@@ -17,7 +18,11 @@ import {
 
 export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
+export type { StandardSchemaV1 } from "./standard-schema";
 export type Result<T, E> = import("./core").Result<T, E>;
+export type StandardSchemaIssue = StandardSchemaV1.Issue;
+export type StandardSchemaPathSegment = StandardSchemaV1.PathSegment;
+export type StandardSchemaResult<Output> = StandardSchemaV1.Result<Output>;
 
 /** Context passed to each `Result.try` attempt. */
 export type TryContext = {
@@ -481,6 +486,72 @@ export interface SerializedErr<E> {
 /** Shape of a serialized Result over RPC. */
 export type SerializedResult<T, E> = SerializedOk<T> | SerializedErr<E>;
 
+export type StandardSchemaInput<TSchema extends StandardSchemaV1<any, any>> =
+  StandardSchemaV1.InferInput<TSchema>;
+
+export type StandardSchemaOutput<TSchema extends StandardSchemaV1<any, any>> =
+  StandardSchemaV1.InferOutput<TSchema>;
+
+type StandardSchemaValidationResult<TSchema extends StandardSchemaV1<any, any>> = ReturnType<
+  TSchema["~standard"]["validate"]
+>;
+
+type StandardSchemaIsAsync<TSchema extends StandardSchemaV1<any, any>> =
+  Extract<StandardSchemaValidationResult<TSchema>, Promise<unknown>> extends never ? false : true;
+
+type Or<A extends boolean, B extends boolean> = A extends true ? true : B;
+
+type MaybePromise<T, TAsync extends boolean> = TAsync extends true ? Promise<T> : T;
+
+type CodecSerializeIsAsync<
+  TOkSerialize extends StandardSchemaV1<any, any>,
+  TErrSerialize extends StandardSchemaV1<any, any>,
+> = Or<StandardSchemaIsAsync<TOkSerialize>, StandardSchemaIsAsync<TErrSerialize>>;
+
+type CodecDeserializeIsAsync<
+  TOkDeserialize extends StandardSchemaV1<any, any>,
+  TErrDeserialize extends StandardSchemaV1<any, any>,
+> = Or<StandardSchemaIsAsync<TOkDeserialize>, StandardSchemaIsAsync<TErrDeserialize>>;
+
+export interface ResultCodecConfig<
+  TOkSerialize extends StandardSchemaV1<any, any>,
+  TErrSerialize extends StandardSchemaV1<any, any>,
+  TOkDeserialize extends StandardSchemaV1<any, any>,
+  TErrDeserialize extends StandardSchemaV1<any, any>,
+> {
+  readonly serialize: {
+    readonly ok: TOkSerialize;
+    readonly err: TErrSerialize;
+  };
+  readonly deserialize: {
+    readonly ok: TOkDeserialize;
+    readonly err: TErrDeserialize;
+  };
+}
+
+export interface ResultCodec<
+  TOkSerialize extends StandardSchemaV1<any, any>,
+  TErrSerialize extends StandardSchemaV1<any, any>,
+  TOkDeserialize extends StandardSchemaV1<any, any>,
+  TErrDeserialize extends StandardSchemaV1<any, any>,
+> {
+  serialize: (
+    result: Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
+  ) => MaybePromise<
+    SerializedResult<StandardSchemaOutput<TOkSerialize>, StandardSchemaOutput<TErrSerialize>>,
+    CodecSerializeIsAsync<TOkSerialize, TErrSerialize>
+  >;
+  deserialize: (
+    value: unknown,
+  ) => MaybePromise<
+    Result<
+      StandardSchemaOutput<TOkDeserialize>,
+      StandardSchemaOutput<TErrDeserialize> | ResultDeserializationError
+    >,
+    CodecDeserializeIsAsync<TOkDeserialize, TErrDeserialize>
+  >;
+}
+
 function isSerializedResult(obj: unknown): obj is SerializedResult<unknown, unknown> {
   return (
     obj !== null &&
@@ -490,26 +561,137 @@ function isSerializedResult(obj: unknown): obj is SerializedResult<unknown, unkn
   );
 }
 
-const serialize = <T, E>(result: Result<T, E>): SerializedResult<T, E> => {
-  return result.status === "ok"
-    ? { status: "ok", value: result.value }
-    : { status: "error", error: result.error };
+const isPromiseLike = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
 };
 
-const deserialize = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
-  if (isSerializedResult(value)) {
-    return value.status === "ok"
-      ? (new Ok(value.value) as Result<T, E>)
-      : (new Err(value.error) as Result<T, E>);
+const validateStandardSchema = <TSchema extends StandardSchemaV1<any, any>>(
+  schema: TSchema,
+  value: unknown,
+  message: string,
+): StandardSchemaValidationResult<TSchema> => {
+  const result = tryOrPanic(() => schema["~standard"].validate(value), message);
+  // SAFETY: result is returned directly from this exact schema's validate function.
+  return result as StandardSchemaValidationResult<TSchema>;
+};
+
+const unwrapSerializedValue = <TSchema extends StandardSchemaV1<any, any>>(
+  schema: TSchema,
+  value: StandardSchemaInput<TSchema>,
+  result: StandardSchemaV1.Result<StandardSchemaOutput<TSchema>>,
+): StandardSchemaOutput<TSchema> => {
+  if ("issues" in result && result.issues) {
+    throw panic("Result.codec serialize schema rejected value", {
+      vendor: schema["~standard"].vendor,
+      value,
+      issues: result.issues,
+    });
   }
-  return err(new ResultDeserializationError({ value }));
+  return result.value;
 };
 
-/**
- * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
- */
-const hydrate = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
-  return deserialize(value);
+const serializeWithSchema = <TSchema extends StandardSchemaV1<any, any>>(
+  schema: TSchema,
+  value: StandardSchemaInput<TSchema>,
+): StandardSchemaOutput<TSchema> | Promise<StandardSchemaOutput<TSchema>> => {
+  const result = validateStandardSchema(schema, value, "Result.codec serialize schema threw");
+  if (isPromiseLike(result)) {
+    return Promise.resolve(result).then((resolved) =>
+      unwrapSerializedValue(schema, value, resolved),
+    );
+  }
+  return unwrapSerializedValue(schema, value, result);
+};
+
+const unwrapDeserializedValue = <TSchema extends StandardSchemaV1<any, any>>(
+  value: unknown,
+  result: StandardSchemaV1.Result<StandardSchemaOutput<TSchema>>,
+): Result<StandardSchemaOutput<TSchema>, ResultDeserializationError> => {
+  if ("issues" in result && result.issues) {
+    return err(new ResultDeserializationError({ value, issues: result.issues }));
+  }
+  return ok(result.value);
+};
+
+const deserializeWithSchema = <TSchema extends StandardSchemaV1<any, any>>(
+  schema: TSchema,
+  value: unknown,
+):
+  | Result<StandardSchemaOutput<TSchema>, ResultDeserializationError>
+  | Promise<Result<StandardSchemaOutput<TSchema>, ResultDeserializationError>> => {
+  const result = validateStandardSchema(schema, value, "Result.codec deserialize schema threw");
+  if (isPromiseLike(result)) {
+    return Promise.resolve(result).then((resolved) =>
+      unwrapDeserializedValue<TSchema>(value, resolved),
+    );
+  }
+  return unwrapDeserializedValue<TSchema>(value, result);
+};
+
+const codec = <
+  TOkSerialize extends StandardSchemaV1<any, any>,
+  TErrSerialize extends StandardSchemaV1<any, any>,
+  TOkDeserialize extends StandardSchemaV1<any, any>,
+  TErrDeserialize extends StandardSchemaV1<any, any>,
+>(
+  config: ResultCodecConfig<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>,
+): ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize> => {
+  const serializeResult = (
+    result: Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
+  ) => {
+    if (result.status === "ok") {
+      const value = serializeWithSchema(config.serialize.ok, result.value);
+      return isPromiseLike(value)
+        ? Promise.resolve(value).then((resolved) => ({ status: "ok" as const, value: resolved }))
+        : { status: "ok" as const, value };
+    }
+    const error = serializeWithSchema(config.serialize.err, result.error);
+    return isPromiseLike(error)
+      ? Promise.resolve(error).then((resolved) => ({ status: "error" as const, error: resolved }))
+      : { status: "error" as const, error };
+  };
+
+  const deserializeResult = (value: unknown) => {
+    if (!isSerializedResult(value)) {
+      return err(new ResultDeserializationError({ value }));
+    }
+    if (value.status === "ok") {
+      const parsed = deserializeWithSchema(config.deserialize.ok, value.value);
+      const finish = (
+        resolved: Result<StandardSchemaOutput<TOkDeserialize>, ResultDeserializationError>,
+      ) =>
+        resolved.status === "ok"
+          ? ok(resolved.value)
+          : // SAFETY: Ok payload decode failed, widening Err phantom ok type is safe.
+            (resolved as unknown as Err<
+              StandardSchemaOutput<TOkDeserialize>,
+              ResultDeserializationError
+            >);
+      return isPromiseLike(parsed) ? Promise.resolve(parsed).then(finish) : finish(parsed);
+    }
+    const parsed = deserializeWithSchema(config.deserialize.err, value.error);
+    const finish = (
+      resolved: Result<StandardSchemaOutput<TErrDeserialize>, ResultDeserializationError>,
+    ) =>
+      resolved.status === "ok"
+        ? err(resolved.value)
+        : // SAFETY: Err payload decode failed, widening Err phantom ok type is safe.
+          (resolved as unknown as Err<
+            StandardSchemaOutput<TOkDeserialize>,
+            ResultDeserializationError
+          >);
+    return isPromiseLike(parsed) ? Promise.resolve(parsed).then(finish) : finish(parsed);
+  };
+
+  return {
+    serialize: serializeResult,
+    deserialize: deserializeResult,
+  } as ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>;
 };
 
 const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {
@@ -774,34 +956,18 @@ export const Result = {
    */
   await: resultAwait,
   /**
-   * Converts a Result to a plain object for serialization (e.g., RPC, server actions).
+   * Builds a Result-level codec from Standard Schema-compatible serializers/deserializers.
    *
    * @example
-   * const serialized = Result.serialize(ok(42)); // { status: "ok", value: 42 }
-   */
-  serialize,
-  /**
-   * Rehydrates serialized Result from RPC back into Ok/Err instances.
-   * Returns `Err<ResultDeserializationError>` if the input is not a valid serialized Result.
+   * const UserResultCodec = Result.codec({
+   *   serialize: { ok: UserToWireSchema, err: AppErrorToWireSchema },
+   *   deserialize: { ok: WireToUserSchema, err: WireToAppErrorSchema },
+   * });
    *
-   * @example
-   * // Valid serialized Result
-   * const result = Result.deserialize<User, AppError>(rpcResponse);
-   * if (Result.isOk(result)) {
-   *   console.log(result.value); // User
-   * }
-   *
-   * // Invalid input returns ResultDeserializationError
-   * const invalid = Result.deserialize({ foo: "bar" });
-   * if (Result.isError(invalid) && ResultDeserializationError.is(invalid.error)) {
-   *   console.log("Bad input:", invalid.error.value);
-   * }
+   * const outbound = UserResultCodec.serialize(Result.ok(user));
+   * const inbound = UserResultCodec.deserialize(outbound);
    */
-  deserialize,
-  /**
-   * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
-   */
-  hydrate,
+  codec,
   /**
    * Splits array of Results into tuple of [okValues, errorValues].
    *

--- a/src/result.ts
+++ b/src/result.ts
@@ -20,8 +20,11 @@ export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
 export type { StandardSchemaV1 } from "./standard-schema";
 export type Result<T, E> = import("./core").Result<T, E>;
+/** A validation issue reported by a Standard Schema-compatible schema. */
 export type StandardSchemaIssue = StandardSchemaV1.Issue;
+/** A property key wrapper used in Standard Schema validation paths. */
 export type StandardSchemaPathSegment = StandardSchemaV1.PathSegment;
+/** The success or issue result returned by a Standard Schema-compatible validator. */
 export type StandardSchemaResult<Output> = StandardSchemaV1.Result<Output>;
 
 /** Context passed to each `Result.try` attempt. */
@@ -486,81 +489,143 @@ export interface SerializedErr<E> {
 /** Shape of a serialized Result over RPC. */
 export type SerializedResult<T, E> = SerializedOk<T> | SerializedErr<E>;
 
-export type StandardSchemaInput<TSchema extends StandardSchemaV1<any, any>> =
+/** Infers the input accepted by a Standard Schema-compatible schema. */
+export type StandardSchemaInput<TSchema extends StandardSchemaV1> =
   StandardSchemaV1.InferInput<TSchema>;
 
-export type StandardSchemaOutput<TSchema extends StandardSchemaV1<any, any>> =
+/** Infers the output produced by a Standard Schema-compatible schema. */
+export type StandardSchemaOutput<TSchema extends StandardSchemaV1> =
   StandardSchemaV1.InferOutput<TSchema>;
 
-type StandardSchemaValidationResult<TSchema extends StandardSchemaV1<any, any>> = ReturnType<
+type StandardSchemaValidationResult<TSchema extends StandardSchemaV1> = ReturnType<
   TSchema["~standard"]["validate"]
 >;
 
-type StandardSchemaIsAsync<TSchema extends StandardSchemaV1<any, any>> =
-  Extract<StandardSchemaValidationResult<TSchema>, Promise<unknown>> extends never ? false : true;
+type StandardSchemaAsyncValidation<TSchema extends StandardSchemaV1> = Extract<
+  StandardSchemaValidationResult<TSchema>,
+  PromiseLike<unknown>
+>;
 
-type Or<A extends boolean, B extends boolean> = A extends true ? true : B;
+type StandardSchemaSyncValidation<TSchema extends StandardSchemaV1> = Exclude<
+  StandardSchemaValidationResult<TSchema>,
+  PromiseLike<unknown>
+>;
 
-type MaybePromise<T, TAsync extends boolean> = TAsync extends true ? Promise<T> : T;
+type StandardSchemaOperationResult<T, TSchema extends StandardSchemaV1> = [
+  StandardSchemaAsyncValidation<TSchema>,
+] extends [never]
+  ? T
+  : [StandardSchemaSyncValidation<TSchema>] extends [never]
+    ? Promise<T>
+    : T | Promise<T>;
 
-type CodecSerializeIsAsync<
-  TOkSerialize extends StandardSchemaV1<any, any>,
-  TErrSerialize extends StandardSchemaV1<any, any>,
-> = Or<StandardSchemaIsAsync<TOkSerialize>, StandardSchemaIsAsync<TErrSerialize>>;
+type SerializedCodecResult<
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+> = Result<
+  SerializedResult<StandardSchemaOutput<TOkSerialize>, StandardSchemaOutput<TErrSerialize>>,
+  ResultSerializationError
+>;
 
-type CodecDeserializeIsAsync<
-  TOkDeserialize extends StandardSchemaV1<any, any>,
-  TErrDeserialize extends StandardSchemaV1<any, any>,
-> = Or<StandardSchemaIsAsync<TOkDeserialize>, StandardSchemaIsAsync<TErrDeserialize>>;
+type SerializedCodecOperationResult<
+  TResult extends Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+> =
+  TResult extends Ok<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>
+    ? StandardSchemaOperationResult<
+        SerializedCodecResult<TOkSerialize, TErrSerialize>,
+        TOkSerialize
+      >
+    : TResult extends Err<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>
+      ? StandardSchemaOperationResult<
+          SerializedCodecResult<TOkSerialize, TErrSerialize>,
+          TErrSerialize
+        >
+      : never;
 
+type DeserializedCodecResult<
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+> = Result<
+  StandardSchemaOutput<TOkDeserialize>,
+  StandardSchemaOutput<TErrDeserialize> | ResultDeserializationError
+>;
+
+type UnknownDeserializationResult<
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+> =
+  | DeserializedCodecResult<TOkDeserialize, TErrDeserialize>
+  | StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TOkDeserialize
+    >
+  | StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TErrDeserialize
+    >;
+
+/** Standard Schema serializers and deserializers for both Result branches. */
 export interface ResultCodecConfig<
-  TOkSerialize extends StandardSchemaV1<any, any>,
-  TErrSerialize extends StandardSchemaV1<any, any>,
-  TOkDeserialize extends StandardSchemaV1<any, any>,
-  TErrDeserialize extends StandardSchemaV1<any, any>,
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
 > {
+  /** Schemas that convert in-memory Result payloads into wire payloads. */
   readonly serialize: {
+    /** Serializes an Ok value. */
     readonly ok: TOkSerialize;
+    /** Serializes an Err value. */
     readonly err: TErrSerialize;
   };
+  /** Schemas that parse wire payloads back into in-memory Result payloads. */
   readonly deserialize: {
+    /** Deserializes a serialized Ok value. */
     readonly ok: TOkDeserialize;
+    /** Deserializes a serialized Err value. */
     readonly err: TErrDeserialize;
   };
 }
 
+/** Converts Result values to and from a validated serialized representation. */
 export interface ResultCodec<
-  TOkSerialize extends StandardSchemaV1<any, any>,
-  TErrSerialize extends StandardSchemaV1<any, any>,
-  TOkDeserialize extends StandardSchemaV1<any, any>,
-  TErrDeserialize extends StandardSchemaV1<any, any>,
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
 > {
-  serialize: (
-    result: Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
-  ) => MaybePromise<
-    Result<
-      SerializedResult<StandardSchemaOutput<TOkSerialize>, StandardSchemaOutput<TErrSerialize>>,
-      ResultSerializationError
-    >,
-    CodecSerializeIsAsync<TOkSerialize, TErrSerialize>
-  >;
-  deserialize: (
-    value: unknown,
-  ) => MaybePromise<
-    Result<
-      StandardSchemaOutput<TOkDeserialize>,
-      StandardSchemaOutput<TErrDeserialize> | ResultDeserializationError
-    >,
-    CodecDeserializeIsAsync<TOkDeserialize, TErrDeserialize>
-  >;
+  /** Serializes the selected Result branch, preserving that branch schema's sync or async return. */
+  readonly serialize: <
+    TResult extends Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
+  >(
+    result: TResult,
+  ) => SerializedCodecOperationResult<TResult, TOkSerialize, TErrSerialize>;
+  /** Deserializes a known branch precisely; unknown envelopes include sync failure and async schema outcomes. */
+  readonly deserialize: {
+    (
+      value: SerializedOk<unknown>,
+    ): StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TOkDeserialize
+    >;
+    (
+      value: SerializedErr<unknown>,
+    ): StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TErrDeserialize
+    >;
+    (value: unknown): UnknownDeserializationResult<TOkDeserialize, TErrDeserialize>;
+  };
 }
 
-function isSerializedResult(obj: unknown): obj is SerializedResult<unknown, unknown> {
+function isSerializedResult(value: unknown): value is SerializedResult<unknown, unknown> {
   return (
-    obj !== null &&
-    typeof obj === "object" &&
-    "status" in obj &&
-    ((obj.status === "ok" && "value" in obj) || (obj.status === "error" && "error" in obj))
+    value !== null &&
+    typeof value === "object" &&
+    "status" in value &&
+    ((value.status === "ok" && "value" in value) || (value.status === "error" && "error" in value))
   );
 }
 
@@ -573,151 +638,170 @@ const isPromiseLike = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> =>
   );
 };
 
-const validateStandardSchema = <TSchema extends StandardSchemaV1<any, any>>(
-  schema: TSchema,
-  value: unknown,
-  message: string,
-): StandardSchemaValidationResult<TSchema> => {
-  const result = tryOrPanic(() => schema["~standard"].validate(value), message);
-  // SAFETY: result is returned directly from this exact schema's validate function.
-  return result as StandardSchemaValidationResult<TSchema>;
+const runStandardSchemaValidation = <TResult>(
+  validate: () => TResult,
+  panicMessage: string,
+): TResult => {
+  return tryOrPanic(validate, panicMessage);
 };
 
-const unwrapSerializedValue = <TSchema extends StandardSchemaV1<any, any>>(
-  value: StandardSchemaInput<TSchema>,
-  result: StandardSchemaV1.Result<StandardSchemaOutput<TSchema>>,
-): Result<StandardSchemaOutput<TSchema>, ResultSerializationError> => {
-  if ("issues" in result && result.issues) {
-    return err(new ResultSerializationError({ value, issues: result.issues }));
+const mapStandardSchemaValidation = <T, U>(
+  validation: StandardSchemaV1.Result<T> | PromiseLike<StandardSchemaV1.Result<T>>,
+  panicMessage: string,
+  mapValidation: (validation: StandardSchemaV1.Result<T>) => U,
+): U | Promise<U> => {
+  if (isPromiseLike(validation)) {
+    return Promise.resolve(validation)
+      .catch((cause: unknown) => {
+        throw panic(panicMessage, cause);
+      })
+      .then(mapValidation);
   }
-  return ok(result.value);
+  return mapValidation(validation);
 };
 
-const serializeWithSchema = <TSchema extends StandardSchemaV1<any, any>>(
+const unwrapCodecValidation = <T, E>(
+  validation: StandardSchemaV1.Result<T>,
+  makeError: (issues: ReadonlyArray<StandardSchemaV1.Issue>) => E,
+): Result<T, E> => {
+  if ("issues" in validation && validation.issues) {
+    return err(makeError(validation.issues));
+  }
+  return ok(validation.value);
+};
+
+const serializeWithSchema = <TSchema extends StandardSchemaV1>(
   schema: TSchema,
   value: StandardSchemaInput<TSchema>,
 ):
   | Result<StandardSchemaOutput<TSchema>, ResultSerializationError>
   | Promise<Result<StandardSchemaOutput<TSchema>, ResultSerializationError>> => {
-  const result = validateStandardSchema(schema, value, "Result.codec serialize schema threw");
-  if (isPromiseLike(result)) {
-    return Promise.resolve(result).then((resolved) =>
-      unwrapSerializedValue<TSchema>(value, resolved),
-    );
-  }
-  return unwrapSerializedValue<TSchema>(value, result);
+  const validation = runStandardSchemaValidation(
+    () => schema["~standard"].validate(value),
+    "Result.codec serialize schema threw",
+  );
+  return mapStandardSchemaValidation(
+    validation,
+    "Result.codec serialize schema threw",
+    (resolved) =>
+      unwrapCodecValidation(resolved, (issues) => new ResultSerializationError({ value, issues })),
+  );
 };
 
-const unwrapDeserializedValue = <TSchema extends StandardSchemaV1<any, any>>(
-  value: unknown,
-  result: StandardSchemaV1.Result<StandardSchemaOutput<TSchema>>,
-): Result<StandardSchemaOutput<TSchema>, ResultDeserializationError> => {
-  if ("issues" in result && result.issues) {
-    return err(new ResultDeserializationError({ value, issues: result.issues }));
-  }
-  return ok(result.value);
-};
-
-const deserializeWithSchema = <TSchema extends StandardSchemaV1<any, any>>(
+const deserializeWithSchema = <TSchema extends StandardSchemaV1>(
   schema: TSchema,
   value: unknown,
 ):
   | Result<StandardSchemaOutput<TSchema>, ResultDeserializationError>
   | Promise<Result<StandardSchemaOutput<TSchema>, ResultDeserializationError>> => {
-  const result = validateStandardSchema(schema, value, "Result.codec deserialize schema threw");
-  if (isPromiseLike(result)) {
-    return Promise.resolve(result).then((resolved) =>
-      unwrapDeserializedValue<TSchema>(value, resolved),
-    );
-  }
-  return unwrapDeserializedValue<TSchema>(value, result);
+  const validation = runStandardSchemaValidation(
+    () => schema["~standard"].validate(value),
+    "Result.codec deserialize schema threw",
+  );
+  return mapStandardSchemaValidation(
+    validation,
+    "Result.codec deserialize schema threw",
+    (resolved) =>
+      unwrapCodecValidation(
+        resolved,
+        (issues) => new ResultDeserializationError({ value, issues }),
+      ),
+  );
 };
 
 const codec = <
-  TOkSerialize extends StandardSchemaV1<any, any>,
-  TErrSerialize extends StandardSchemaV1<any, any>,
-  TOkDeserialize extends StandardSchemaV1<any, any>,
-  TErrDeserialize extends StandardSchemaV1<any, any>,
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
 >(
   config: ResultCodecConfig<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>,
 ): ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize> => {
-  const serializeResult = (
-    result: Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
-  ) => {
-    if (result.status === "ok") {
-      const serialized = serializeWithSchema(config.serialize.ok, result.value);
-      const finish = (
-        resolved: Result<StandardSchemaOutput<TOkSerialize>, ResultSerializationError>,
-      ) =>
-        resolved.status === "ok"
-          ? ok({ status: "ok" as const, value: resolved.value })
-          : // SAFETY: Ok payload encode failed, widening Ok payload phantom type is safe.
-            (resolved as unknown as Err<
-              SerializedResult<
-                StandardSchemaOutput<TOkSerialize>,
-                StandardSchemaOutput<TErrSerialize>
-              >,
-              ResultSerializationError
-            >);
-      return isPromiseLike(serialized)
-        ? Promise.resolve(serialized).then(finish)
-        : finish(serialized);
+  type SerializeResult = SerializedCodecResult<TOkSerialize, TErrSerialize>;
+  type DeserializeResult = DeserializedCodecResult<TOkDeserialize, TErrDeserialize>;
+  type InputResult = Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>;
+
+  const finishOkSerialization = (
+    resolved: Result<StandardSchemaOutput<TOkSerialize>, ResultSerializationError>,
+  ): SerializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
     }
-    const serialized = serializeWithSchema(config.serialize.err, result.error);
-    const finish = (
-      resolved: Result<StandardSchemaOutput<TErrSerialize>, ResultSerializationError>,
-    ) =>
-      resolved.status === "ok"
-        ? ok({ status: "error" as const, error: resolved.value })
-        : // SAFETY: Err payload encode failed, widening Ok payload phantom type is safe.
-          (resolved as unknown as Err<
-            SerializedResult<
-              StandardSchemaOutput<TOkSerialize>,
-              StandardSchemaOutput<TErrSerialize>
-            >,
-            ResultSerializationError
-          >);
-    return isPromiseLike(serialized)
-      ? Promise.resolve(serialized).then(finish)
-      : finish(serialized);
+    return ok({ status: "ok", value: resolved.value });
   };
 
-  const deserializeResult = (value: unknown) => {
+  const finishErrSerialization = (
+    resolved: Result<StandardSchemaOutput<TErrSerialize>, ResultSerializationError>,
+  ): SerializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return ok({ status: "error", error: resolved.value });
+  };
+
+  function serializeResult<TResult extends InputResult>(
+    result: TResult,
+  ): SerializedCodecOperationResult<TResult, TOkSerialize, TErrSerialize>;
+  function serializeResult(result: InputResult): SerializeResult | Promise<SerializeResult> {
+    if (result.status === "ok") {
+      const serialized = serializeWithSchema(config.serialize.ok, result.value);
+      return isPromiseLike(serialized)
+        ? Promise.resolve(serialized).then(finishOkSerialization)
+        : finishOkSerialization(serialized);
+    }
+    const serialized = serializeWithSchema(config.serialize.err, result.error);
+    return isPromiseLike(serialized)
+      ? Promise.resolve(serialized).then(finishErrSerialization)
+      : finishErrSerialization(serialized);
+  }
+
+  const finishOkDeserialization = (
+    resolved: Result<StandardSchemaOutput<TOkDeserialize>, ResultDeserializationError>,
+  ): DeserializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return ok(resolved.value);
+  };
+
+  const finishErrDeserialization = (
+    resolved: Result<StandardSchemaOutput<TErrDeserialize>, ResultDeserializationError>,
+  ): DeserializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return err(resolved.value);
+  };
+
+  function deserializeResult(
+    value: SerializedOk<unknown>,
+  ): StandardSchemaOperationResult<DeserializeResult, TOkDeserialize>;
+  function deserializeResult(
+    value: SerializedErr<unknown>,
+  ): StandardSchemaOperationResult<DeserializeResult, TErrDeserialize>;
+  function deserializeResult(
+    value: unknown,
+  ): UnknownDeserializationResult<TOkDeserialize, TErrDeserialize>;
+  function deserializeResult(value: unknown): DeserializeResult | Promise<DeserializeResult> {
     if (!isSerializedResult(value)) {
       return err(new ResultDeserializationError({ value }));
     }
     if (value.status === "ok") {
-      const parsed = deserializeWithSchema(config.deserialize.ok, value.value);
-      const finish = (
-        resolved: Result<StandardSchemaOutput<TOkDeserialize>, ResultDeserializationError>,
-      ) =>
-        resolved.status === "ok"
-          ? ok(resolved.value)
-          : // SAFETY: Ok payload decode failed, widening Err phantom ok type is safe.
-            (resolved as unknown as Err<
-              StandardSchemaOutput<TOkDeserialize>,
-              ResultDeserializationError
-            >);
-      return isPromiseLike(parsed) ? Promise.resolve(parsed).then(finish) : finish(parsed);
+      const deserialized = deserializeWithSchema(config.deserialize.ok, value.value);
+      return isPromiseLike(deserialized)
+        ? Promise.resolve(deserialized).then(finishOkDeserialization)
+        : finishOkDeserialization(deserialized);
     }
-    const parsed = deserializeWithSchema(config.deserialize.err, value.error);
-    const finish = (
-      resolved: Result<StandardSchemaOutput<TErrDeserialize>, ResultDeserializationError>,
-    ) =>
-      resolved.status === "ok"
-        ? err(resolved.value)
-        : // SAFETY: Err payload decode failed, widening Err phantom ok type is safe.
-          (resolved as unknown as Err<
-            StandardSchemaOutput<TOkDeserialize>,
-            ResultDeserializationError
-          >);
-    return isPromiseLike(parsed) ? Promise.resolve(parsed).then(finish) : finish(parsed);
-  };
+    const deserialized = deserializeWithSchema(config.deserialize.err, value.error);
+    return isPromiseLike(deserialized)
+      ? Promise.resolve(deserialized).then(finishErrDeserialization)
+      : finishErrDeserialization(deserialized);
+  }
 
   return {
     serialize: serializeResult,
     deserialize: deserializeResult,
-  } as ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>;
+  } satisfies ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>;
 };
 
 const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {

--- a/src/standard-schema.ts
+++ b/src/standard-schema.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendored Standard Schema interface.
+ *
+ * Source: https://standardschema.dev/schema#the-interface
+ */
+
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1;
+    /** The vendor name of the schema library. */
+    readonly vendor: string;
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown,
+      options?: StandardSchemaV1.Options | undefined,
+    ) => Result<Output> | Promise<Result<Output>>;
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output;
+    /** A falsy value for `issues` indicates success. */
+    readonly issues?: undefined;
+  }
+
+  export interface Options {
+    /** Explicit support for additional vendor-specific parameters, if needed. */
+    readonly libraryOptions?: Record<string, unknown> | undefined;
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input;
+    /** The output type of the schema. */
+    readonly output: Output;
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["input"];
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["output"];
+}


### PR DESCRIPTION
## Summary
- add `Result.codec({ serialize, deserialize })` built around Standard Schema-compatible codecs
- remove legacy `Result.serialize`, `Result.deserialize`, and `Result.hydrate` in favor of the new 3.0 API
- expand docs/tests and enrich `ResultDeserializationError` with `phase` and optional `issues`

## Testing
- bun run check
- bun test
- bun run build

closes #70 