### PR TITLE
Add dynamic retry delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,9 +312,31 @@ const result = await Result.tryPromise(
 );
 ```
 
+### Dynamic Retry Delays
+
+Pass a callback as `delayMs` when each error determines how long to wait. The callback receives the typed error and the context for the failed attempt. `times` remains required so every retry policy has an explicit limit:
+
+```ts
+const result = await Result.tryPromise(
+  {
+    try: () => callApi(url),
+    catch: (cause) => parseApiError(cause),
+  },
+  {
+    retry: {
+      times: 3,
+      shouldRetry: (error) => error.retryable,
+      delayMs: (error, { attempt }) => error.retryAfterMs,
+    },
+  },
+);
+```
+
+A dynamic `delayMs` returns the final delay before the next attempt and cannot be combined with `backoff` or `jitter`. If the callback throws, `Result.tryPromise` throws a `Panic`.
+
 ### Async Retry Decisions
 
-For retry decisions that require async operations (rate limits, feature flags, etc.), enrich the error in the `catch` handler instead of making `shouldRetry` async:
+Retry callbacks are synchronous. For decisions that require async operations (rate limits, feature flags, etc.), enrich the error in the `catch` handler before making the retry decision:
 
 ```ts
 class ApiError extends TaggedError("ApiError")<{

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -912,6 +912,82 @@ describe("Result", () => {
       }
     });
 
+    it("uses the typed error and failed-attempt context to choose each delay", async () => {
+      let attempts = 0;
+      const delayContexts: TryPromiseContext[] = [];
+      const start = Date.now();
+
+      const result = await Result.tryPromise(
+        {
+          try: () => {
+            attempts++;
+            if (attempts === 1) throw new Error("rate limited");
+            return Promise.resolve("success");
+          },
+          catch: () => ({ kind: "rate-limit" as const, retryAfterMs: 20 }),
+        },
+        {
+          retry: {
+            times: 1,
+            delayMs: (error, context) => {
+              expectTypeOf(error).toEqualTypeOf<{
+                kind: "rate-limit";
+                retryAfterMs: number;
+              }>();
+              expectTypeOf(context).toEqualTypeOf<TryPromiseContext>();
+              delayContexts.push(context);
+              return error.retryAfterMs;
+            },
+          },
+        },
+      );
+
+      expect(result.unwrap()).toBe("success");
+      expect(attempts).toBe(2);
+      expect(delayContexts.map(({ attempt }) => attempt)).toEqual([1]);
+      expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+    });
+
+    it("enforces times when delayMs is dynamic", async () => {
+      let attempts = 0;
+      let delayCalculations = 0;
+
+      const result = await Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          retry: {
+            times: 3,
+            delayMs: (error, context) => {
+              expectTypeOf(error).toEqualTypeOf<UnhandledException>();
+              expectTypeOf(context).toEqualTypeOf<TryPromiseContext>();
+              delayCalculations++;
+              return 0;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(4);
+      expect(delayCalculations).toBe(3);
+    });
+
+    it("throws Panic when a dynamic delay callback throws", async () => {
+      await expect(
+        Result.tryPromise(() => Promise.reject(new Error("fail")), {
+          retry: {
+            times: 1,
+            delayMs: () => {
+              throw new Error("delay callback bug");
+            },
+          },
+        }),
+      ).rejects.toBeInstanceOf(Panic);
+    });
+
     it("respects shouldRetry predicate", async () => {
       let attempts = 0;
       const result = await Result.tryPromise(
@@ -2987,6 +3063,29 @@ describe("Type Inference", () => {
           },
         );
         expectTypeOf(custom).toEqualTypeOf<Promise<ResultType<string, ErrorA>>>();
+      };
+
+      expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();
+    });
+
+    it("keeps backoff and jitter exclusive to static delays", () => {
+      const compileTimeOnly = () => {
+        // @ts-expect-error dynamic delayMs cannot be combined with static backoff.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: () => 100,
+            backoff: "constant",
+          },
+        });
+        // @ts-expect-error dynamic delayMs cannot be combined with static jitter.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: () => 100,
+            jitter: true,
+          },
+        });
       };
 
       expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();

--- a/src/result.ts
+++ b/src/result.ts
@@ -104,22 +104,39 @@ const tryFn: {
   return result;
 };
 
+type RetryPredicate<E> = (error: E, context: TryPromiseContext) => boolean;
+
+type RetryOptions<E> =
+  | {
+      times: number;
+      delayMs: number;
+      backoff: "linear" | "constant" | "exponential";
+      /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
+      shouldRetry?: RetryPredicate<E>;
+      /**
+       * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
+       * A number from 0 through 1 is the maximum reduction — e.g. `0.3` may shave up to
+       * 30% off each delay. `true` allows full reduction (down to 0). Defaults to no jitter.
+       */
+      jitter?: boolean | number;
+    }
+  | {
+      times: number;
+      /** Returns the final delay in milliseconds for the next retry. */
+      delayMs: (error: E, context: TryPromiseContext) => number;
+      /** Dynamic delays cannot be combined with static backoff. */
+      backoff?: never;
+      /** Dynamic delays cannot be combined with static jitter. */
+      jitter?: never;
+      /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
+      shouldRetry?: RetryPredicate<E>;
+    };
+
 type RetryConfig<E = unknown> = {
   /** Abort signal forwarded unchanged to every try and retry-decision context. */
   signal?: AbortSignal;
-  retry?: {
-    times: number;
-    delayMs: number;
-    backoff: "linear" | "constant" | "exponential";
-    /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
-    shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
-    /**
-     * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
-     * A number from 0 through 1 is the maximum reduction — e.g. `0.3` may shave up to
-     * 30% off each delay. `true` allows full reduction (down to 0). Defaults to no jitter.
-     */
-    jitter?: boolean | number;
-  };
+  /** Bounded retry configuration with either a static backoff or error-dependent delay. */
+  retry?: RetryOptions<E>;
 };
 
 const tryPromise: {
@@ -171,14 +188,18 @@ const tryPromise: {
     return execute({ attempt: 1, signal: config?.signal });
   }
 
-  const getBaseDelay = (retryAttempt: number): number => {
-    switch (retry.backoff) {
+  const getStaticRetryDelay = (
+    delayMs: number,
+    backoff: "linear" | "constant" | "exponential",
+    retryAttempt: number,
+  ): number => {
+    switch (backoff) {
       case "constant":
-        return retry.delayMs;
+        return delayMs;
       case "linear":
-        return retry.delayMs * (retryAttempt + 1);
+        return delayMs * (retryAttempt + 1);
       case "exponential":
-        return retry.delayMs * 2 ** retryAttempt;
+        return delayMs * 2 ** retryAttempt;
     }
   };
 
@@ -188,10 +209,9 @@ const tryPromise: {
   }
   const jitterFactor = jitter === true ? 1 : jitter === false ? 0 : jitter;
 
-  const getDelay = (retryAttempt: number): number => {
-    const baseDelay = getBaseDelay(retryAttempt);
-    if (jitterFactor === 0) return baseDelay;
-    return baseDelay * (1 - jitterFactor + Math.random() * jitterFactor);
+  const applyStaticRetryJitter = (baseDelayMs: number): number => {
+    if (jitterFactor === 0) return baseDelayMs;
+    return baseDelayMs * (1 - jitterFactor + Math.random() * jitterFactor);
   };
 
   const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>
@@ -215,7 +235,6 @@ const tryPromise: {
 
   let context: TryPromiseContext = { attempt: 1, signal: config.signal };
   let result = await execute(context);
-
   const shouldRetryFn = retry.shouldRetry ?? (() => true);
 
   for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
@@ -226,7 +245,24 @@ const tryPromise: {
       "shouldRetry predicate threw",
     );
     if (!shouldContinue) break;
-    const delayCompleted = await sleepForRetryDelay(getDelay(retryAttempt), context.signal);
+
+    let delayMs: number;
+    if (typeof retry.delayMs === "function") {
+      const getDynamicRetryDelay = retry.delayMs;
+      delayMs = tryOrPanic(
+        () => getDynamicRetryDelay(error, context),
+        "Result.tryPromise delayMs callback threw",
+      );
+    } else {
+      if (retry.backoff === undefined) {
+        throw panic("Result.tryPromise static retry delay requires backoff");
+      }
+      delayMs = applyStaticRetryJitter(
+        getStaticRetryDelay(retry.delayMs, retry.backoff, retryAttempt),
+      );
+    }
+
+    const delayCompleted = await sleepForRetryDelay(delayMs, context.signal);
     if (!delayCompleted || context.signal?.aborted) break;
     context = { attempt: context.attempt + 1, signal: config.signal };
     result = await execute(context);
@@ -929,6 +965,18 @@ export const Result = {
    *     delayMs: 100,
    *     backoff: "exponential",
    *     shouldRetry: e => e._tag === "RetryableError"
+   *   }
+   * })
+   *
+   * @example
+   * // Dynamic delay: the typed error determines when the next retry runs
+   * await Result.tryPromise({
+   *   try: () => callApi(url),
+   *   catch: e => new ApiError({ cause: e, retryAfterMs: readRetryAfter(e) })
+   * }, {
+   *   retry: {
+   *     times: 3,
+   *     delayMs: error => error.retryAfterMs
    *   }
    * })
    *


### PR DESCRIPTION
## Summary

- allow `Result.tryPromise` retry `delayMs` to derive the next delay from the typed error and failed-attempt context
- keep `times` required and `shouldRetry` boolean-only
- make dynamic delays final and mutually exclusive with static backoff and jitter
- preserve abortable retry waits and panic when the dynamic delay callback throws
- document dynamic rate-limit delay usage

## Example

```ts
await Result.tryPromise(
  {
    try: () => callApi(url),
    catch: (cause) => parseApiError(cause),
  },
  {
    retry: {
      times: 3,
      shouldRetry: (error) => error.retryable,
      delayMs: (error) => error.retryAfterMs,
    },
  },
);
```

## Verification

- `bun test`
- `bun run check`
- `bun run build`
- `bun run lint`
- `bun run fmt:check`

Closes #90
