### PR TITLE
Improve matchError/matchErrorPartial type inference with independent handler returns

### DIFF
--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -1,0 +1,219 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { matchError, matchErrorPartial, TaggedError } from "./error";
+import { Result } from "./result";
+
+class ErrorA extends TaggedError("ErrorA")<{}>() {}
+class ErrorB extends TaggedError("ErrorB")<{}>() {}
+class ErrorC extends TaggedError("ErrorC")<{}>() {}
+
+describe("matchError", () => {
+  it("infers union from divergent handler returns", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError(result.error, {
+      ErrorA: (_err) => 1,
+      ErrorB: (_err) => "B",
+    });
+    expectTypeOf(outcome).toEqualTypeOf<number | string>();
+  });
+
+  it("drops `never` contributed by a throwing handler", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError(result.error, {
+      ErrorA: (_err) => 1,
+      ErrorB: (err) => {
+        throw err;
+      },
+    });
+    expectTypeOf(outcome).toEqualTypeOf<number>();
+  });
+
+  it("narrows handler params to the matched error (data-first)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchError(result.error, {
+      ErrorA: (e) => expectTypeOf(e).toEqualTypeOf<ErrorA>(),
+      ErrorB: (e) => expectTypeOf(e).toEqualTypeOf<ErrorB>(),
+    });
+  });
+
+  it("rejects a non-exhaustive handler map (data-first)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    // @ts-expect-error - ErrorB handler is missing
+    matchError(result.error, {
+      ErrorA: (_err) => 1,
+    });
+  });
+
+  it("works data-last (pipeable)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError({
+      ErrorA: (_err) => "A" as const,
+      ErrorB: (err) => {
+        throw err;
+      },
+    })(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"A">();
+  });
+
+  it("rejects a non-exhaustive handler map at application (data-last)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const matcher = matchError({
+      ErrorA: (_err) => 1,
+    });
+    // @ts-expect-error - ErrorB is unhandled, so the error union is not exhaustively matched
+    matcher(result.error);
+  });
+
+  it("accepts explicit type parameters", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError<ErrorA | ErrorB, string>(result.error, {
+      ErrorA: (_err) => "A" as const,
+      ErrorB: (_err) => "B" as const,
+    });
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("explicit R rejects a handler returning the wrong type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchError<ErrorA | ErrorB, string>(result.error, {
+      ErrorA: (_err) => "A",
+      // @ts-expect-error - number is not assignable to string
+      ErrorB: (_err) => 123,
+    });
+  });
+
+  it("explicit R constrains all handler returns (data-last)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError<ErrorA | ErrorB, string>({
+      ErrorA: (_err) => "A" as const,
+      ErrorB: (_err) => "B" as const,
+    })(result.error);
+    expectTypeOf(outcome).toBeString();
+  });
+});
+
+describe("matchErrorPartial", () => {
+  it("explicit R constrains all handler returns (data-first)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (_err) => "B" as const,
+      },
+      (_err) => "fallback" as const,
+    );
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("explicit R rejects a handler returning the wrong type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      {
+        // @ts-expect-error - number is not assignable to string
+        ErrorA: (_err) => 123,
+      },
+      (_err) => "fallback",
+    );
+  });
+
+  it("explicit R constrains all handler returns (data-last)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (_err) => "B" as const,
+      },
+      (_err) => "fallback" as const,
+    )(result.error);
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("infers union from divergent handler and fallback returns", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(
+      result.error,
+      {
+        ErrorA: (_err) => "specific" as const,
+      },
+      (_err) => 0,
+    );
+    expectTypeOf(outcome).toEqualTypeOf<"specific" | number>();
+  });
+
+  it("drops `never` from throwing handler and fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (err) => {
+          throw err;
+        },
+      },
+      (err) => {
+        throw err;
+      },
+    );
+    expectTypeOf(outcome).toEqualTypeOf<"A">();
+  });
+
+  it("works data-last (pipeable)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (err) => {
+          throw err;
+        },
+      },
+      (_err) => "fallback" as const,
+    )(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+  });
+
+  it("accepts explicit type parameters", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (_err) => "B" as const,
+      },
+      (_err) => "fallback" as const,
+    );
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("narrows fallback type to exclude handled errors", () => {
+    const result = Result.err<void, ErrorA | ErrorB | ErrorC>(new ErrorA());
+    const outcome = matchErrorPartial(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+      },
+      (err) => {
+        expectTypeOf(err).toEqualTypeOf<ErrorB | ErrorC>();
+        return "fallback" as const;
+      },
+    );
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+  });
+
+  it("fallback error is accessible in data-last form without contextual E", () => {
+    // Should NOT produce `never` — fallback param must be accessible even when
+    // E is deferred (no contextual error type at matchErrorPartial call site).
+    const matcher = matchErrorPartial(
+      {
+        ErrorA: (_err) => "A" as const,
+      },
+      (e) => {
+        expectTypeOf(e._tag).toBeString();
+        return "fallback" as const;
+      },
+    );
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matcher(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+  });
+});

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -1,10 +1,18 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { matchError, matchErrorPartial, TaggedError } from "./error";
-import { Result } from "./result";
+import { matchError, matchErrorPartial, Result, TaggedError } from "./index";
 
-class ErrorA extends TaggedError("ErrorA")<{}>() {}
-class ErrorB extends TaggedError("ErrorB")<{}>() {}
-class ErrorC extends TaggedError("ErrorC")<{}>() {}
+class ErrorA extends TaggedError("ErrorA")<{}> {}
+class ErrorB extends TaggedError("ErrorB")<{}> {}
+class ErrorC extends TaggedError("ErrorC")<{}> {}
+
+class StructuralTaggedError extends Error {
+  readonly _tag = "StructuralTaggedError";
+}
+
+type HttpErrorResponse = {
+  readonly status: number;
+  readonly message: string;
+};
 
 describe("matchError", () => {
   it("infers union from divergent handler returns", () => {
@@ -27,6 +35,39 @@ describe("matchError", () => {
     expectTypeOf(outcome).toEqualTypeOf<number>();
   });
 
+  it("infers `never` when every handler throws", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError(result.error, {
+      ErrorA: (err) => {
+        throw err;
+      },
+      ErrorB: (err) => {
+        throw err;
+      },
+    });
+    expectTypeOf(outcome).toBeNever();
+  });
+
+  it("supports a concrete return type when other handlers throw", () => {
+    const toHttpErrorResponse = (error: ErrorA | ErrorB): HttpErrorResponse =>
+      matchError(error, {
+        ErrorA: () => ({ status: 400, message: "Invalid request" }),
+        ErrorB: (err) => {
+          throw err;
+        },
+      });
+
+    expectTypeOf(toHttpErrorResponse).returns.toEqualTypeOf<HttpErrorResponse>();
+  });
+
+  it("continues to support structurally tagged errors", () => {
+    const error = new StructuralTaggedError("structural");
+    const outcome = matchError(error, {
+      StructuralTaggedError: () => "handled" as const,
+    });
+    expectTypeOf(outcome).toEqualTypeOf<"handled">();
+  });
+
   it("narrows handler params to the matched error (data-first)", () => {
     const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
     matchError(result.error, {
@@ -43,7 +84,16 @@ describe("matchError", () => {
     });
   });
 
-  it("works data-last (pipeable)", () => {
+  it("infers union from divergent handler returns data-last", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError({
+      ErrorA: () => 1,
+      ErrorB: () => "B",
+    })(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<number | string>();
+  });
+
+  it("drops `never` data-last", () => {
     const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
     const outcome = matchError({
       ErrorA: (_err) => "A" as const,
@@ -117,6 +167,16 @@ describe("matchErrorPartial", () => {
     );
   });
 
+  it("explicit R rejects a fallback returning the wrong type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      { ErrorA: () => "A" },
+      // @ts-expect-error - number is not assignable to string
+      (_err) => 123,
+    );
+  });
+
   it("explicit R constrains all handler returns (data-last)", () => {
     const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
     const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
@@ -139,6 +199,18 @@ describe("matchErrorPartial", () => {
       (_err) => 0,
     );
     expectTypeOf(outcome).toEqualTypeOf<"specific" | number>();
+  });
+
+  it("infers only the fallback return for an empty handler map", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(result.error, {}, () => "fallback" as const);
+    expectTypeOf(outcome).toEqualTypeOf<"fallback">();
+  });
+
+  it("continues to support structurally tagged errors", () => {
+    const error = new StructuralTaggedError("structural");
+    const outcome = matchErrorPartial(error, {}, () => "fallback" as const);
+    expectTypeOf(outcome).toEqualTypeOf<"fallback">();
   });
 
   it("drops `never` from throwing handler and fallback", () => {

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -26,6 +26,10 @@ class NetworkError extends TaggedError("NetworkError")<{
 
 type AppError = NotFoundError | ValidationError | NetworkError;
 
+class StructuralTaggedError extends Error {
+  readonly _tag = "StructuralTaggedError";
+}
+
 describe("TaggedError", () => {
   describe("construction", () => {
     it("sets name to tag", () => {
@@ -241,6 +245,39 @@ describe("TaggedError", () => {
       expect(matchAppError(error)).toBe("network: https://api.example.com");
     });
 
+    it("propagates an exception from the selected handler", () => {
+      const throwSelectedHandler = (error: AppError) =>
+        matchError(error, {
+          NotFoundError: (e) => `missing: ${e.id}`,
+          ValidationError: (e) => `invalid: ${e.field}`,
+          NetworkError: (e) => {
+            throw e;
+          },
+        });
+      const error = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      let thrown: unknown;
+      try {
+        throwSelectedHandler(error);
+      } catch (cause) {
+        thrown = cause;
+      }
+
+      expect(thrown).toBe(error);
+    });
+
+    it("matches structurally tagged errors without requiring TaggedError methods", () => {
+      const error = new StructuralTaggedError("structural");
+      const outcome = matchError(error, {
+        StructuralTaggedError: (e) => e.message,
+      });
+
+      expect(outcome).toBe("structural");
+    });
+
     it("works data-last (pipeable)", () => {
       const error: AppError = new NotFoundError({ id: "456", message: "not found" });
       const matcher = matchError<AppError, string>({
@@ -298,6 +335,26 @@ describe("TaggedError", () => {
         message: "failed",
       });
       expect(matchPartialAppError(error)).toBe("fallback: NetworkError");
+    });
+
+    it("propagates an exception from the selected fallback", () => {
+      const throwSelectedFallback = (error: AppError) =>
+        matchErrorPartial(error, { NotFoundError: (e) => `missing: ${e.id}` }, (e) => {
+          throw e;
+        });
+      const error = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      let thrown: unknown;
+      try {
+        throwSelectedFallback(error);
+      } catch (cause) {
+        thrown = cause;
+      }
+
+      expect(thrown).toBe(error);
     });
 
     it("narrows fallback type to exclude handled errors (data-first)", () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -122,12 +122,12 @@ export type TaggedErrorClass<Tag extends string> = {
 };
 
 /** Handler map for exhaustive matching (returns inferred per-handler) */
-type MatchHandlers<E extends AnyTaggedError> = {
+type MatchHandlers<E extends TaggedErrorLike> = {
   [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => unknown;
 };
 
 /** Handler map constraining every handler to return `R` */
-type MatchHandlersWithReturn<E extends AnyTaggedError, R> = {
+type MatchHandlersWithReturn<E extends TaggedErrorLike, R> = {
   [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => R;
 };
 
@@ -137,7 +137,7 @@ type MatchReturn<H> = {
 }[keyof H];
 
 /** Partial handler map for non-exhaustive matching */
-type PartialMatchHandlers<E extends AnyTaggedError, R> = Partial<MatchHandlersWithReturn<E, R>>;
+type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlersWithReturn<E, R>>;
 
 /** Extract handled tags from a handlers object */
 type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
@@ -160,16 +160,16 @@ type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
  */
 export const matchError: {
   /** Data-last, E deferred to application; returns the union of handler returns */
-  <H extends MatchHandlers<AnyTaggedError>>(
+  <H extends MatchHandlers<TaggedErrorLike>>(
     handlers: H,
-  ): <E extends AnyTaggedError & { _tag: keyof H }>(err: E) => MatchReturn<H>;
+  ): <E extends TaggedErrorLike & { _tag: keyof H }>(err: E) => MatchReturn<H>;
   /** Data-last with explicit E, R constraining every handler return */
-  <E extends AnyTaggedError, R>(handlers: MatchHandlersWithReturn<E, R>): (err: E) => R;
+  <E extends TaggedErrorLike, R>(handlers: MatchHandlersWithReturn<E, R>): (err: E) => R;
   /** Data-first, inferred; returns the union of handler returns */
-  <E extends AnyTaggedError, H extends MatchHandlers<E>>(err: E, handlers: H): MatchReturn<H>;
+  <E extends TaggedErrorLike, H extends MatchHandlers<E>>(err: E, handlers: H): MatchReturn<H>;
   /** Data-first with explicit R constraining every handler return */
-  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlersWithReturn<E, R>): R;
-} = dual(2, <E extends AnyTaggedError>(err: E, handlers: MatchHandlers<E>): unknown => {
+  <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlersWithReturn<E, R>): R;
+} = dual(2, <E extends TaggedErrorLike>(err: E, handlers: MatchHandlers<E>): unknown => {
   const handler = handlers[err._tag as E["_tag"]];
   // SAFETY: exhaustiveness is enforced at the type level
   return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
@@ -184,16 +184,16 @@ export const matchError: {
  * }, (e) => `Unknown: ${e.message}`);
  */
 export const matchErrorPartial: {
-  /** Pipeable — E deferred to call site, fallback receives AnyTaggedError */
-  <H extends Partial<MatchHandlers<AnyTaggedError>>, R>(
+  /** Pipeable — E deferred to call site, fallback receives a tagged error-like value */
+  <H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
     handlers: H,
-    fallback: (e: AnyTaggedError) => R,
+    fallback: (e: TaggedErrorLike) => R,
   ): {
-    <E extends AnyTaggedError>(err: E): MatchReturn<H> | R;
+    <E extends TaggedErrorLike>(err: E): MatchReturn<H> | R;
   };
   /** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
   <
-E extends AnyTaggedError,
+    E extends TaggedErrorLike,
     R,
     const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
   >(
@@ -201,14 +201,14 @@ E extends AnyTaggedError,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): (err: E) => R;
   /** Data-first with inference — E from err, H from handlers, R from fallback */
-  <E extends AnyTaggedError, const H extends Partial<MatchHandlers<E>>, R>(
+  <E extends TaggedErrorLike, const H extends Partial<MatchHandlers<E>>, R>(
     err: E,
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): MatchReturn<H> | R;
   /** Data-first with explicit R — H inferred via default, fallback narrowed */
   <
-    E extends AnyTaggedError,
+    E extends TaggedErrorLike,
     R,
     const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
   >(
@@ -218,10 +218,10 @@ E extends AnyTaggedError,
   ): R;
 } = dual(
   3,
-(
-    err: AnyTaggedError,
-    handlers: Partial<MatchHandlers<AnyTaggedError>>,
-    fallback: (e: AnyTaggedError) => unknown,
+  (
+    err: TaggedErrorLike,
+    handlers: Partial<MatchHandlers<TaggedErrorLike>>,
+    fallback: (e: TaggedErrorLike) => unknown,
   ): unknown => {
     const handler = handlers[err._tag];
     if (typeof handler === "function") {

--- a/src/error.ts
+++ b/src/error.ts
@@ -121,13 +121,23 @@ export type TaggedErrorClass<Tag extends string> = {
   is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C>;
 };
 
-/** Handler map for exhaustive matching */
-type MatchHandlers<E extends TaggedErrorLike, R> = {
+/** Handler map for exhaustive matching (returns inferred per-handler) */
+type MatchHandlers<E extends AnyTaggedError> = {
+  [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => unknown;
+};
+
+/** Handler map constraining every handler to return `R` */
+type MatchHandlersWithReturn<E extends AnyTaggedError, R> = {
   [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => R;
 };
 
+/** Union of every handler's return type */
+type MatchReturn<H> = {
+  [K in keyof H]: H[K] extends (err: never) => infer R ? R : never;
+}[keyof H];
+
 /** Partial handler map for non-exhaustive matching */
-type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlers<E, R>>;
+type PartialMatchHandlers<E extends AnyTaggedError, R> = Partial<MatchHandlersWithReturn<E, R>>;
 
 /** Extract handled tags from a handlers object */
 type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
@@ -149,11 +159,19 @@ type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
  * }));
  */
 export const matchError: {
-  <E extends TaggedErrorLike, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
-  <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlers<E, R>): R;
-} = dual(2, <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlers<E, R>): R => {
+  /** Data-last, E deferred to application; returns the union of handler returns */
+  <H extends MatchHandlers<AnyTaggedError>>(
+    handlers: H,
+  ): <E extends AnyTaggedError & { _tag: keyof H }>(err: E) => MatchReturn<H>;
+  /** Data-last with explicit E, R constraining every handler return */
+  <E extends AnyTaggedError, R>(handlers: MatchHandlersWithReturn<E, R>): (err: E) => R;
+  /** Data-first, inferred; returns the union of handler returns */
+  <E extends AnyTaggedError, H extends MatchHandlers<E>>(err: E, handlers: H): MatchReturn<H>;
+  /** Data-first with explicit R constraining every handler return */
+  <E extends AnyTaggedError, R>(err: E, handlers: MatchHandlersWithReturn<E, R>): R;
+} = dual(2, <E extends AnyTaggedError>(err: E, handlers: MatchHandlers<E>): unknown => {
   const handler = handlers[err._tag as E["_tag"]];
-  // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
+  // SAFETY: exhaustiveness is enforced at the type level
   return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
 });
 
@@ -166,34 +184,50 @@ export const matchError: {
  * }, (e) => `Unknown: ${e.message}`);
  */
 export const matchErrorPartial: {
+  /** Pipeable — E deferred to call site, fallback receives AnyTaggedError */
+  <H extends Partial<MatchHandlers<AnyTaggedError>>, R>(
+    handlers: H,
+    fallback: (e: AnyTaggedError) => R,
+  ): {
+    <E extends AnyTaggedError>(err: E): MatchReturn<H> | R;
+  };
+  /** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
   <
-    E extends TaggedErrorLike,
+E extends AnyTaggedError,
     R,
     const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
   >(
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): (err: E) => R;
-  <E extends TaggedErrorLike, R, const H extends PartialMatchHandlers<E, R>>(
+  /** Data-first with inference — E from err, H from handlers, R from fallback */
+  <E extends AnyTaggedError, const H extends Partial<MatchHandlers<E>>, R>(
+    err: E,
+    handlers: H,
+    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+  ): MatchReturn<H> | R;
+  /** Data-first with explicit R — H inferred via default, fallback narrowed */
+  <
+    E extends AnyTaggedError,
+    R,
+    const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
+  >(
     err: E,
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): R;
 } = dual(
   3,
-  <E extends TaggedErrorLike, R, H extends PartialMatchHandlers<E, R>>(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: HandledTags<E, H> }>) => R,
-  ): R => {
-    type K = HandledTags<E, H>;
-    const handler = handlers[err._tag as K];
+(
+    err: AnyTaggedError,
+    handlers: Partial<MatchHandlers<AnyTaggedError>>,
+    fallback: (e: AnyTaggedError) => unknown,
+  ): unknown => {
+    const handler = handlers[err._tag];
     if (typeof handler === "function") {
-      // SAFETY: handler exists and matches the tag
-      return handler(err as Parameters<NonNullable<typeof handler>>[0]);
+      return handler(err);
     }
-    // SAFETY: If no handler matched, err is in the Exclude type
-    return fallback(err as Exclude<E, { _tag: K }>);
+    return fallback(err);
   },
 );
 


### PR DESCRIPTION
`matchError` and `matchErrorPartial` previously constrained all handlers to return the same type `R`, forcing callers to widen returns manually. This change allows each handler to return a different type, inferred as a union — with `never` dropped automatically for throwing handlers.

## Changes

- **`src/error.ts`**: Split `MatchHandlers<E, R>` into `MatchHandlers<E>` (inferred per-handler returns) and `MatchHandlersWithReturn<E, R>` (explicit return constraint). Added `MatchReturn<H>` to compute the union of handler returns. Updated `matchError` and `matchErrorPartial` overloads to prefer inference by default, with explicit `R` overloads retained for backward compatibility.
- **`src/error.test-d.ts`**: Comprehensive type-level tests covering inferred unions, `never` dropping, handler param narrowing, exhaustiveness enforcement, and both data-first and data-last forms — including the deferred-`E` pipeable case where the fallback must remain accessible.

## Why

The previous `MatchHandlers<E, R>` signature forced all handlers to return the same `R`. When a branch threw (returning `never`), the inferred `R` collapsed to `never` instead of the correct non-never handler return type. By decoupling handler return types and computing the union through `MatchReturn<H>`, each branch infers independently and `never` contributions are dropped naturally — the non-throwing handlers determine the result type without widening or explicit annotations.
