### PR TITLE
allow aborting retry delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,26 @@ const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(ur
 });
 ```
 
+### Cancelling Retries
+
+Pass an `AbortSignal` to stop a pending delay and prevent later retry attempts:
+
+```ts
+const controller = new AbortController();
+
+const result = await Result.tryPromise(() => fetch(url, { signal: controller.signal }), {
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "exponential",
+    signal: controller.signal,
+  },
+});
+```
+
+The signal only controls retry scheduling. Pass it to the operation as well when the current attempt
+must also be cancelled.
+
 ### Conditional Retry
 
 Retry only for specific error types using `shouldRetry`:

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -448,6 +448,58 @@ describe("Result", () => {
       expect(Result.isError(result)).toBe(true);
     });
 
+    it("does not retry when the signal is already aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      let attempts = 0;
+
+      const result = await Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+            signal: controller.signal,
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+    });
+
+    it("interrupts a pending retry delay when the signal is aborted", async () => {
+      const controller = new AbortController();
+      let attempts = 0;
+      const start = Date.now();
+
+      const pending = Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          retry: {
+            times: 3,
+            delayMs: 10_000,
+            backoff: "constant",
+            signal: controller.signal,
+          },
+        },
+      );
+
+      setTimeout(() => controller.abort(), 10);
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+      expect(Date.now() - start).toBeLessThan(500);
+    });
+
     it("throws Panic when shouldRetry predicate throws", async () => {
       await expect(
         Result.tryPromise(

--- a/src/result.ts
+++ b/src/result.ts
@@ -95,6 +95,8 @@ type RetryConfig<E = unknown> = {
     backoff: "linear" | "constant" | "exponential";
     /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
     shouldRetry?: (error: E) => boolean;
+    /** Stops a pending delay and prevents further retry attempts when aborted. */
+    signal?: AbortSignal;
   };
 };
 
@@ -153,7 +155,24 @@ const tryPromise: {
     }
   };
 
-  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const sleep = (ms: number, signal?: AbortSignal): Promise<boolean> =>
+    new Promise((resolve) => {
+      if (signal?.aborted) {
+        resolve(false);
+        return;
+      }
+
+      const onAbort = () => {
+        clearTimeout(timeout);
+        resolve(false);
+      };
+      const timeout = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve(true);
+      }, ms);
+
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
 
   let attempt = 1;
   let result = await execute({ attempt });
@@ -162,10 +181,12 @@ const tryPromise: {
 
   for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
     if (result.status !== "error") break;
+    if (retry.signal?.aborted) break;
     const error = result.error;
     const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
     if (!shouldContinue) break;
-    await sleep(getDelay(retryAttempt));
+    const delayCompleted = await sleep(getDelay(retryAttempt), retry.signal);
+    if (!delayCompleted || retry.signal?.aborted) break;
     attempt++;
     result = await execute({ attempt });
   }


### PR DESCRIPTION
fixes #91

retry config now accepts an optional `AbortSignal`. aborting it stops a pending delay and prevents later attempts while preserving the latest typed result.

the signal only controls retry scheduling, so the documentation shows passing the same signal to the underlying operation when the current attempt also needs cancellation.

validation

* `bun test` with 231 passing tests
* `bun run check`
* `bun run lint`
* `bun run fmt:check`
* `bun run build`