### PR TITLE
Add AbortSignal context to Result.tryPromise

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(ur
 });
 ```
 
-Pass an abort signal in the top-level config to forward it to every attempt. The same signal and the failed attempt number are available in the `shouldRetry` context:
+Pass an abort signal in the top-level config to interrupt a pending retry delay and prevent later retries. The signal is also forwarded to every attempt so the try callback can cancel abort-aware operations:
 
 ```ts
 const controller = new AbortController();
@@ -277,12 +277,13 @@ const result = await Result.tryPromise(({ signal }) => fetch(url, { signal }), {
     times: 3,
     delayMs: 100,
     backoff: "constant",
-    shouldRetry: (_error, { signal }) => !signal?.aborted,
   },
 });
 ```
 
-`Result.tryPromise` forwards the signal but does not abort operations or retry delays itself. The try callback must pass it to abort-aware operations, and `shouldRetry` controls whether an aborted failure is retried.
+The same signal and failed attempt number are available as the second `shouldRetry` argument for custom retry decisions: `shouldRetry: (error, { attempt, signal }) => boolean`.
+
+`Result.tryPromise` cannot abort an operation by itself. The try callback must pass the signal to operations such as `fetch` that support cancellation. When aborted, retry scheduling stops and the latest typed result is returned.
 
 ### Conditional Retry
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ const result = await Result.tryPromise(() => fetch(url), {
 });
 ```
 
-The try callback receives a `TryContext` with a 1-based `attempt` number:
+The async try callback receives a `TryPromiseContext` with a 1-based `attempt` number and the optional top-level abort signal. The synchronous `Result.try` callback continues to receive a `TryContext` containing only `attempt`.
 
 ```ts
 const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(url, attempt), {

--- a/README.md
+++ b/README.md
@@ -266,6 +266,24 @@ const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(ur
 });
 ```
 
+Pass an abort signal in the top-level config to forward it to every attempt. The same signal and the failed attempt number are available in the `shouldRetry` context:
+
+```ts
+const controller = new AbortController();
+
+const result = await Result.tryPromise(({ signal }) => fetch(url, { signal }), {
+  signal: controller.signal,
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "constant",
+    shouldRetry: (_error, { signal }) => !signal?.aborted,
+  },
+});
+```
+
+`Result.tryPromise` forwards the signal but does not abort operations or retry delays itself. The try callback must pass it to abort-aware operations, and `shouldRetry` controls whether an aborted failure is retried.
+
 ### Conditional Retry
 
 Retry only for specific error types using `shouldRetry`:

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
   SerializedOk,
   SerializedErr,
   TryContext,
+  TryPromiseContext,
 } from "./result";
 export {
   Panic,

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -301,6 +301,125 @@ describe("Result", () => {
       expect(Result.isError(result)).toBe(true);
     });
 
+    it("passes the configured abort signal to the try context without retries", async () => {
+      const abortController = new AbortController();
+
+      const result = await Result.tryPromise(
+        ({ signal }) => {
+          expectTypeOf(signal).toEqualTypeOf<AbortSignal | undefined>();
+          expect(signal).toBe(abortController.signal);
+          return Promise.resolve(42);
+        },
+        { signal: abortController.signal },
+      );
+
+      expect(result.unwrap()).toBe(42);
+    });
+
+    it("passes the configured abort signal to the object overload", async () => {
+      const abortController = new AbortController();
+
+      const result = await Result.tryPromise(
+        {
+          try: ({ signal }) => {
+            expectTypeOf(signal).toEqualTypeOf<AbortSignal | undefined>();
+            expect(signal).toBe(abortController.signal);
+            return Promise.resolve(42);
+          },
+          catch: () => new Error("failed"),
+        },
+        { signal: abortController.signal },
+      );
+
+      expect(result.unwrap()).toBe(42);
+    });
+
+    it("still invokes the try callback when the abort signal is already aborted", async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      let invoked = false;
+
+      const result = await Result.tryPromise(
+        ({ signal }) => {
+          invoked = true;
+          expect(signal?.aborted).toBe(true);
+          return Promise.resolve(42);
+        },
+        { signal: abortController.signal },
+      );
+
+      expect(invoked).toBe(true);
+      expect(result.unwrap()).toBe(42);
+    });
+
+    it("can stop retries when the abort signal is aborted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+
+      const result = await Result.tryPromise(
+        {
+          try: ({ signal }) => {
+            attempts++;
+            expect(signal).toBe(abortController.signal);
+            abortController.abort();
+            return Promise.reject(new Error("cancelled"));
+          },
+          catch: (cause) => ({ kind: "request-failure" as const, cause }),
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+            shouldRetry: (error, context) => {
+              expectTypeOf(error).toEqualTypeOf<{
+                kind: "request-failure";
+                cause: unknown;
+              }>();
+              expectTypeOf(context.signal).toEqualTypeOf<AbortSignal | undefined>();
+              return context.signal?.aborted !== true;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+    });
+
+    it("passes the abort signal and failed attempt to shouldRetry", async () => {
+      const abortController = new AbortController();
+      const tryContexts: Array<{ attempt: number; signal?: AbortSignal }> = [];
+      const retryContexts: Array<{ attempt: number; signal?: AbortSignal }> = [];
+
+      const result = await Result.tryPromise(
+        (context) => {
+          tryContexts.push(context);
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 2,
+            delayMs: 1,
+            backoff: "constant",
+            shouldRetry: (_error, context) => {
+              expectTypeOf(context.signal).toEqualTypeOf<AbortSignal | undefined>();
+              retryContexts.push(context);
+              return true;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(tryContexts.map(({ attempt }) => attempt)).toEqual([1, 2, 3]);
+      expect(retryContexts.map(({ attempt }) => attempt)).toEqual([1, 2]);
+      expect(tryContexts.every(({ signal }) => signal === abortController.signal)).toBe(true);
+      expect(retryContexts.every(({ signal }) => signal === abortController.signal)).toBe(true);
+    });
+
     it("supports retry with exponential backoff", async () => {
       let attempts = 0;
       const start = Date.now();

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { Result, Ok, Err } from "./result";
+import { Result, Ok, Err, type TryContext, type TryPromiseContext } from "./result";
 import { Panic, ResultDeserializationError, UnhandledException } from "./error";
+
+const longConstantRetryConfig = {
+  times: 3,
+  delayMs: 10_000,
+  backoff: "constant",
+} as const;
+
+const createDeferred = () => {
+  let resolve = () => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve } as const;
+};
 
 describe("Result", () => {
   describe("ok", () => {
@@ -303,6 +317,10 @@ describe("Result", () => {
 
     it("passes the configured abort signal to the try context without retries", async () => {
       const abortController = new AbortController();
+      type TryContextHasSignal = "signal" extends keyof TryContext ? true : false;
+
+      expectTypeOf<TryContextHasSignal>().toEqualTypeOf<false>();
+      expectTypeOf<TryPromiseContext["signal"]>().toEqualTypeOf<AbortSignal | undefined>();
 
       const result = await Result.tryPromise(
         ({ signal }) => {
@@ -374,11 +392,7 @@ describe("Result", () => {
         },
         {
           signal: abortController.signal,
-          retry: {
-            times: 3,
-            delayMs: 10_000,
-            backoff: "constant",
-          },
+          retry: longConstantRetryConfig,
         },
       );
 
@@ -437,10 +451,7 @@ describe("Result", () => {
     it("interrupts a pending retry delay when the abort signal is aborted", async () => {
       const abortController = new AbortController();
       let attempts = 0;
-      let approveRetry = () => {};
-      const retryApproved = new Promise<void>((resolve) => {
-        approveRetry = resolve;
-      });
+      const retryApproved = createDeferred();
 
       const pending = Result.tryPromise(
         () => {
@@ -450,18 +461,16 @@ describe("Result", () => {
         {
           signal: abortController.signal,
           retry: {
-            times: 3,
-            delayMs: 10_000,
-            backoff: "constant",
+            ...longConstantRetryConfig,
             shouldRetry: () => {
-              approveRetry();
+              retryApproved.resolve();
               return true;
             },
           },
         },
       );
 
-      await retryApproved;
+      await retryApproved.promise;
       abortController.abort();
       const result = await pending;
 
@@ -482,9 +491,7 @@ describe("Result", () => {
         {
           signal: abortController.signal,
           retry: {
-            times: 3,
-            delayMs: 10_000,
-            backoff: "constant",
+            ...longConstantRetryConfig,
             shouldRetry: (_error, { signal }) => {
               retryDecisions++;
               abortController.abort();
@@ -503,10 +510,7 @@ describe("Result", () => {
     it("returns the latest typed error when a later retry delay is interrupted", async () => {
       const abortController = new AbortController();
       let attempts = 0;
-      let observeSecondFailure = () => {};
-      const secondFailureObserved = new Promise<void>((resolve) => {
-        observeSecondFailure = resolve;
-      });
+      const secondFailureObserved = createDeferred();
 
       const pending = Result.tryPromise(
         () => {
@@ -520,14 +524,14 @@ describe("Result", () => {
             delayMs: 1,
             backoff: "constant",
             shouldRetry: (_error, { attempt }) => {
-              if (attempt === 2) observeSecondFailure();
+              if (attempt === 2) secondFailureObserved.resolve();
               return true;
             },
           },
         },
       );
 
-      await secondFailureObserved;
+      await secondFailureObserved.promise;
       abortController.abort();
       const result = await pending;
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -345,16 +345,57 @@ describe("Result", () => {
           expect(signal?.aborted).toBe(true);
           return Promise.resolve(42);
         },
-        { signal: abortController.signal },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+          },
+        },
       );
 
       expect(invoked).toBe(true);
       expect(result.unwrap()).toBe(42);
     });
 
-    it("can stop retries when the abort signal is aborted", async () => {
+    it("cancels an in-flight abort-aware operation and prevents retries", async () => {
       const abortController = new AbortController();
       let attempts = 0;
+
+      const pending = Result.tryPromise(
+        ({ signal }) => {
+          attempts++;
+          return new Promise<never>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("operation aborted")), {
+              once: true,
+            });
+          });
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 10_000,
+            backoff: "constant",
+          },
+        },
+      );
+
+      abortController.abort();
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+      if (Result.isError(result)) {
+        expect(result.error.cause).toBeInstanceOf(Error);
+      }
+    });
+
+    it("automatically stops retries when the abort signal is aborted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      let retryDecisions = 0;
 
       const result = await Result.tryPromise(
         {
@@ -378,7 +419,8 @@ describe("Result", () => {
                 cause: unknown;
               }>();
               expectTypeOf(context.signal).toEqualTypeOf<AbortSignal | undefined>();
-              return context.signal?.aborted !== true;
+              retryDecisions++;
+              return true;
             },
           },
         },
@@ -386,6 +428,117 @@ describe("Result", () => {
 
       expect(Result.isError(result)).toBe(true);
       expect(attempts).toBe(1);
+      expect(retryDecisions).toBe(0);
+      if (Result.isError(result)) {
+        expect(result.error.kind).toBe("request-failure");
+      }
+    });
+
+    it("interrupts a pending retry delay when the abort signal is aborted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      let approveRetry = () => {};
+      const retryApproved = new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+
+      const pending = Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 10_000,
+            backoff: "constant",
+            shouldRetry: () => {
+              approveRetry();
+              return true;
+            },
+          },
+        },
+      );
+
+      await retryApproved;
+      abortController.abort();
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+    });
+
+    it("does not start a retry when shouldRetry aborts the signal", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      let retryDecisions = 0;
+
+      const result = await Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 10_000,
+            backoff: "constant",
+            shouldRetry: (_error, { signal }) => {
+              retryDecisions++;
+              abortController.abort();
+              expect(signal?.aborted).toBe(true);
+              return true;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+      expect(retryDecisions).toBe(1);
+    });
+
+    it("returns the latest typed error when a later retry delay is interrupted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      let observeSecondFailure = () => {};
+      const secondFailureObserved = new Promise<void>((resolve) => {
+        observeSecondFailure = resolve;
+      });
+
+      const pending = Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error(`attempt ${attempts} failed`));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+            shouldRetry: (_error, { attempt }) => {
+              if (attempt === 2) observeSecondFailure();
+              return true;
+            },
+          },
+        },
+      );
+
+      await secondFailureObserved;
+      abortController.abort();
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(2);
+      if (Result.isError(result)) {
+        expect(result.error.cause).toBeInstanceOf(Error);
+        if (result.error.cause instanceof Error) {
+          expect(result.error.cause.message).toBe("attempt 2 failed");
+        }
+      }
     });
 
     it("passes the abort signal and failed attempt to shouldRetry", async () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -19,11 +19,15 @@ export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
 export type Result<T, E> = import("./core").Result<T, E>;
 
-/** Context passed to each `Result.try` or `Result.tryPromise` attempt. */
+/** Context passed to each `Result.try` attempt. */
 export type TryContext = {
   /** One-based execution count, including the initial attempt. */
   readonly attempt: number;
-  /** Abort signal supplied to `Result.tryPromise`; absent for `Result.try`. */
+};
+
+/** Context passed to each `Result.tryPromise` attempt and retry decision. */
+export type TryPromiseContext = TryContext & {
+  /** Abort signal supplied through the top-level `Result.tryPromise` config. */
   readonly signal?: AbortSignal;
 };
 
@@ -100,29 +104,34 @@ type RetryConfig<E = unknown> = {
     delayMs: number;
     backoff: "linear" | "constant" | "exponential";
     /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
-    shouldRetry?: (error: E, context: TryContext) => boolean;
+    shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
   };
 };
 
 const tryPromise: {
   <A, E>(
     options: {
-      try: (context: TryContext) => Promise<A>;
+      try: (context: TryPromiseContext) => Promise<A>;
       catch: (cause: unknown) => E | Promise<E>;
     },
     config?: RetryConfig<E>,
   ): Promise<Result<A, E>>;
   <A>(
-    thunk: (context: TryContext) => Promise<A>,
+    thunk: (context: TryPromiseContext) => Promise<A>,
     config?: RetryConfig<UnhandledException>,
   ): Promise<Result<A, UnhandledException>>;
 } = async <A, E>(
   options:
-    | ((context: TryContext) => Promise<A>)
-    | { try: (context: TryContext) => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
+    | ((context: TryPromiseContext) => Promise<A>)
+    | {
+        try: (context: TryPromiseContext) => Promise<A>;
+        catch: (cause: unknown) => E | Promise<E>;
+      },
   config?: RetryConfig<E | UnhandledException>,
 ): Promise<Result<A, E | UnhandledException>> => {
-  const execute = async (context: TryContext): Promise<Result<A, E | UnhandledException>> => {
+  const execute = async (
+    context: TryPromiseContext,
+  ): Promise<Result<A, E | UnhandledException>> => {
     if (typeof options === "function") {
       try {
         return ok(await options(context));
@@ -178,7 +187,7 @@ const tryPromise: {
       signal?.addEventListener("abort", onAbort, { once: true });
     });
 
-  let context: TryContext = { attempt: 1, signal: config.signal };
+  let context: TryPromiseContext = { attempt: 1, signal: config.signal };
   let result = await execute(context);
 
   const shouldRetryFn = retry.shouldRetry ?? (() => true);

--- a/src/result.ts
+++ b/src/result.ts
@@ -159,7 +159,24 @@ const tryPromise: {
     }
   };
 
-  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>
+    new Promise((resolve) => {
+      if (signal?.aborted) {
+        resolve(false);
+        return;
+      }
+
+      const onAbort = () => {
+        clearTimeout(timeout);
+        resolve(false);
+      };
+      const timeout = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve(true);
+      }, ms);
+
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
 
   let context: TryContext = { attempt: 1, signal: config.signal };
   let result = await execute(context);
@@ -167,14 +184,15 @@ const tryPromise: {
   const shouldRetryFn = retry.shouldRetry ?? (() => true);
 
   for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
-    if (result.status !== "error") break;
+    if (result.status !== "error" || context.signal?.aborted) break;
     const error = result.error;
     const shouldContinue = tryOrPanic(
       () => shouldRetryFn(error, context),
       "shouldRetry predicate threw",
     );
     if (!shouldContinue) break;
-    await sleep(getDelay(retryAttempt));
+    const delayCompleted = await sleepForRetryDelay(getDelay(retryAttempt), context.signal);
+    if (!delayCompleted || context.signal?.aborted) break;
     context = { attempt: context.attempt + 1, signal: config.signal };
     result = await execute(context);
   }
@@ -562,7 +580,7 @@ export const Result = {
    * Executes async function, wraps result/error in Result with retry support.
    *
    * @example
-   * // Basic retry with cancellation forwarded to each attempt
+   * // Basic retry with cancellation forwarded to each attempt and retry delay
    * await Result.tryPromise(({ signal }) => fetch(url, { signal }), {
    *   signal: abortController.signal,
    *   retry: { times: 3, delayMs: 100, backoff: "exponential" }

--- a/src/result.ts
+++ b/src/result.ts
@@ -19,8 +19,12 @@ export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
 export type Result<T, E> = import("./core").Result<T, E>;
 
+/** Context passed to each `Result.try` or `Result.tryPromise` attempt. */
 export type TryContext = {
+  /** One-based execution count, including the initial attempt. */
   readonly attempt: number;
+  /** Abort signal supplied to `Result.tryPromise`; absent for `Result.try`. */
+  readonly signal?: AbortSignal;
 };
 
 /** Executes fn, panics if it throws. */
@@ -89,12 +93,14 @@ const tryFn: {
 };
 
 type RetryConfig<E = unknown> = {
+  /** Abort signal forwarded unchanged to every try and retry-decision context. */
+  signal?: AbortSignal;
   retry?: {
     times: number;
     delayMs: number;
     backoff: "linear" | "constant" | "exponential";
     /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
-    shouldRetry?: (error: E) => boolean;
+    shouldRetry?: (error: E, context: TryContext) => boolean;
   };
 };
 
@@ -139,7 +145,7 @@ const tryPromise: {
   const retry = config?.retry;
 
   if (!retry) {
-    return execute({ attempt: 1 });
+    return execute({ attempt: 1, signal: config?.signal });
   }
 
   const getDelay = (retryAttempt: number): number => {
@@ -155,19 +161,22 @@ const tryPromise: {
 
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-  let attempt = 1;
-  let result = await execute({ attempt });
+  let context: TryContext = { attempt: 1, signal: config.signal };
+  let result = await execute(context);
 
   const shouldRetryFn = retry.shouldRetry ?? (() => true);
 
   for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
     if (result.status !== "error") break;
     const error = result.error;
-    const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
+    const shouldContinue = tryOrPanic(
+      () => shouldRetryFn(error, context),
+      "shouldRetry predicate threw",
+    );
     if (!shouldContinue) break;
     await sleep(getDelay(retryAttempt));
-    attempt++;
-    result = await execute({ attempt });
+    context = { attempt: context.attempt + 1, signal: config.signal };
+    result = await execute(context);
   }
 
   return result;
@@ -553,8 +562,9 @@ export const Result = {
    * Executes async function, wraps result/error in Result with retry support.
    *
    * @example
-   * // Basic retry
-   * await Result.tryPromise(() => fetch(url), {
+   * // Basic retry with cancellation forwarded to each attempt
+   * await Result.tryPromise(({ signal }) => fetch(url, { signal }), {
+   *   signal: abortController.signal,
    *   retry: { times: 3, delayMs: 100, backoff: "exponential" }
    * })
    *


### PR DESCRIPTION
## Summary

- add an optional top-level `signal` to `Result.tryPromise` configuration
- introduce `TryPromiseContext` for async attempts while keeping synchronous `TryContext` limited to `attempt`
- forward the signal to every async try attempt through `TryPromiseContext`
- pass the failed attempt context, including the signal, as the second `shouldRetry` argument
- interrupt pending retry delays and prevent later retries when the signal aborts
- preserve the latest typed result when cancellation stops retry scheduling
- document operation cancellation and cancellation-aware retry behavior
- cover both overloads, pre-aborted signals, in-flight cancellation, aborts before and during retry delays, aborts during retry decisions, later-attempt cancellation, and type inference

The signal intentionally lives at the top level because it governs the complete async operation and retry lifecycle, rather than retry scheduling alone.

`Result.tryPromise` forwards the signal to operations but cannot cancel them itself; callers pass the context signal to abort-aware operations such as `fetch`. Retry scheduling observes the signal directly.

Includes the abort-aware retry-delay behavior proposed in #93.

Closes #91.

## Verification

- `bun run check`
- `bun run test` (238 tests)
- `bun run lint`
- `bun run fmt:check`
- `bun run build`
