### PR TITLE
Add Result collection combinators for 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,27 +670,30 @@ Migration differences:
 
 ### Result
 
-| Method                                  | Description                                                                          |
-| --------------------------------------- | ------------------------------------------------------------------------------------ |
-| `Result.ok(value)`                      | Create success                                                                       |
-| `Result.err(error)`                     | Create error                                                                         |
-| `Result.try(fn)`                        | Wrap throwing function                                                               |
-| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                              |
-| `Result.isOk(result)`                   | Type guard for Ok                                                                    |
-| `Result.isError(result)`                | Type guard for Err                                                                   |
-| `Result.gen(fn)`                        | Generator composition                                                                |
-| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                 |
-| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                           |
-| `Result.tap(result, fn)`                | Run side effect on success and return original result                                |
-| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                          |
-| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                  |
-| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                            |
-| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                          |
-| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                    |
-| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                  |
-| `Result.codec(config)`                  | Build a Result-level codec from Standard Schema-compatible serializers/deserializers |
-| `Result.partition(results)`             | Split array into [okValues, errValues]                                               |
-| `Result.flatten(result)`                | Flatten nested Result                                                                |
+| Method                                  | Description                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `Result.ok(value)`                      | Create success                                                                        |
+| `Result.err(error)`                     | Create error                                                                          |
+| `Result.try(fn)`                        | Wrap throwing function                                                                |
+| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                               |
+| `Result.isOk(result)`                   | Type guard for Ok                                                                     |
+| `Result.isError(result)`                | Type guard for Err                                                                    |
+| `Result.gen(fn)`                        | Generator composition                                                                 |
+| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                  |
+| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                            |
+| `Result.tap(result, fn)`                | Run side effect on success and return original result                                 |
+| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                           |
+| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                   |
+| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                             |
+| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                           |
+| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                     |
+| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                   |
+| `Result.codec(config)`                  | Build a Result-level codec from Standard Schema-compatible serializers/deserializers  |
+| `Result.all(results)`                   | Collect success values or return the first error, preserving tuple types              |
+| `Result.allAsync(results)`              | Concurrently await Results, then collect values or return the first input-order error |
+| `Result.partition(results)`             | Split Results into success and error arrays, preserving heterogeneous unions          |
+| `Result.partitionAsync(results)`        | Concurrently await Results, then split successes and errors into ordered arrays       |
+| `Result.flatten(result)`                | Flatten nested Result                                                                 |
 
 ### Instance Methods
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -4,7 +4,6 @@ import {
   Result,
   Ok,
   Err,
-  type Result as ResultType,
   type SerializedResult,
   type StandardSchemaResult,
   type StandardSchemaV1,
@@ -2381,10 +2380,10 @@ describe("Result", () => {
       });
 
       expectTypeOf(serialized).toEqualTypeOf<
-        Promise<ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>>
+        Promise<Result<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>>
       >();
       expectTypeOf(deserialized).toEqualTypeOf<
-        Promise<ResultType<User, AppError | ResultDeserializationError>>
+        Promise<Result<User, AppError | ResultDeserializationError>>
       >();
       await expect(serialized).resolves.toBeInstanceOf(Ok);
       await expect(serialized).resolves.toEqual(
@@ -2442,16 +2441,16 @@ describe("Result", () => {
       });
 
       expectTypeOf(syncSerialized).toEqualTypeOf<
-        ResultType<SerializedResult<string, number>, ResultSerializationError>
+        Result<SerializedResult<string, number>, ResultSerializationError>
       >();
       expectTypeOf(asyncDeserialized).toEqualTypeOf<
-        Promise<ResultType<string, number | ResultDeserializationError>>
+        Promise<Result<string, number | ResultDeserializationError>>
       >();
       expectTypeOf(asyncSerialized).toEqualTypeOf<
-        Promise<ResultType<SerializedResult<string, number>, ResultSerializationError>>
+        Promise<Result<SerializedResult<string, number>, ResultSerializationError>>
       >();
       expectTypeOf(syncDeserialized).toEqualTypeOf<
-        ResultType<string, number | ResultDeserializationError>
+        Result<string, number | ResultDeserializationError>
       >();
       expect(syncSerialized).toEqual(Result.ok({ status: "ok", value: "value" }));
       await expect(asyncDeserialized).resolves.toEqual(Result.ok("value"));
@@ -2474,7 +2473,7 @@ describe("Result", () => {
           })),
         },
       });
-      const getResult = (): ResultType<string, number> => Result.ok("value");
+      const getResult = (): Result<string, number> => Result.ok("value");
       const unknownEnvelope: unknown = { status: "error", error: 42 };
 
       const serializedOk = MixedBranchCodec.serialize(Result.ok("value"));
@@ -2484,8 +2483,8 @@ describe("Result", () => {
       const deserializedErr = MixedBranchCodec.deserialize({ status: "error", error: 42 });
       const deserializedUnknownEnvelope = MixedBranchCodec.deserialize(unknownEnvelope);
 
-      type Serialized = ResultType<SerializedResult<string, number>, ResultSerializationError>;
-      type Deserialized = ResultType<string, number | ResultDeserializationError>;
+      type Serialized = Result<SerializedResult<string, number>, ResultSerializationError>;
+      type Deserialized = Result<string, number | ResultDeserializationError>;
       expectTypeOf(serializedOk).toEqualTypeOf<Serialized>();
       expectTypeOf(serializedErr).toEqualTypeOf<Promise<Serialized>>();
       expectTypeOf(serializedUnknownBranch).toEqualTypeOf<Serialized | Promise<Serialized>>();
@@ -2521,8 +2520,8 @@ describe("Result", () => {
       const result = AsyncCodec.deserialize(invalidEnvelope);
 
       expectTypeOf(result).toEqualTypeOf<
-        | ResultType<string, number | ResultDeserializationError>
-        | Promise<ResultType<string, number | ResultDeserializationError>>
+        | Result<string, number | ResultDeserializationError>
+        | Promise<Result<string, number | ResultDeserializationError>>
       >();
       expect(result).toBeInstanceOf(Err);
     });
@@ -2585,11 +2584,9 @@ describe("Result", () => {
       });
 
       expectTypeOf(outbound).toEqualTypeOf<
-        ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>
+        Result<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>
       >();
-      expectTypeOf(inbound).toEqualTypeOf<
-        ResultType<User, AppError | ResultDeserializationError>
-      >();
+      expectTypeOf(inbound).toEqualTypeOf<Result<User, AppError | ResultDeserializationError>>();
 
       const serializeInvalidUser = (): void => {
         // @ts-expect-error -- The Ok serializer requires the complete User input type.
@@ -3332,6 +3329,114 @@ describe("Type Inference", () => {
     });
   });
 
+  describe("all", () => {
+    it("returns an empty tuple for empty input", () => {
+      const result = Result.all([]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[], never>>();
+      expect(result).toEqual(Result.ok([]));
+    });
+
+    it("collects Ok values in input order and preserves tuple types", () => {
+      const getNumberResult = (): Result<number, ErrorA> => Result.ok(1);
+      const getStringResult = (): Result<string, ErrorB> => Result.ok("hello");
+      const result = Result.all([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+
+    it("returns the first error and unions tuple error types", () => {
+      const firstError = new ErrorA("first");
+      const secondError = new ErrorB("second");
+      const getNumberResult = (): Result<number, ErrorA> => Result.err(firstError);
+      const getStringResult = (): Result<string, ErrorB> => Result.err(secondError);
+      const result = Result.all([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error).toBe(firstError);
+      }
+    });
+
+    it("infers homogeneous array value and error types", () => {
+      const results: Array<Result<number, ErrorA>> = [Result.ok(1), Result.ok(2)];
+      const result = Result.all(results);
+
+      expectTypeOf(result).toEqualTypeOf<Result<number[], ErrorA>>();
+      expect(result).toEqual(Result.ok([1, 2]));
+    });
+
+    it("accepts readonly tuples and returns a mutable value tuple", () => {
+      const results = [Result.ok(1), Result.ok("hello")] as const;
+      const result = Result.all(results);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], never>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+  });
+
+  describe("allAsync", () => {
+    it("returns an empty tuple for empty input", async () => {
+      const result = await Result.allAsync([]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[], never>>();
+      expect(result).toEqual(Result.ok([]));
+    });
+
+    it("collects asynchronous Ok values and preserves tuple types", async () => {
+      const getNumberResult = async (): Promise<Result<number, ErrorA>> => Result.ok(1);
+      const getStringResult = async (): Promise<Result<string, ErrorB>> => Result.ok("hello");
+      const result = await Result.allAsync([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+
+    it("returns the first error by input order", async () => {
+      const firstError = new ErrorA("first");
+      const secondError = new ErrorB("second");
+      const getNumberResult = async (): Promise<Result<number, ErrorA>> => Result.err(firstError);
+      const getStringResult = async (): Promise<Result<string, ErrorB>> => Result.err(secondError);
+      const result = await Result.allAsync([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error).toBe(firstError);
+      }
+    });
+
+    it("infers homogeneous asynchronous array types", async () => {
+      const results: Array<Promise<Result<number, ErrorA>>> = [
+        Promise.resolve(Result.ok(1)),
+        Promise.resolve(Result.ok(2)),
+      ];
+      const result = await Result.allAsync(results);
+
+      expectTypeOf(result).toEqualTypeOf<Result<number[], ErrorA>>();
+      expect(result).toEqual(Result.ok([1, 2]));
+    });
+
+    it("accepts mixed Result and Promise<Result> inputs", async () => {
+      const result = await Result.allAsync([Result.ok(1), Promise.resolve(Result.ok("hello"))]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], never>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+
+    it("panics when an input promise rejects", async () => {
+      const cause = new Error("input rejected");
+
+      await expect(Result.allAsync([Promise.reject(cause)])).rejects.toMatchObject({
+        _tag: "Panic",
+        message: "Result.allAsync input promise rejected",
+        cause,
+      });
+    });
+  });
+
   describe("partition", () => {
     it("returns empty arrays for empty input", () => {
       expect(Result.partition([])).toEqual([[], []]);
@@ -3353,6 +3458,77 @@ describe("Type Inference", () => {
         [1, 2],
         ["a", "b"],
       ]);
+    });
+
+    it("infers heterogeneous success and error unions", () => {
+      const getNumberResult = (): Result<number, ErrorA> => Result.ok(1);
+      const getStringResult = (): Result<string, ErrorB> => Result.err(new ErrorB("failed"));
+      const partitioned = Result.partition([getNumberResult(), getStringResult()] as const);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[Array<number | string>, Array<ErrorA | ErrorB>]>();
+      expect(partitioned).toEqual([[1], [new ErrorB("failed")]]);
+    });
+  });
+
+  describe("partitionAsync", () => {
+    it("returns empty arrays for empty input", async () => {
+      const partitioned = await Result.partitionAsync([]);
+
+      const expected: [never[], never[]] = partitioned;
+      expect(expected).toEqual([[], []]);
+    });
+
+    it("partitions asynchronous heterogeneous Results and preserves order", async () => {
+      const errorA = new ErrorA("a");
+      const errorB = new ErrorB("b");
+      const getFirstNumber = async (): Promise<Result<number, ErrorA>> => Result.ok(1);
+      const getFirstString = async (): Promise<Result<string, ErrorA>> => Result.err(errorA);
+      const getSecondNumber = async (): Promise<Result<number, ErrorB>> => Result.ok(2);
+      const getSecondString = async (): Promise<Result<string, ErrorB>> => Result.err(errorB);
+      const partitioned = await Result.partitionAsync([
+        getFirstNumber(),
+        getFirstString(),
+        getSecondNumber(),
+        getSecondString(),
+      ]);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[Array<number | string>, Array<ErrorA | ErrorB>]>();
+      expect(partitioned).toEqual([
+        [1, 2],
+        [errorA, errorB],
+      ]);
+    });
+
+    it("infers homogeneous asynchronous array types", async () => {
+      const results: Array<Promise<Result<number, ErrorA>>> = [
+        Promise.resolve(Result.ok(1)),
+        Promise.resolve(Result.err(new ErrorA("failed"))),
+      ];
+      const partitioned = await Result.partitionAsync(results);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[number[], ErrorA[]]>();
+      expect(partitioned[0]).toEqual([1]);
+      expect(partitioned[1]).toEqual([new ErrorA("failed")]);
+    });
+
+    it("accepts mixed Result and Promise<Result> inputs", async () => {
+      const partitioned = await Result.partitionAsync([
+        Result.ok(1),
+        Promise.resolve(Result.err("failed")),
+      ]);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[number[], string[]]>();
+      expect(partitioned).toEqual([[1], ["failed"]]);
+    });
+
+    it("panics when an input promise rejects", async () => {
+      const cause = new Error("input rejected");
+
+      await expect(Result.partitionAsync([Promise.reject(cause)])).rejects.toMatchObject({
+        _tag: "Panic",
+        message: "Result.partitionAsync input promise rejected",
+        cause,
+      });
     });
   });
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -817,17 +817,93 @@ const codec = <
   } satisfies ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>;
 };
 
-const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {
-  const oks: T[] = [];
-  const errs: E[] = [];
-  for (const r of results) {
-    if (r.status === "ok") {
-      oks.push(r.value);
+type AllResultValues<Results extends readonly AnyResult[]> = {
+  -readonly [Index in keyof Results]: InferOk<Results[Index]>;
+};
+
+type AnyAsyncResult = AnyResult | PromiseLike<AnyResult>;
+type AwaitedResults<Results extends readonly AnyAsyncResult[]> = {
+  -readonly [Index in keyof Results]: Awaited<Results[Index]>;
+};
+
+type ResultValueUnion<Results extends readonly AnyResult[]> = InferOk<Results[number]>;
+type ResultErrorUnion<Results extends readonly AnyResult[]> = InferErr<Results[number]>;
+
+type PartitionedResults<Results extends readonly AnyResult[]> = [
+  Array<ResultValueUnion<Results>>,
+  Array<ResultErrorUnion<Results>>,
+];
+
+/** Awaits Result inputs concurrently and converts an unexpected rejection into a Panic. */
+const awaitResultsOrPanic = async <const Results extends readonly AnyAsyncResult[]>(
+  results: Results,
+  panicMessage: string,
+): Promise<AwaitedResults<Results>> => {
+  try {
+    return await Promise.all(results);
+  } catch (cause) {
+    return panic(panicMessage, cause);
+  }
+};
+
+/** Collects success values in input order or returns the first error. */
+const all = <const Results extends readonly AnyResult[]>(
+  results: Results,
+): Result<AllResultValues<Results>, ResultErrorUnion<Results>> => {
+  const values: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "error") {
+      // SAFETY: The input constraint guarantees this error belongs to Results[number].
+      // TypeScript cannot correlate the narrowed indexed element with ResultErrorUnion<Results>.
+      return result as unknown as Err<AllResultValues<Results>, ResultErrorUnion<Results>>;
+    }
+    values.push(result.value);
+  }
+  // SAFETY: Every input was Ok and values were appended once in input order, so this
+  // mutable array has exactly the mapped tuple or homogeneous array shape.
+  return ok(values as unknown as AllResultValues<Results>);
+};
+
+/** Concurrently awaits Results, then collects success values or returns the first input-order error. */
+const allAsync = async <const Results extends readonly AnyAsyncResult[]>(
+  results: Results,
+): Promise<
+  Result<AllResultValues<AwaitedResults<Results>>, ResultErrorUnion<AwaitedResults<Results>>>
+> => {
+  const awaitedResults = await awaitResultsOrPanic(
+    results,
+    "Result.allAsync input promise rejected",
+  );
+  return all(awaitedResults);
+};
+
+/** Splits success values and errors into separate arrays while preserving input order. */
+const partition = <const Results extends readonly AnyResult[]>(
+  results: Results,
+): PartitionedResults<Results> => {
+  const oks: unknown[] = [];
+  const errs: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "ok") {
+      oks.push(result.value);
     } else {
-      errs.push(r.error);
+      errs.push(result.error);
     }
   }
-  return [oks, errs];
+  // SAFETY: Each payload came from the corresponding branch of Results[number].
+  // Both arrays preserve the relative input order of their branch.
+  return [oks, errs] as unknown as PartitionedResults<Results>;
+};
+
+/** Concurrently awaits Results, then splits success values and errors into ordered arrays. */
+const partitionAsync = async <const Results extends readonly AnyAsyncResult[]>(
+  results: Results,
+): Promise<PartitionedResults<AwaitedResults<Results>>> => {
+  const awaitedResults = await awaitResultsOrPanic(
+    results,
+    "Result.partitionAsync input promise rejected",
+  );
+  return partition(awaitedResults);
 };
 
 /**
@@ -1092,12 +1168,40 @@ export const Result = {
    */
   codec,
   /**
-   * Splits array of Results into tuple of [okValues, errorValues].
+   * Collects success values in input order or returns the first error.
+   * Tuple inputs preserve each success value type and union their error types.
    *
    * @example
-   * partition([ok(1), err("a"), ok(2)]) // [[1, 2], ["a"]]
+   * Result.all([Result.ok(1), Result.ok("hello")]) // Ok([1, "hello"])
+   * Result.all([Result.ok(1), Result.err("failed")]) // Err("failed")
+   */
+  all,
+  /**
+   * Concurrently awaits Results, then collects success values or returns the first input-order error.
+   * Tuple inputs preserve each success value type and union their error types.
+   * A rejected input promise is an unrecoverable defect and throws `Panic`.
+   *
+   * @example
+   * await Result.allAsync([fetchUser(), fetchAccount()]) // Result<[User, Account], UserError | AccountError>
+   */
+  allAsync,
+  /**
+   * Splits Results into [successValues, errorValues], preserving relative input order.
+   * Heterogeneous inputs produce unions in their corresponding output arrays.
+   *
+   * @example
+   * Result.partition([Result.ok(1), Result.err("a"), Result.ok(2)]) // [[1, 2], ["a"]]
    */
   partition,
+  /**
+   * Concurrently awaits Results, then splits successes and errors into ordered arrays.
+   * Heterogeneous inputs produce unions in their corresponding output arrays.
+   * A rejected input promise is an unrecoverable defect and throws `Panic`.
+   *
+   * @example
+   * await Result.partitionAsync([fetchUser(), fetchAccount()]) // [[User], [AccountError]]
+   */
+  partitionAsync,
   /**
    * Flattens nested Result into single Result.
    *


### PR DESCRIPTION
## Summary

- add tuple-preserving `Result.all` with first-error, input-order semantics
- add `Result.allAsync` for concurrent `Result`/`Promise<Result>` collection
- improve `Result.partition` inference for heterogeneous inputs
- add symmetric `Result.partitionAsync`

`Result` values are already settled, so `partition`/`partitionAsync` provide the useful settled aggregation shape instead of adding identity-like `allSettled` APIs.

The async combinators preserve input ordering and convert rejected input promises into `Panic`, while typed `Err` values remain ordinary Result failures.

## Verification

- `bun test` — 268 passing
- `bun run check`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`

Closes #32
