### PR TITLE
Default matchErrorPartial fallback to identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,21 @@ matchError(error, {
   ValidationError: (e) => `Bad field: ${e.field}`,
 });
 
-// Partial matching with fallback
-matchErrorPartial(
+// Partial matching leaves unhandled errors unchanged by default
+const transformed = matchErrorPartial(error, {
+  NotFoundError: (e) => `Missing: ${e.id}`,
+});
+// string | ValidationError
+
+// In data-last form, annotate handlers that use variant-specific fields
+const transformError = matchErrorPartial({
+  NotFoundError: (e: NotFoundError) => `Missing: ${e.id}`,
+});
+const piped = transformError(error);
+// string | ValidationError
+
+// A custom fallback can transform unhandled errors
+const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },
   (e) => `Unknown: ${e.message}`,
@@ -716,15 +729,15 @@ Migration differences:
 
 ### TaggedError
 
-| Method                                 | Description                        |
-| -------------------------------------- | ---------------------------------- |
-| `TaggedError(tag)<Props>()`            | Factory for tagged error class     |
-| `TaggedError.is(value)`                | Type guard for any TaggedError     |
-| `matchError(err, handlers)`            | Exhaustive pattern match by `_tag` |
-| `matchErrorPartial(err, handlers, fb)` | Partial match with fallback        |
-| `isTaggedError(value)`                 | Type guard (standalone function)   |
-| `panic(message, cause?)`               | Throw unrecoverable Panic          |
-| `isPanic(value)`                       | Type guard for Panic               |
+| Method                                  | Description                                             |
+| --------------------------------------- | ------------------------------------------------------- |
+| `TaggedError(tag)<Props>()`             | Factory for tagged error class                          |
+| `TaggedError.is(value)`                 | Type guard for any TaggedError                          |
+| `matchError(err, handlers)`             | Exhaustive pattern match by `_tag`                      |
+| `matchErrorPartial(err, handlers, fb?)` | Partial match; unhandled errors pass through by default |
+| `isTaggedError(value)`                  | Type guard (standalone function)                        |
+| `panic(message, cause?)`                | Throw unrecoverable Panic                               |
+| `isPanic(value)`                        | Type guard for Panic                                    |
 
 ### Type Helpers
 

--- a/skills/better-result-adopt/references/tagged-errors.md
+++ b/skills/better-result-adopt/references/tagged-errors.md
@@ -107,13 +107,22 @@ const message = matchError(error, {
 });
 ```
 
-### Partial Match with Fallback
+### Partial Match
 
-Handle subset, catch-all for rest:
+Handle a subset while leaving unhandled errors unchanged:
 
 ```typescript
 import { matchErrorPartial } from "better-result";
 
+const transformed = matchErrorPartial(error, {
+  NotFoundError: (e) => `Missing: ${e.id}`,
+});
+// string | ValidationError | AuthError
+```
+
+Provide a custom fallback to transform the remaining errors:
+
+```typescript
 const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -1,9 +1,10 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { matchError, matchErrorPartial, Result, TaggedError } from "./index";
+import { matchError, matchErrorPartial, type Ok, Result, TaggedError } from "./index";
 
 class ErrorA extends TaggedError("ErrorA")<{}> {}
 class ErrorB extends TaggedError("ErrorB")<{}> {}
 class ErrorC extends TaggedError("ErrorC")<{}> {}
+class DetailedError extends TaggedError("DetailedError")<{ detail: string }> {}
 
 class StructuralTaggedError extends Error {
   readonly _tag = "StructuralTaggedError";
@@ -199,6 +200,90 @@ describe("matchErrorPartial", () => {
       (_err) => 0,
     );
     expectTypeOf(outcome).toEqualTypeOf<"specific" | number>();
+  });
+
+  it("infers handler returns and unhandled errors with data-first identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB | ErrorC>(new ErrorA());
+    const outcome = matchErrorPartial(result.error, {
+      ErrorA: (_err) => "handled" as const,
+    });
+    expectTypeOf(outcome).toEqualTypeOf<"handled" | ErrorB | ErrorC>();
+  });
+
+  it("infers handler returns and unhandled errors with data-last identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB | ErrorC>(new ErrorA());
+    const outcome = matchErrorPartial({
+      ErrorA: (_err) => "handled" as const,
+    })(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"handled" | ErrorB | ErrorC>();
+  });
+
+  it("accepts a concrete handler annotation in data-last identity form", () => {
+    const result = Result.err<void, DetailedError | ErrorB>(
+      new DetailedError({ detail: "context" }),
+    );
+    const outcome = matchErrorPartial({
+      DetailedError: (error: DetailedError) => Result.ok(error),
+    })(result.error);
+
+    expectTypeOf(outcome).toEqualTypeOf<Ok<DetailedError, never> | ErrorB>();
+  });
+
+  it("rejects a concrete handler annotation with a mismatched tag", () => {
+    const result = Result.err<void, DetailedError | ErrorB>(
+      new DetailedError({ detail: "context" }),
+    );
+    const matcher = matchErrorPartial({
+      // @ts-expect-error - ErrorB does not accept the DetailedError tag
+      DetailedError: (error: ErrorB) => Result.ok(error),
+    });
+
+    matcher(result.error);
+  });
+
+  it("infers the original error union for an empty identity handler map", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+
+    expectTypeOf(matchErrorPartial(result.error, {})).toEqualTypeOf<ErrorA | ErrorB>();
+    expectTypeOf(matchErrorPartial({})(result.error)).toEqualTypeOf<ErrorA | ErrorB>();
+  });
+
+  it("drops the identity branch when every error is handled", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(result.error, {
+      ErrorA: () => "A" as const,
+      ErrorB: () => 2 as const,
+    });
+    expectTypeOf(outcome).toEqualTypeOf<"A" | 2>();
+  });
+
+  it("keeps E conservatively with explicit E and R for identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const handlers = {
+      ErrorA: () => "A",
+    };
+
+    const dataFirst = matchErrorPartial<ErrorA | ErrorB, string>(result.error, handlers);
+    const dataLast = matchErrorPartial<ErrorA | ErrorB, string>(handlers)(result.error);
+    expectTypeOf(dataFirst).toEqualTypeOf<string | ErrorA | ErrorB>();
+    expectTypeOf(dataLast).toEqualTypeOf<string | ErrorA | ErrorB>();
+  });
+
+  it("excludes handled errors with explicit E, R, and H for identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const handlers = {
+      ErrorA: () => "A",
+    };
+
+    const dataFirst = matchErrorPartial<ErrorA | ErrorB, string, typeof handlers>(
+      result.error,
+      handlers,
+    );
+    const dataLast = matchErrorPartial<ErrorA | ErrorB, string, typeof handlers>(handlers)(
+      result.error,
+    );
+    expectTypeOf(dataFirst).toEqualTypeOf<string | ErrorB>();
+    expectTypeOf(dataLast).toEqualTypeOf<string | ErrorB>();
   });
 
   it("infers only the fallback return for an empty handler map", () => {

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -30,6 +30,10 @@ class StructuralTaggedError extends Error {
   readonly _tag = "StructuralTaggedError";
 }
 
+class InheritedPropertyTagError extends Error {
+  readonly _tag = "toString";
+}
+
 describe("TaggedError", () => {
   describe("construction", () => {
     it("sets name to tag", () => {
@@ -335,6 +339,67 @@ describe("TaggedError", () => {
         message: "failed",
       });
       expect(matchPartialAppError(error)).toBe("fallback: NetworkError");
+    });
+
+    it("uses the identity fallback in data-first form", () => {
+      const matchWithIdentity = (error: AppError) =>
+        matchErrorPartial(error, {
+          NotFoundError: (e) => `missing: ${e.id}`,
+        });
+      const handled = new NotFoundError({ id: "123", message: "not found" });
+      const unhandled = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      expect(matchWithIdentity(handled)).toBe("missing: 123");
+      expect(matchWithIdentity(unhandled)).toBe(unhandled);
+    });
+
+    it("uses the identity fallback in data-last form", () => {
+      const matchWithIdentity = matchErrorPartial({
+        NotFoundError: (e) => `handled: ${e._tag}`,
+      });
+      const handled = new NotFoundError({ id: "123", message: "not found" });
+      const unhandled = new ValidationError({ field: "email", message: "invalid" });
+
+      expect(matchWithIdentity(handled)).toBe("handled: NotFoundError");
+      expect(matchWithIdentity(unhandled)).toBe(unhandled);
+    });
+
+    it("is identity for an empty handler map", () => {
+      const error: AppError = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      expect(matchErrorPartial(error, {})).toBe(error);
+      expect(matchErrorPartial({})(error)).toBe(error);
+    });
+
+    it("returns an unhandled structural tagged error unchanged", () => {
+      const error = new StructuralTaggedError("structural");
+
+      expect(matchErrorPartial(error, {})).toBe(error);
+      expect(matchErrorPartial({})(error)).toBe(error);
+    });
+
+    it("ignores inherited handler properties", () => {
+      const error = new InheritedPropertyTagError("prototype collision");
+
+      expect(matchErrorPartial(error, {})).toBe(error);
+      expect(matchErrorPartial({})(error)).toBe(error);
+      expect(matchErrorPartial(error, {}, (unhandled) => unhandled)).toBe(error);
+    });
+
+    it("calls an explicitly defined handler that shares an inherited property name", () => {
+      const error = new InheritedPropertyTagError("own handler");
+
+      expect(
+        matchErrorPartial(error, {
+          toString: (handled) => `handled: ${handled.message}`,
+        }),
+      ).toBe("handled: own handler");
     });
 
     it("propagates an exception from the selected fallback", () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -140,8 +140,23 @@ type MatchReturn<H> = {
 /** Partial handler map for non-exhaustive matching */
 type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlersWithReturn<E, R>>;
 
+/** Deferred handlers with explicitly annotated concrete error parameters. */
+type AnnotatedMatchHandlers = Record<string, (err: never) => unknown>;
+
+/** Ensure each annotated handler parameter accepts the tag represented by its key. */
+type ValidateAnnotatedMatchHandlers<H extends AnnotatedMatchHandlers> = {
+  [K in keyof H]: H[K] extends (err: infer E extends TaggedErrorLike) => unknown
+    ? Extract<K, string> extends E["_tag"]
+      ? H[K]
+      : never
+    : never;
+};
+
 /** Extract handled tags from a handlers object */
 type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
+
+/** Error variants not selected by a partial handler map. */
+type UnhandledMatchErrors<E extends TaggedErrorLike, H> = Exclude<E, { _tag: HandledTags<E, H> }>;
 
 /**
  * Exhaustive pattern match on tagged error union.
@@ -176,61 +191,123 @@ export const matchError: {
   return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
 });
 
+const returnTaggedErrorIdentity = (error: TaggedErrorLike): TaggedErrorLike => error;
+
+const applyMatchErrorPartial = (
+  err: TaggedErrorLike,
+  handlers: Partial<MatchHandlers<TaggedErrorLike>>,
+  onUnhandled: (e: TaggedErrorLike) => unknown,
+): unknown => {
+  const handler = Object.hasOwn(handlers, err._tag) ? handlers[err._tag] : undefined;
+  if (typeof handler === "function") {
+    return handler(err);
+  }
+  return onUnhandled(err);
+};
+
 /**
- * Partial pattern match with fallback for unhandled tags.
+ * Partially matches tagged errors, returning unhandled errors unchanged by default.
  *
  * @example
- * matchErrorPartial(err, {
+ * const transformed = matchErrorPartial(err, {
  *   NotFoundError: (e) => `Missing: ${e.id}`,
- * }, (e) => `Unknown: ${e.message}`);
+ * });
+ *
+ * // Annotate variant-specific handlers when using the pipeable form.
+ * const transformError = matchErrorPartial({
+ *   NotFoundError: (e: NotFoundError) => `Missing: ${e.id}`,
+ * });
+ *
+ * // Supply a fallback to transform unhandled errors instead.
+ * const message = matchErrorPartial(
+ *   err,
+ *   { NotFoundError: (e) => `Missing: ${e.id}` },
+ *   (e) => `Unknown: ${e.message}`,
+ * );
  */
-export const matchErrorPartial: {
-  /** Pipeable — E deferred to call site, fallback receives a tagged error-like value */
-  <H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
-    handlers: H,
-    fallback: (e: TaggedErrorLike) => R,
-  ): {
-    <E extends TaggedErrorLike>(err: E): MatchReturn<H> | R;
-  };
-  /** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
-  <
-    E extends TaggedErrorLike,
-    R,
-    const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
-  >(
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): (err: E) => R;
-  /** Data-first with inference — E from err, H from handlers, R from fallback */
-  <E extends TaggedErrorLike, const H extends Partial<MatchHandlers<E>>, R>(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): MatchReturn<H> | R;
-  /** Data-first with explicit R — H inferred via default, fallback narrowed */
-  <
-    E extends TaggedErrorLike,
-    R,
-    const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
-  >(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): R;
-} = dual(
-  3,
-  (
-    err: TaggedErrorLike,
-    handlers: Partial<MatchHandlers<TaggedErrorLike>>,
-    fallback: (e: TaggedErrorLike) => unknown,
-  ): unknown => {
-    const handler = handlers[err._tag];
-    if (typeof handler === "function") {
-      return handler(err);
-    }
-    return fallback(err);
-  },
-);
+export function matchErrorPartial<H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
+  handlers: H,
+  fallback: (e: TaggedErrorLike) => R,
+): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | R;
+/** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
+>(handlers: H, fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R): (err: E) => R;
+/** Pipeable with identity fallback — E is deferred until the matcher is applied */
+export function matchErrorPartial<const H extends Partial<MatchHandlers<TaggedErrorLike>>>(
+  handlers: H,
+): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | UnhandledMatchErrors<E, H>;
+/** Pipeable with explicitly annotated handler parameters and identity fallback */
+export function matchErrorPartial<const H extends AnnotatedMatchHandlers>(
+  handlers: H & ValidateAnnotatedMatchHandlers<H>,
+): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | UnhandledMatchErrors<E, H>;
+/** Pipeable with explicit E, R and identity fallback — unhandled E remains conservative */
+export function matchErrorPartial<E extends TaggedErrorLike, R>(
+  handlers: PartialMatchHandlers<E, R>,
+): (err: E) => R | E;
+/** Pipeable with exact H and identity fallback — handled variants are excluded */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R>,
+>(handlers: H): (err: E) => R | UnhandledMatchErrors<E, H>;
+/** Data-first with identity fallback — returns handler results or unhandled variants */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  const H extends Partial<MatchHandlers<E>>,
+>(err: E, handlers: H): MatchReturn<H> | UnhandledMatchErrors<E, H>;
+/** Data-first with explicit E, R and identity fallback — unhandled E remains conservative */
+export function matchErrorPartial<E extends TaggedErrorLike, R>(
+  err: E,
+  handlers: PartialMatchHandlers<E, R>,
+): R | E;
+/** Data-first with exact H and identity fallback — handled variants are excluded */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R>,
+>(err: E, handlers: H): R | UnhandledMatchErrors<E, H>;
+/** Data-first with inference — E from err, H from handlers, R from fallback */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  const H extends Partial<MatchHandlers<E>>,
+  R,
+>(
+  err: E,
+  handlers: H,
+  fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+): MatchReturn<H> | R;
+/** Data-first with explicit R — H inferred via default, fallback narrowed */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
+>(err: E, handlers: H, fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R): R;
+export function matchErrorPartial(
+  errOrHandlers: TaggedErrorLike | Partial<MatchHandlers<TaggedErrorLike>>,
+  handlersOrFallback?: Partial<MatchHandlers<TaggedErrorLike>> | ((e: TaggedErrorLike) => unknown),
+  fallback?: (e: TaggedErrorLike) => unknown,
+): unknown {
+  if (typeof handlersOrFallback === "function") {
+    // SAFETY: In the two-argument pipeable overload, the first argument is the handler map.
+    const handlers = errOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
+    return (err: TaggedErrorLike): unknown =>
+      applyMatchErrorPartial(err, handlers, handlersOrFallback);
+  }
+
+  if (handlersOrFallback === undefined) {
+    // SAFETY: In the one-argument pipeable overload, the first argument is the handler map.
+    const handlers = errOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
+    return (err: TaggedErrorLike): unknown =>
+      applyMatchErrorPartial(err, handlers, returnTaggedErrorIdentity);
+  }
+
+  // SAFETY: In data-first overloads, the first argument is the tagged error.
+  const err = errOrHandlers as TaggedErrorLike;
+  return applyMatchErrorPartial(err, handlersOrFallback, fallback ?? returnTaggedErrorIdentity);
+}
 
 /**
  * Type guard for tagged error instances.


### PR DESCRIPTION
## Summary

- default `matchErrorPartial` to return unhandled errors unchanged
- support omitted fallbacks in both data-first and data-last forms while preserving existing custom-fallback calls
- preserve precise handled/unhandled union inference, including sound explicitly annotated concrete handlers in data-last form
- ignore inherited handler-map properties while still allowing explicitly defined collision keys such as `toString`
- document the identity fallback and add runtime/type-level coverage

The runtime uses shape-aware dispatch because the existing two-argument curried form `(handlers, fallback)` overlaps by arity with the new data-first form `(error, handlers)`.

Closes #71.

## Validation

- `bun run check`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`
- `bunx vitest --typecheck --run src/error.test.ts src/error.test-d.ts` (85 tests)
- `bun test` (257 tests)

`bun run test` still has the four pre-existing `Result.codec` failures present on the 3.0 baseline; all 52 runtime error tests and all 33 error type tests pass.
