### PR TITLE
Make `Ok<void>` round-trips through JSON transports safe

### DIFF
--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1685,8 +1685,8 @@ describe("Result", () => {
         { foo: "bar" },
         null,
         42,
-        { status: "ok" }, // missing value
-        { status: "error" }, // missing error
+        { status: "nope" }, // invalid status
+        { value: 42 }, // missing status
       ];
 
       for (const input of testCases) {
@@ -1697,6 +1697,33 @@ describe("Result", () => {
           expect((result.error as ResultDeserializationError).value).toBe(input);
         }
       }
+    });
+
+    it("deserializes a missing value key as Ok<undefined>", () => {
+      // JSON transports drop undefined-valued keys, so a serialized
+      // Ok<void> arrives as `{ status: "ok" }` without a value key
+      const result = Result.deserialize<undefined, never>({ status: "ok" });
+      expect(result).toBeInstanceOf(Ok);
+      expect(result.unwrap()).toBe(undefined);
+    });
+
+    it("deserializes a missing error key as Err<undefined>", () => {
+      const result = Result.deserialize<never, undefined>({ status: "error" });
+      expect(result).toBeInstanceOf(Err);
+      if (Result.isError(result)) {
+        expect(result.error).toBe(undefined);
+      }
+    });
+
+    it("excludes ResultDeserializationError when input is a typed SerializedResult", () => {
+      const serialized = Result.serialize(Result.ok<number, string>(42));
+      const result = Result.deserialize(serialized);
+      expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+      expect(result.unwrap()).toBe(42);
+
+      const untyped: unknown = serialized;
+      const guarded = Result.deserialize<number, string>(untyped);
+      expectTypeOf(guarded).toEqualTypeOf<Result<number, string | ResultDeserializationError>>();
     });
 
     it("deserializes complex values", () => {
@@ -1734,6 +1761,17 @@ describe("Result", () => {
       const deserialized = Result.deserialize<{ id: number; data: number[] }, never>(parsed);
 
       expect(deserialized?.unwrap()).toEqual({ id: 1, data: [1, 2, 3] });
+    });
+
+    it("roundtrips Ok<void> through JSON.stringify/parse", () => {
+      // JSON.stringify drops the undefined-valued `value` key entirely,
+      // so this arrives as `{"status":"ok"}` on the other side
+      const json = JSON.stringify(Result.serialize(Result.ok()));
+      expect(json).toBe('{"status":"ok"}');
+
+      const deserialized = Result.deserialize<void, never>(JSON.parse(json));
+      expect(deserialized).toBeInstanceOf(Ok);
+      expect(deserialized.unwrap()).toBe(undefined);
     });
   });
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -446,11 +446,15 @@ export interface SerializedErr<E> {
 export type SerializedResult<T, E> = SerializedOk<T> | SerializedErr<E>;
 
 function isSerializedResult(obj: unknown): obj is SerializedResult<unknown, unknown> {
+  // The `value`/`error` keys are intentionally not required.
+  // JSON transports drop keys whose value is `undefined` (JSON.stringify omits them, and JSON.parse revivers delete them),
+  // so a serialized Ok<void> arrives as `{ status: "ok" }`.
+  // A missing key deserializes as `undefined`.
   return (
     obj !== null &&
     typeof obj === "object" &&
     "status" in obj &&
-    ((obj.status === "ok" && "value" in obj) || (obj.status === "error" && "error" in obj))
+    (obj.status === "ok" || obj.status === "error")
   );
 }
 
@@ -460,14 +464,16 @@ const serialize = <T, E>(result: Result<T, E>): SerializedResult<T, E> => {
     : { status: "error", error: result.error };
 };
 
-const deserialize = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
+function deserialize<T, E>(value: SerializedResult<T, E>): Result<T, E>;
+function deserialize<T, E>(value: unknown): Result<T, E | ResultDeserializationError>;
+function deserialize<T, E>(value: unknown): Result<T, E | ResultDeserializationError> {
   if (isSerializedResult(value)) {
     return value.status === "ok"
-      ? (new Ok(value.value) as Result<T, E>)
-      : (new Err(value.error) as Result<T, E>);
+      ? (new Ok((value as SerializedOk<T>).value) as Result<T, E>)
+      : (new Err((value as SerializedErr<E>).error) as Result<T, E>);
   }
   return err(new ResultDeserializationError({ value }));
-};
+}
 
 /**
  * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.


### PR DESCRIPTION
## Problem

`Result.serialize(Result.ok())` produces `{ status: "ok", value: undefined }`, but `JSON.stringify` omits undefined-valued keys (and `JSON.parse` revivers delete them), so the other side of any JSON transport receives `{ "status": "ok" }`.

`isSerializedResult` requires the `value` key to exist, so `Result.deserialize` rejects it with `ResultDeserializationError`, meaning `Result<void, E>` cannot round-trip at all.

The existing test suite makes two promises that contradict each other:

- `Ok<void> serializes correctly` -> `{ status: "ok", value: undefined }`
- `roundtrips through JSON.stringify/parse`

Both cannot hold with the strict key check, since the JSON step erases the key.

I hit this in production-shaped code with RSC; the client-side `Result.deserialize` failed on a perfectly valid response.

## Changes

1. **`isSerializedResult` no longer requires the `value`/`error` key.** An object with `status: "ok" | "error"` is a valid serialized Result; a missing key deserializes as `undefined`. Inputs without a valid `status` are still rejected. This is a behavior change for `{ status: "ok" }`-shaped input (previously `Err<ResultDeserializationError>`, now `Ok(undefined)`), which is what such input means on the receiving end of a JSON transport.

2. **`deserialize` gains a typed overload.** When the input is already typed `SerializedResult<T, E>` (e.g. the declared return type of your own server action), the returned union is `Result<T, E>` without `ResultDeserializationError`; the guard cannot fail for that input, so callers no longer need to handle an impossible branch. `unknown` input keeps the current signature.