### PR TITLE
Allow tryRecover to recover into a wider success type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,20 @@ jobs:
             exit 1
           fi
 
+      - name: Determine release channel
+        id: release
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          if [[ "$VERSION" == *-* ]]; then
+            echo "npm-tag=next" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run checks
         run: |
           bun run check
@@ -69,11 +83,12 @@ jobs:
         run: npm pack
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag "${{ steps.release.outputs.npm-tag }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ steps.release.outputs.prerelease }}
           generate_release_notes: true
           files: |
             better-result-*.tgz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ better-result/
 | Add static combinator | `src/result.ts:782`        | `Result` namespace object                  |
 | New error type        | `src/error.ts`             | Extend `TaggedError`, add `_tag`           |
 | Change exports        | `src/index.ts`             | Barrel file                                |
-| Add tests             | `src/*.test.ts`            | Colocated, Bun test runner                 |
+| Add tests             | `src/*.test.ts`            | Colocated, Vitest runner                   |
 | Update agent skills   | `skills/*/SKILL.md`        | Keep `name:` matching the directory name   |
 | Add skill references  | `skills/*/references/*.md` | Prefer linked references over giant skills |
 
@@ -56,7 +56,7 @@ better-result/
 
 - **Strict TypeScript**: `noUncheckedIndexedAccess`, full strict mode
 - **ESM only**: No CommonJS (`"type": "module"`)
-- **Bun runtime**: `bun test`, `bun run build`
+- **Bun toolchain**: Use `bun run test` for Vitest and `bun run build` for packaging
 - **Phantom types**: `Ok<A, E>` and `Err<T, E>` both carry phantom type for the other variant
 - **Dual API**: All combinators support both `fn(result, arg)` and `fn(arg)(result)`
 - **Ox toolchain**: `oxlint` for linting, `oxfmt` for formatting (Rust-based, fast)
@@ -106,9 +106,9 @@ const result = await Result.gen(async function* () {
 ## TEST PATTERNS
 
 - **Colocated**: `*.test.ts` in `src/` alongside implementation
-- **Bun test**: Native `bun:test` with `describe`/`it`/`expect`
+- **Vitest runtime tests**: Import `describe`/`it`/`expect` from `vitest` in `*.test.ts`
+- **Vitest type tests**: Use `expectTypeOf` in `*.test-d.ts`; `bun run test` runs them with `tsc`
 - **Law verification**: Explicit Functor/Monad law tests
-- **Type tests**: Compile-time type inference verification
 - **Custom errors**: Per-file test error classes with `_tag`
 
 ## COMMANDS
@@ -116,7 +116,8 @@ const result = await Result.gen(async function* () {
 ```bash
 bun run build     # tsdown compilation
 bun run check     # Type-check only (--noEmit)
-bun test          # Run tests
+bun run test      # Run Vitest runtime and type tests
+bun run test:watch # Run Vitest in watch mode
 bun run lint      # oxlint
 bun run fmt       # oxfmt format
 bun run fmt:check # oxfmt check

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -42,7 +42,7 @@ TaggedError.isTaggedError(value)
 
 ```typescript
 matchError(error, { ... })
-matchErrorPartial(error, { ... }, fallback)
+matchErrorPartial(error, { ... }, onUnhandled)
 isTaggedError(value)
 ```
 

--- a/README.md
+++ b/README.md
@@ -312,9 +312,31 @@ const result = await Result.tryPromise(
 );
 ```
 
+### Dynamic Retry Delays
+
+Pass a callback as `delayMs` when each error determines how long to wait. The callback receives the typed error and the context for the failed attempt. `times` remains required so every retry policy has an explicit limit:
+
+```ts
+const result = await Result.tryPromise(
+  {
+    try: () => callApi(url),
+    catch: (cause) => parseApiError(cause),
+  },
+  {
+    retry: {
+      times: 3,
+      shouldRetry: (error) => error.retryable,
+      delayMs: (error, { attempt }) => error.retryAfterMs,
+    },
+  },
+);
+```
+
+A dynamic `delayMs` returns the final delay before the next attempt and cannot be combined with `backoff` or `jitter`. If the callback throws, `Result.tryPromise` throws a `Panic`.
+
 ### Async Retry Decisions
 
-For retry decisions that require async operations (rate limits, feature flags, etc.), enrich the error in the `catch` handler instead of making `shouldRetry` async:
+Retry callbacks are synchronous. For decisions that require async operations (rate limits, feature flags, etc.), enrich the error in the `catch` handler before making the retry decision:
 
 ```ts
 class ApiError extends TaggedError("ApiError")<{

--- a/README.md
+++ b/README.md
@@ -733,27 +733,30 @@ Migration differences:
 
 ### Result
 
-| Method                                  | Description                                                                          |
-| --------------------------------------- | ------------------------------------------------------------------------------------ |
-| `Result.ok(value)`                      | Create success                                                                       |
-| `Result.err(error)`                     | Create error                                                                         |
-| `Result.try(fn)`                        | Wrap throwing function                                                               |
-| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                              |
-| `Result.isOk(result)`                   | Type guard for Ok                                                                    |
-| `Result.isError(result)`                | Type guard for Err                                                                   |
-| `Result.gen(fn)`                        | Generator composition                                                                |
-| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                 |
-| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                           |
-| `Result.tap(result, fn)`                | Run side effect on success and return original result                                |
-| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                          |
-| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                  |
-| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                            |
-| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                          |
-| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                    |
-| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                  |
-| `Result.codec(config)`                  | Build a Result-level codec from Standard Schema-compatible serializers/deserializers |
-| `Result.partition(results)`             | Split array into [okValues, errValues]                                               |
-| `Result.flatten(result)`                | Flatten nested Result                                                                |
+| Method                                  | Description                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `Result.ok(value)`                      | Create success                                                                        |
+| `Result.err(error)`                     | Create error                                                                          |
+| `Result.try(fn)`                        | Wrap throwing function                                                                |
+| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                               |
+| `Result.isOk(result)`                   | Type guard for Ok                                                                     |
+| `Result.isError(result)`                | Type guard for Err                                                                    |
+| `Result.gen(fn)`                        | Generator composition                                                                 |
+| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                  |
+| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                            |
+| `Result.tap(result, fn)`                | Run side effect on success and return original result                                 |
+| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                           |
+| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                   |
+| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                             |
+| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                           |
+| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                     |
+| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                   |
+| `Result.codec(config)`                  | Build a Result-level codec from Standard Schema-compatible serializers/deserializers  |
+| `Result.all(results)`                   | Collect success values or return the first error, preserving tuple types              |
+| `Result.allAsync(results)`              | Concurrently await Results, then collect values or return the first input-order error |
+| `Result.partition(results)`             | Split Results into success and error arrays, preserving heterogeneous unions          |
+| `Result.partitionAsync(results)`        | Concurrently await Results, then split successes and errors into ordered arrays       |
+| `Result.flatten(result)`                | Flatten nested Result                                                                 |
 
 ### Instance Methods
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Result.map((x) => x + 1)(result); // Pipeable
 // Transform error type
 const result = fetchUser(id).mapError((e) => new AppError(`Failed to fetch user: ${e.message}`));
 
-// Recover from specific errors while preserving the same success type
+// Recover from specific errors, widening the success type when needed
 const result = fetchUser(id).tryRecover((e) =>
   e._tag === "NotFoundError" ? Result.ok(defaultUser) : Result.err(e),
 );
@@ -532,11 +532,16 @@ const transformError = matchErrorPartial({
 const piped = transformError(error);
 // string | ValidationError
 
-// A custom fallback can transform unhandled errors
+// A custom onUnhandled callback can transform unhandled errors
 const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },
   (e) => `Unknown: ${e.message}`,
+);
+
+// Result.err preserves unhandled variants when composing with tryRecover
+const recovered = result.tryRecover(
+  matchErrorPartial({ NotFoundError: (e: NotFoundError) => Result.ok(defaultValue) }, Result.err),
 );
 
 // Type guards
@@ -742,8 +747,8 @@ Migration differences:
 | `Result.isOk(result)`                   | Type guard for Ok                                                                     |
 | `Result.isError(result)`                | Type guard for Err                                                                    |
 | `Result.gen(fn)`                        | Generator composition                                                                 |
-| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                  |
-| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                            |
+| `Result.tryRecover(result, fn)`         | Recover error, widening the success type when needed                                  |
+| `Result.tryRecoverAsync(result, fn)`    | Async recover error, widening the success type when needed                            |
 | `Result.tap(result, fn)`                | Run side effect on success and return original result                                 |
 | `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                           |
 | `Result.tapError(result, fn)`           | Run side effect on error and return original result                                   |
@@ -760,37 +765,37 @@ Migration differences:
 
 ### Instance Methods
 
-| Method                    | Description                                |
-| ------------------------- | ------------------------------------------ |
-| `.isOk()`                 | Type guard, narrows to Ok                  |
-| `.isErr()`                | Type guard, narrows to Err                 |
-| `.map(fn)`                | Transform success value                    |
-| `.mapError(fn)`           | Transform error value                      |
-| `.tryRecover(fn)`         | Recover error into same success type       |
-| `.tryRecoverAsync(fn)`    | Async recover error into same success type |
-| `.andThen(fn)`            | Chain Result-returning function            |
-| `.andThenAsync(fn)`       | Chain async Result-returning function      |
-| `.match({ ok, err })`     | Pattern match                              |
-| `.unwrap(message?)`       | Extract value or throw                     |
-| `.unwrapOr(fallback)`     | Extract value or return fallback           |
-| `.tap(fn)`                | Side effect on success                     |
-| `.tapAsync(fn)`           | Async side effect on success               |
-| `.tapError(fn)`           | Side effect on error                       |
-| `.tapErrorAsync(fn)`      | Async side effect on error                 |
-| `.tapBoth(handlers)`      | Side effect on either branch               |
-| `.tapBothAsync(handlers)` | Async side effect on either branch         |
+| Method                    | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `.isOk()`                 | Type guard, narrows to Ok                         |
+| `.isErr()`                | Type guard, narrows to Err                        |
+| `.map(fn)`                | Transform success value                           |
+| `.mapError(fn)`           | Transform error value                             |
+| `.tryRecover(fn)`         | Recover error and widen success when needed       |
+| `.tryRecoverAsync(fn)`    | Async recover error and widen success when needed |
+| `.andThen(fn)`            | Chain Result-returning function                   |
+| `.andThenAsync(fn)`       | Chain async Result-returning function             |
+| `.match({ ok, err })`     | Pattern match                                     |
+| `.unwrap(message?)`       | Extract value or throw                            |
+| `.unwrapOr(fallback)`     | Extract value or return fallback                  |
+| `.tap(fn)`                | Side effect on success                            |
+| `.tapAsync(fn)`           | Async side effect on success                      |
+| `.tapError(fn)`           | Side effect on error                              |
+| `.tapErrorAsync(fn)`      | Async side effect on error                        |
+| `.tapBoth(handlers)`      | Side effect on either branch                      |
+| `.tapBothAsync(handlers)` | Async side effect on either branch                |
 
 ### TaggedError
 
-| Method                                  | Description                                             |
-| --------------------------------------- | ------------------------------------------------------- |
-| `TaggedError(tag)<Props>()`             | Factory for tagged error class                          |
-| `TaggedError.is(value)`                 | Type guard for any TaggedError                          |
-| `matchError(err, handlers)`             | Exhaustive pattern match by `_tag`                      |
-| `matchErrorPartial(err, handlers, fb?)` | Partial match; unhandled errors pass through by default |
-| `isTaggedError(value)`                  | Type guard (standalone function)                        |
-| `panic(message, cause?)`                | Throw unrecoverable Panic                               |
-| `isPanic(value)`                        | Type guard for Panic                                    |
+| Method                                             | Description                                             |
+| -------------------------------------------------- | ------------------------------------------------------- |
+| `TaggedError(tag)<Props>()`                        | Factory for tagged error class                          |
+| `TaggedError.is(value)`                            | Type guard for any TaggedError                          |
+| `matchError(err, handlers)`                        | Exhaustive pattern match by `_tag`                      |
+| `matchErrorPartial(error, handlers, onUnhandled?)` | Partial match; unhandled errors pass through by default |
+| `isTaggedError(value)`                             | Type guard (standalone function)                        |
+| `panic(message, cause?)`                           | Throw unrecoverable Panic                               |
+| `isPanic(value)`                                   | Type guard for Panic                                    |
 
 ### Type Helpers
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ const result = await Result.tryPromise(() => fetch(url), {
 });
 ```
 
-The try callback receives a `TryContext` with a 1-based `attempt` number:
+The async try callback receives a `TryPromiseContext` with a 1-based `attempt` number and the optional top-level abort signal. The synchronous `Result.try` callback continues to receive a `TryContext` containing only `attempt`.
 
 ```ts
 const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(url, attempt), {
@@ -265,6 +265,25 @@ const result = await Result.tryPromise(({ attempt }) => fetchWithRetryContext(ur
   },
 });
 ```
+
+Pass an abort signal in the top-level config to interrupt a pending retry delay and prevent later retries. The signal is also forwarded to every attempt so the try callback can cancel abort-aware operations:
+
+```ts
+const controller = new AbortController();
+
+const result = await Result.tryPromise(({ signal }) => fetch(url, { signal }), {
+  signal: controller.signal,
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "constant",
+  },
+});
+```
+
+The same signal and failed attempt number are available as the second `shouldRetry` argument for custom retry decisions: `shouldRetry: (error, { attempt, signal }) => boolean`.
+
+`Result.tryPromise` cannot abort an operation by itself. The try callback must pass the signal to operations such as `fetch` that support cancellation. When aborted, retry scheduling stops and the latest typed result is returned.
 
 ### Conditional Retry
 

--- a/README.md
+++ b/README.md
@@ -519,8 +519,21 @@ matchError(error, {
   ValidationError: (e) => `Bad field: ${e.field}`,
 });
 
-// Partial matching with fallback
-matchErrorPartial(
+// Partial matching leaves unhandled errors unchanged by default
+const transformed = matchErrorPartial(error, {
+  NotFoundError: (e) => `Missing: ${e.id}`,
+});
+// string | ValidationError
+
+// In data-last form, annotate handlers that use variant-specific fields
+const transformError = matchErrorPartial({
+  NotFoundError: (e: NotFoundError) => `Missing: ${e.id}`,
+});
+const piped = transformError(error);
+// string | ValidationError
+
+// A custom fallback can transform unhandled errors
+const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },
   (e) => `Unknown: ${e.message}`,
@@ -766,15 +779,15 @@ Migration differences:
 
 ### TaggedError
 
-| Method                                 | Description                        |
-| -------------------------------------- | ---------------------------------- |
-| `TaggedError(tag)<Props>()`            | Factory for tagged error class     |
-| `TaggedError.is(value)`                | Type guard for any TaggedError     |
-| `matchError(err, handlers)`            | Exhaustive pattern match by `_tag` |
-| `matchErrorPartial(err, handlers, fb)` | Partial match with fallback        |
-| `isTaggedError(value)`                 | Type guard (standalone function)   |
-| `panic(message, cause?)`               | Throw unrecoverable Panic          |
-| `isPanic(value)`                       | Type guard for Panic               |
+| Method                                  | Description                                             |
+| --------------------------------------- | ------------------------------------------------------- |
+| `TaggedError(tag)<Props>()`             | Factory for tagged error class                          |
+| `TaggedError.is(value)`                 | Type guard for any TaggedError                          |
+| `matchError(err, handlers)`             | Exhaustive pattern match by `_tag`                      |
+| `matchErrorPartial(err, handlers, fb?)` | Partial match; unhandled errors pass through by default |
+| `isTaggedError(value)`                  | Type guard (standalone function)                        |
+| `panic(message, cause?)`                | Throw unrecoverable Panic                               |
+| `isPanic(value)`                        | Type guard for Panic                                    |
 
 ### Type Helpers
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,34 @@ const result = await Result.tryPromise(
 );
 ```
 
+### Jitter
+
+To avoid thundering-herd retries when many callers fail at the same time, randomize each delay with `jitter`:
+
+```ts
+const result = await Result.tryPromise(() => fetch(url), {
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "exponential",
+    jitter: true, // full jitter: delay is uniform in [0, baseDelay)
+  },
+});
+```
+
+Pass a number from `0` through `1` to control how much of the base delay is randomized:
+
+```ts
+retry: {
+  times: 3,
+  delayMs: 100,
+  backoff: "exponential",
+  jitter: 0.3, // delay uniform in [0.7 * baseDelay, baseDelay)
+}
+```
+
+`jitter: true` is equivalent to `jitter: 1`. Values outside the inclusive range from `0` to `1`, including `NaN` and infinities, throw a `Panic` before the first attempt.
+
 ## UnhandledException
 
 When `Result.try()` or `Result.tryPromise()` catches an exception without a custom handler, the error type is `UnhandledException`:

--- a/README.md
+++ b/README.md
@@ -527,63 +527,170 @@ new NetworkError({ url: "/api", status: 404 });
 
 ## Serialization
 
-Convert Results to plain objects for RPC, storage, or server actions:
+Build Result-level codecs for RPC, storage, or server actions with Standard Schema-compatible schemas. This example uses Zod, but any Standard Schema implementation works:
 
 ```ts
-import { Result, SerializedResult, ResultDeserializationError } from "better-result";
+import { z } from "zod";
+import {
+  Result,
+  ResultDeserializationError,
+  ResultSerializationError,
+  type Result as ResultType,
+  type SerializedResult,
+} from "better-result";
 
-// Serialize to plain object
-const result = Result.ok(42);
-const serialized = Result.serialize(result);
-// { status: "ok", value: 42 }
+const UserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.date(),
+});
+const UserWireSchema = z.object({
+  id: z.string(),
+  display_name: z.string(),
+  created_at_iso: z.string(),
+});
+const ValidationErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+const ValidationErrorWireSchema = z.object({
+  type: z.string(),
+  message: z.string(),
+});
+type UserWire = z.output<typeof UserWireSchema>;
+type ValidationErrorWire = z.output<typeof ValidationErrorWireSchema>;
 
-// Deserialize back to Result instance
-const deserialized = Result.deserialize<number, never>(serialized);
-// Ok(42) - can use .map(), .andThen(), etc.
+const UserResultCodec = Result.codec({
+  serialize: {
+    ok: UserSchema.transform((user) => ({
+      id: user.id,
+      display_name: user.name,
+      created_at_iso: user.createdAt.toISOString(),
+    })),
+    err: ValidationErrorSchema.transform((error) => ({
+      type: error.code,
+      message: error.message,
+    })),
+  },
+  deserialize: {
+    ok: UserWireSchema.transform((wire) => ({
+      id: wire.id,
+      name: wire.display_name,
+      createdAt: new Date(wire.created_at_iso),
+    })),
+    err: ValidationErrorWireSchema.transform((wire) => ({
+      code: wire.type,
+      message: wire.message,
+    })),
+  },
+});
 
-// Invalid input returns ResultDeserializationError
-const invalid = Result.deserialize({ foo: "bar" });
+const outbound = await UserResultCodec.serialize(Result.ok(user));
+// Ok({ status: "ok", value: { id, display_name, created_at_iso } })
+
+if (Result.isError(outbound) && ResultSerializationError.is(outbound.error)) {
+  console.log("Bad payload:", outbound.error.value, outbound.error.issues);
+}
+
+const inbound = await outbound.andThenAsync(async (wire) => {
+  return await UserResultCodec.deserialize(wire);
+});
+// Ok(user)
+
+const invalid = await UserResultCodec.deserialize({ foo: "bar" });
 if (Result.isError(invalid) && ResultDeserializationError.is(invalid.error)) {
-  console.log("Bad input:", invalid.error.value);
+  console.log("Bad envelope or payload:", invalid.error.value, invalid.error.issues);
 }
 
-// Typed boundary for Next.js server actions
-async function createUser(data: FormData): Promise<SerializedResult<User, ValidationError>> {
+async function createUser(
+  data: FormData,
+): Promise<ResultType<SerializedResult<UserWire, ValidationErrorWire>, ResultSerializationError>> {
   const result = await validateAndCreate(data);
-  return Result.serialize(result);
+  return UserResultCodec.serialize(result);
 }
-
-// Client-side
-const serialized = await createUser(formData);
-const result = Result.deserialize<User, ValidationError>(serialized);
 ```
+
+### Synchronous and asynchronous schemas
+
+Serialization and deserialization infer their return types independently. Within either direction, the selected `ok` or `err` schema determines whether a concrete branch returns a `Result` or a `Promise<Result>`—no runtime mode configuration is needed.
+
+```ts
+const serializedOk = MixedCodec.serialize(Result.ok(user)); // Result when serialize.ok is sync
+const serializedErr = MixedCodec.serialize(Result.err(error)); // Promise<Result> when serialize.err is async
+
+const deserializedOk = MixedCodec.deserialize({ status: "ok", value: userWire });
+const deserializedErr = MixedCodec.deserialize({ status: "error", error: errorWire });
+```
+
+When the input's branch is not statically known, mixed schemas honestly return `Result | Promise<Result>`. An `unknown` deserialization input also includes the synchronous `Result` case because an invalid outer envelope fails before a payload schema runs. `await` accepts both forms when callers want one control flow:
+
+```ts
+const decoded = await MixedCodec.deserialize(inputFromNetwork);
+```
+
+Schema validation issues are returned as `ResultSerializationError` or `ResultDeserializationError`. A schema that throws or returns a rejected Promise is a defect: the codec throws or rejects with `Panic` and preserves the original error as `cause`.
+
+JSON transports omit object properties whose value is `undefined`. The codec therefore accepts `{ status: "ok" }` and `{ status: "error" }` as envelopes and passes the missing payload to the selected deserialization schema as `undefined`. A `void` or `undefined` schema can accept it; schemas requiring another payload return `ResultDeserializationError` with their validation issues.
+
+### Migrating from `Result.serialize` / `Result.deserialize`
+
+`Result.serialize`, `Result.deserialize`, and `Result.hydrate` were removed in 3.0. The old helpers copied payloads without validating them:
+
+```ts
+// Before 3.0
+const wire = Result.serialize(result); // SerializedResult<User, ValidationError>
+const resultOrNull = Result.deserialize<User, ValidationError>(input); // Result | null
+```
+
+Create a codec once and let its schemas infer the payload types. For already serializable payloads, use the same validating schemas in both directions:
+
+```ts
+// 3.0
+const LegacyLikeCodec = Result.codec({
+  serialize: { ok: UserWireSchema, err: ValidationErrorWireSchema },
+  deserialize: { ok: UserWireSchema, err: ValidationErrorWireSchema },
+});
+
+const wirePayloadResult = Result.ok(userWire);
+const wireResult = await LegacyLikeCodec.serialize(wirePayloadResult);
+// Result<SerializedResult<UserWire, ValidationErrorWire>, ResultSerializationError>
+
+const decoded = await LegacyLikeCodec.deserialize(input);
+// Result<UserWire, ValidationErrorWire | ResultDeserializationError>
+```
+
+Migration differences:
+
+- Handle `ResultSerializationError` instead of assuming serialization always succeeds.
+- Handle `ResultDeserializationError` instead of checking for `null`; its `issues` preserve schema diagnostics when a payload is invalid.
+- Remove explicit `<User, ValidationError>` deserialization type arguments. The schemas provide those types.
+- Use `await` when a schema is async or when a schema library exposes a sync-or-async Standard Schema validator type.
 
 ## API Reference
 
 ### Result
 
-| Method                                  | Description                                                                              |
-| --------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `Result.ok(value)`                      | Create success                                                                           |
-| `Result.err(error)`                     | Create error                                                                             |
-| `Result.try(fn)`                        | Wrap throwing function                                                                   |
-| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                                  |
-| `Result.isOk(result)`                   | Type guard for Ok                                                                        |
-| `Result.isError(result)`                | Type guard for Err                                                                       |
-| `Result.gen(fn)`                        | Generator composition                                                                    |
-| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                     |
-| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                               |
-| `Result.tap(result, fn)`                | Run side effect on success and return original result                                    |
-| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                              |
-| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                      |
-| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                                |
-| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                              |
-| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                        |
-| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                      |
-| `Result.serialize(result)`              | Convert Result to plain object                                                           |
-| `Result.deserialize(value)`             | Rehydrate serialized Result (returns `Err<ResultDeserializationError>` on invalid input) |
-| `Result.partition(results)`             | Split array into [okValues, errValues]                                                   |
-| `Result.flatten(result)`                | Flatten nested Result                                                                    |
+| Method                                  | Description                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------ |
+| `Result.ok(value)`                      | Create success                                                                       |
+| `Result.err(error)`                     | Create error                                                                         |
+| `Result.try(fn)`                        | Wrap throwing function                                                               |
+| `Result.tryPromise(fn, config?)`        | Wrap async function with optional retry                                              |
+| `Result.isOk(result)`                   | Type guard for Ok                                                                    |
+| `Result.isError(result)`                | Type guard for Err                                                                   |
+| `Result.gen(fn)`                        | Generator composition                                                                |
+| `Result.tryRecover(result, fn)`         | Recover error into same success type                                                 |
+| `Result.tryRecoverAsync(result, fn)`    | Async recover error into same success type                                           |
+| `Result.tap(result, fn)`                | Run side effect on success and return original result                                |
+| `Result.tapAsync(result, fn)`           | Run async side effect on success and return original result                          |
+| `Result.tapError(result, fn)`           | Run side effect on error and return original result                                  |
+| `Result.tapErrorAsync(result, fn)`      | Run async side effect on error and return original result                            |
+| `Result.tapBoth(result, handlers)`      | Run side effect on either branch and return original result                          |
+| `Result.tapBothAsync(result, handlers)` | Run async side effect on either branch and return original result                    |
+| `Result.await(promise)`                 | Wrap Promise<Result> for generators                                                  |
+| `Result.codec(config)`                  | Build a Result-level codec from Standard Schema-compatible serializers/deserializers |
+| `Result.partition(results)`             | Split array into [okValues, errValues]                                               |
+| `Result.flatten(result)`                | Flatten nested Result                                                                |
 
 ### Instance Methods
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "tryhard",
       "devDependencies": {
         "@types/bun": "latest",
+        "fast-check": "^4.9.0",
         "oxfmt": "^0.23.0",
         "oxlint": "^1.38.0",
         "tsdown": "^0.19.0-beta.5",
@@ -267,6 +268,8 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -304,6 +307,8 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "fast-check": "^4.9.0",
     "oxfmt": "^0.23.0",
     "oxlint": "^1.38.0",
     "tsdown": "^0.19.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-result",
-  "version": "2.10.0",
+  "version": "3.0.0-rc.1",
   "description": "Lightweight Result type with generator-based composition",
   "keywords": [
     "error-handling",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "build": "tsdown",
     "prepublishOnly": "bun run build",
-    "test": "vitest --typecheck --run",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "check": "tsc --noEmit",
     "lint": "oxlint .",
     "fmt": "oxfmt .",

--- a/skills/better-result-adopt/references/tagged-errors.md
+++ b/skills/better-result-adopt/references/tagged-errors.md
@@ -107,13 +107,22 @@ const message = matchError(error, {
 });
 ```
 
-### Partial Match with Fallback
+### Partial Match
 
-Handle subset, catch-all for rest:
+Handle a subset while leaving unhandled errors unchanged:
 
 ```typescript
 import { matchErrorPartial } from "better-result";
 
+const transformed = matchErrorPartial(error, {
+  NotFoundError: (e) => `Missing: ${e.id}`,
+});
+// string | ValidationError | AuthError
+```
+
+Provide a custom fallback to transform the remaining errors:
+
+```typescript
 const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },

--- a/skills/better-result-adopt/references/tagged-errors.md
+++ b/skills/better-result-adopt/references/tagged-errors.md
@@ -120,13 +120,21 @@ const transformed = matchErrorPartial(error, {
 // string | ValidationError | AuthError
 ```
 
-Provide a custom fallback to transform the remaining errors:
+Provide a custom `onUnhandled` callback to transform the remaining errors:
 
 ```typescript
 const message = matchErrorPartial(
   error,
   { NotFoundError: (e) => `Missing: ${e.id}` },
-  (e) => `Error: ${e.message}`, // fallback for ValidationError, AuthError
+  (e) => `Error: ${e.message}`, // Handles ValidationError and AuthError
+);
+```
+
+Use `Result.err` as the pipeable `onUnhandled` callback to preserve unhandled variants during recovery:
+
+```typescript
+const recovered = result.tryRecover(
+  matchErrorPartial({ NotFoundError: (e: NotFoundError) => Result.ok(defaultValue) }, Result.err),
 );
 ```
 

--- a/skills/better-result-migrate-v2/references/migration-patterns.md
+++ b/skills/better-result-migrate-v2/references/migration-patterns.md
@@ -102,7 +102,7 @@ class TimestampedError extends TaggedError("TimestampedError")<{
 | v1                                                  | v2                                                |
 | --------------------------------------------------- | ------------------------------------------------- |
 | `TaggedError.match(err, handlers)`                  | `matchError(err, handlers)`                       |
-| `TaggedError.matchPartial(err, handlers, fallback)` | `matchErrorPartial(err, handlers, fallback)`      |
+| `TaggedError.matchPartial(err, handlers, fallback)` | `matchErrorPartial(error, handlers, onUnhandled)` |
 | `TaggedError.isTaggedError(value)`                  | `isTaggedError(value)` or `TaggedError.is(value)` |
 
 ## Import Migration

--- a/src/core.ts
+++ b/src/core.ts
@@ -6,9 +6,6 @@ const serializeCause = (cause: unknown): unknown => {
   return cause;
 };
 
-/** Prevents inference from a type position while supporting TypeScript 5.0. */
-type NoInfer<T> = [T][T extends unknown ? 0 : never];
-
 /**
  * Unrecoverable error — user code threw inside Result operations.
  *
@@ -110,10 +107,6 @@ export type TapBothAsyncErrHandlers<E> = {
   err: (e: E) => Promise<void>;
 };
 
-/** Extracts the success type carried by either Result variant, including Err's phantom T. */
-type InferSuccess<R> =
-  R extends Ok<infer T, unknown> ? T : R extends Err<infer T, unknown> ? T : never;
-
 /** Detects whether a type is a union. */
 type IsUnion<T, U = T> = T extends unknown ? ([U] extends [T] ? false : true) : never;
 
@@ -137,14 +130,14 @@ type MapErrorReturn<R, E2> =
         ? Err<T, E2>
         : never;
 
-/** Return type for recovery that preserves concrete variants but prints public Result for Result unions. */
-type TryRecoverReturn<R, E2> =
+/** Return type for recovery that widens success unions while preserving concrete variant precision. */
+type TryRecoverReturn<R, B, E2> =
   IsUnion<R> extends true
-    ? Result<InferOk<R>, E2>
+    ? Result<InferOk<R> | B, E2>
     : R extends Ok<infer A, unknown>
       ? Ok<A, E2>
-      : R extends Err<infer T, unknown>
-        ? Result<T, E2>
+      : R extends Err<unknown, unknown>
+        ? Result<B, E2>
         : never;
 
 /** Return type for andThen that preserves concrete variants but prints public Result for Result unions. */
@@ -227,44 +220,46 @@ export class Ok<A, E = never> {
   }
 
   /**
-   * No-op on Ok, returns self with new phantom error type.
+   * No-op on Ok, returning the existing success without calling the recovery function.
    *
    * @template E2 New error type.
-   * @param _fn Ignored.
+   * @template B Additional success type returned by the recovery function.
+   * @param _fn Ignored recovery function.
    * @returns Self with updated phantom E type.
    *
    * @example
    * ok(42).tryRecover(() => err("fallback")) // Ok(42)
    */
-  tryRecover<E2>(this: Ok<A, E>, _fn: (e: never) => Result<NoInfer<A>, E2>): Ok<A, E2>;
-  tryRecover<E2, R extends AnyResult = Result<A, E>>(
+  tryRecover<E2, B = A>(this: Ok<A, E>, _fn: (e: never) => Result<B, E2>): Ok<A, E2>;
+  tryRecover<E2, B = A, R extends AnyResult = Result<A, E>>(
     this: R,
-    _fn: (e: InferErr<R>) => Result<NoInfer<InferSuccess<R>>, E2>,
-  ): TryRecoverReturn<R, E2>;
-  tryRecover<E2>(_fn: (e: never) => Result<NoInfer<A>, E2>): Ok<A, E2> {
+    _fn: (e: InferErr<R>) => Result<B, E2>,
+  ): TryRecoverReturn<R, B, E2>;
+  tryRecover<E2, B = A>(_fn: (e: never) => Result<B, E2>): Ok<A, E2> {
     // SAFETY: E is phantom on Ok (not used at runtime).
     return this as unknown as Ok<A, E2>;
   }
 
   /**
-   * No-op on Ok, returns Promise of self with new phantom error type.
+   * No-op on Ok, asynchronously returning the existing success without calling recovery.
    *
    * @template E2 New error type.
-   * @param _fn Ignored.
+   * @template B Additional success type returned by the recovery function.
+   * @param _fn Ignored async recovery function.
    * @returns Promise of self with updated phantom E type.
    *
    * @example
    * await ok(42).tryRecoverAsync(async () => err("fallback")) // Ok(42)
    */
-  tryRecoverAsync<E2>(
+  tryRecoverAsync<E2, B = A>(
     this: Ok<A, E>,
-    _fn: (e: never) => Promise<Result<NoInfer<A>, E2>>,
+    _fn: (e: never) => Promise<Result<B, E2>>,
   ): Promise<Ok<A, E2>>;
-  tryRecoverAsync<E2, R extends AnyResult = Result<A, E>>(
+  tryRecoverAsync<E2, B = A, R extends AnyResult = Result<A, E>>(
     this: R,
-    _fn: (e: InferErr<R>) => Promise<Result<NoInfer<InferSuccess<R>>, E2>>,
-  ): Promise<TryRecoverReturn<R, E2>>;
-  tryRecoverAsync<E2>(_fn: (e: never) => Promise<Result<NoInfer<A>, E2>>): Promise<Ok<A, E2>> {
+    _fn: (e: InferErr<R>) => Promise<Result<B, E2>>,
+  ): Promise<TryRecoverReturn<R, B, E2>>;
+  tryRecoverAsync<E2, B = A>(_fn: (e: never) => Promise<Result<B, E2>>): Promise<Ok<A, E2>> {
     // SAFETY: E is phantom on Ok (not used at runtime).
     return Promise.resolve(this as unknown as Ok<A, E2>);
   }
@@ -535,45 +530,47 @@ export class Err<T, E> {
   }
 
   /**
-   * Attempts to recover from Err into the same success type.
+   * Attempts to recover from Err, allowing the recovery to return a new success type.
    *
    * @template E2 New error type.
-   * @param fn Recovery function returning Result with the same success type.
+   * @template B Success type returned by the recovery function.
+   * @param fn Recovery function returning a Result.
    * @returns Result from fn.
    * @throws {Panic} If fn throws.
    *
    * @example
-   * err<number, string>("missing").tryRecover(e => e === "missing" ? ok(0) : err(new Error(e))) // Ok(0)
+   * err<number, string>("missing").tryRecover(e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
-  tryRecover<E2>(this: Err<T, E>, fn: (e: E) => Result<NoInfer<T>, E2>): Result<T, E2>;
-  tryRecover<E2, R extends AnyResult = Result<T, E>>(
+  tryRecover<E2, B = T>(this: Err<T, E>, fn: (e: E) => Result<B, E2>): Result<B, E2>;
+  tryRecover<E2, B = T, R extends AnyResult = Result<T, E>>(
     this: R,
-    fn: (e: InferErr<R>) => Result<NoInfer<InferSuccess<R>>, E2>,
-  ): TryRecoverReturn<R, E2>;
-  tryRecover<E2>(fn: (e: E) => Result<NoInfer<T>, E2>): Result<T, E2> {
+    fn: (e: InferErr<R>) => Result<B, E2>,
+  ): TryRecoverReturn<R, B, E2>;
+  tryRecover<E2, B = T>(fn: (e: E) => Result<B, E2>): Result<B, E2> {
     return tryOrPanic(() => fn(this.error), "tryRecover callback threw");
   }
 
   /**
-   * Attempts to recover from Err into the same success type asynchronously.
+   * Attempts to recover from Err asynchronously, allowing a new success type.
    *
    * @template E2 New error type.
-   * @param fn Async recovery function returning Result with the same success type.
+   * @template B Success type returned by the recovery function.
+   * @param fn Async recovery function returning a Result.
    * @returns Promise of Result from fn.
    * @throws {Panic} If fn throws synchronously or rejects.
    *
    * @example
-   * await err<number, string>("missing").tryRecoverAsync(async e => e === "missing" ? ok(0) : err(new Error(e))) // Ok(0)
+   * await err<number, string>("missing").tryRecoverAsync(async e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
-  tryRecoverAsync<E2>(
+  tryRecoverAsync<E2, B = T>(
     this: Err<T, E>,
-    fn: (e: E) => Promise<Result<NoInfer<T>, E2>>,
-  ): Promise<Result<T, E2>>;
-  tryRecoverAsync<E2, R extends AnyResult = Result<T, E>>(
+    fn: (e: E) => Promise<Result<B, E2>>,
+  ): Promise<Result<B, E2>>;
+  tryRecoverAsync<E2, B = T, R extends AnyResult = Result<T, E>>(
     this: R,
-    fn: (e: InferErr<R>) => Promise<Result<NoInfer<InferSuccess<R>>, E2>>,
-  ): Promise<TryRecoverReturn<R, E2>>;
-  tryRecoverAsync<E2>(fn: (e: E) => Promise<Result<NoInfer<T>, E2>>): Promise<Result<T, E2>> {
+    fn: (e: InferErr<R>) => Promise<Result<B, E2>>,
+  ): Promise<TryRecoverReturn<R, B, E2>>;
+  tryRecoverAsync<E2, B = T>(fn: (e: E) => Promise<Result<B, E2>>): Promise<Result<B, E2>> {
     return tryOrPanicAsync(() => fn(this.error), "tryRecoverAsync callback threw");
   }
 

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -1,9 +1,10 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { matchError, matchErrorPartial, Result, TaggedError } from "./index";
+import { matchError, matchErrorPartial, type Ok, Result, TaggedError } from "./index";
 
 class ErrorA extends TaggedError("ErrorA")<{}> {}
 class ErrorB extends TaggedError("ErrorB")<{}> {}
 class ErrorC extends TaggedError("ErrorC")<{}> {}
+class DetailedError extends TaggedError("DetailedError")<{ detail: string }> {}
 
 class StructuralTaggedError extends Error {
   readonly _tag = "StructuralTaggedError";
@@ -199,6 +200,90 @@ describe("matchErrorPartial", () => {
       (_err) => 0,
     );
     expectTypeOf(outcome).toEqualTypeOf<"specific" | number>();
+  });
+
+  it("infers handler returns and unhandled errors with data-first identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB | ErrorC>(new ErrorA());
+    const outcome = matchErrorPartial(result.error, {
+      ErrorA: (_err) => "handled" as const,
+    });
+    expectTypeOf(outcome).toEqualTypeOf<"handled" | ErrorB | ErrorC>();
+  });
+
+  it("infers handler returns and unhandled errors with data-last identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB | ErrorC>(new ErrorA());
+    const outcome = matchErrorPartial({
+      ErrorA: (_err) => "handled" as const,
+    })(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"handled" | ErrorB | ErrorC>();
+  });
+
+  it("accepts a concrete handler annotation in data-last identity form", () => {
+    const result = Result.err<void, DetailedError | ErrorB>(
+      new DetailedError({ detail: "context" }),
+    );
+    const outcome = matchErrorPartial({
+      DetailedError: (error: DetailedError) => Result.ok(error),
+    })(result.error);
+
+    expectTypeOf(outcome).toEqualTypeOf<Ok<DetailedError, never> | ErrorB>();
+  });
+
+  it("rejects a concrete handler annotation with a mismatched tag", () => {
+    const result = Result.err<void, DetailedError | ErrorB>(
+      new DetailedError({ detail: "context" }),
+    );
+    const matcher = matchErrorPartial({
+      // @ts-expect-error - ErrorB does not accept the DetailedError tag
+      DetailedError: (error: ErrorB) => Result.ok(error),
+    });
+
+    matcher(result.error);
+  });
+
+  it("infers the original error union for an empty identity handler map", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+
+    expectTypeOf(matchErrorPartial(result.error, {})).toEqualTypeOf<ErrorA | ErrorB>();
+    expectTypeOf(matchErrorPartial({})(result.error)).toEqualTypeOf<ErrorA | ErrorB>();
+  });
+
+  it("drops the identity branch when every error is handled", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(result.error, {
+      ErrorA: () => "A" as const,
+      ErrorB: () => 2 as const,
+    });
+    expectTypeOf(outcome).toEqualTypeOf<"A" | 2>();
+  });
+
+  it("keeps E conservatively with explicit E and R for identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const handlers = {
+      ErrorA: () => "A",
+    };
+
+    const dataFirst = matchErrorPartial<ErrorA | ErrorB, string>(result.error, handlers);
+    const dataLast = matchErrorPartial<ErrorA | ErrorB, string>(handlers)(result.error);
+    expectTypeOf(dataFirst).toEqualTypeOf<string | ErrorA | ErrorB>();
+    expectTypeOf(dataLast).toEqualTypeOf<string | ErrorA | ErrorB>();
+  });
+
+  it("excludes handled errors with explicit E, R, and H for identity fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const handlers = {
+      ErrorA: () => "A",
+    };
+
+    const dataFirst = matchErrorPartial<ErrorA | ErrorB, string, typeof handlers>(
+      result.error,
+      handlers,
+    );
+    const dataLast = matchErrorPartial<ErrorA | ErrorB, string, typeof handlers>(handlers)(
+      result.error,
+    );
+    expectTypeOf(dataFirst).toEqualTypeOf<string | ErrorB>();
+    expectTypeOf(dataLast).toEqualTypeOf<string | ErrorB>();
   });
 
   it("infers only the fallback return for an empty handler map", () => {

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -1,0 +1,291 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { matchError, matchErrorPartial, Result, TaggedError } from "./index";
+
+class ErrorA extends TaggedError("ErrorA")<{}> {}
+class ErrorB extends TaggedError("ErrorB")<{}> {}
+class ErrorC extends TaggedError("ErrorC")<{}> {}
+
+class StructuralTaggedError extends Error {
+  readonly _tag = "StructuralTaggedError";
+}
+
+type HttpErrorResponse = {
+  readonly status: number;
+  readonly message: string;
+};
+
+describe("matchError", () => {
+  it("infers union from divergent handler returns", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError(result.error, {
+      ErrorA: (_err) => 1,
+      ErrorB: (_err) => "B",
+    });
+    expectTypeOf(outcome).toEqualTypeOf<number | string>();
+  });
+
+  it("drops `never` contributed by a throwing handler", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError(result.error, {
+      ErrorA: (_err) => 1,
+      ErrorB: (err) => {
+        throw err;
+      },
+    });
+    expectTypeOf(outcome).toEqualTypeOf<number>();
+  });
+
+  it("infers `never` when every handler throws", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError(result.error, {
+      ErrorA: (err) => {
+        throw err;
+      },
+      ErrorB: (err) => {
+        throw err;
+      },
+    });
+    expectTypeOf(outcome).toBeNever();
+  });
+
+  it("supports a concrete return type when other handlers throw", () => {
+    const toHttpErrorResponse = (error: ErrorA | ErrorB): HttpErrorResponse =>
+      matchError(error, {
+        ErrorA: () => ({ status: 400, message: "Invalid request" }),
+        ErrorB: (err) => {
+          throw err;
+        },
+      });
+
+    expectTypeOf(toHttpErrorResponse).returns.toEqualTypeOf<HttpErrorResponse>();
+  });
+
+  it("continues to support structurally tagged errors", () => {
+    const error = new StructuralTaggedError("structural");
+    const outcome = matchError(error, {
+      StructuralTaggedError: () => "handled" as const,
+    });
+    expectTypeOf(outcome).toEqualTypeOf<"handled">();
+  });
+
+  it("narrows handler params to the matched error (data-first)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchError(result.error, {
+      ErrorA: (e) => expectTypeOf(e).toEqualTypeOf<ErrorA>(),
+      ErrorB: (e) => expectTypeOf(e).toEqualTypeOf<ErrorB>(),
+    });
+  });
+
+  it("rejects a non-exhaustive handler map (data-first)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    // @ts-expect-error - ErrorB handler is missing
+    matchError(result.error, {
+      ErrorA: (_err) => 1,
+    });
+  });
+
+  it("infers union from divergent handler returns data-last", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError({
+      ErrorA: () => 1,
+      ErrorB: () => "B",
+    })(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<number | string>();
+  });
+
+  it("drops `never` data-last", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError({
+      ErrorA: (_err) => "A" as const,
+      ErrorB: (err) => {
+        throw err;
+      },
+    })(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"A">();
+  });
+
+  it("rejects a non-exhaustive handler map at application (data-last)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const matcher = matchError({
+      ErrorA: (_err) => 1,
+    });
+    // @ts-expect-error - ErrorB is unhandled, so the error union is not exhaustively matched
+    matcher(result.error);
+  });
+
+  it("accepts explicit type parameters", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError<ErrorA | ErrorB, string>(result.error, {
+      ErrorA: (_err) => "A" as const,
+      ErrorB: (_err) => "B" as const,
+    });
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("explicit R rejects a handler returning the wrong type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchError<ErrorA | ErrorB, string>(result.error, {
+      ErrorA: (_err) => "A",
+      // @ts-expect-error - number is not assignable to string
+      ErrorB: (_err) => 123,
+    });
+  });
+
+  it("explicit R constrains all handler returns (data-last)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchError<ErrorA | ErrorB, string>({
+      ErrorA: (_err) => "A" as const,
+      ErrorB: (_err) => "B" as const,
+    })(result.error);
+    expectTypeOf(outcome).toBeString();
+  });
+});
+
+describe("matchErrorPartial", () => {
+  it("explicit R constrains all handler returns (data-first)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (_err) => "B" as const,
+      },
+      (_err) => "fallback" as const,
+    );
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("explicit R rejects a handler returning the wrong type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      {
+        // @ts-expect-error - number is not assignable to string
+        ErrorA: (_err) => 123,
+      },
+      (_err) => "fallback",
+    );
+  });
+
+  it("explicit R rejects a fallback returning the wrong type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      { ErrorA: () => "A" },
+      // @ts-expect-error - number is not assignable to string
+      (_err) => 123,
+    );
+  });
+
+  it("explicit R constrains all handler returns (data-last)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (_err) => "B" as const,
+      },
+      (_err) => "fallback" as const,
+    )(result.error);
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("infers union from divergent handler and fallback returns", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(
+      result.error,
+      {
+        ErrorA: (_err) => "specific" as const,
+      },
+      (_err) => 0,
+    );
+    expectTypeOf(outcome).toEqualTypeOf<"specific" | number>();
+  });
+
+  it("infers only the fallback return for an empty handler map", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(result.error, {}, () => "fallback" as const);
+    expectTypeOf(outcome).toEqualTypeOf<"fallback">();
+  });
+
+  it("continues to support structurally tagged errors", () => {
+    const error = new StructuralTaggedError("structural");
+    const outcome = matchErrorPartial(error, {}, () => "fallback" as const);
+    expectTypeOf(outcome).toEqualTypeOf<"fallback">();
+  });
+
+  it("drops `never` from throwing handler and fallback", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (err) => {
+          throw err;
+        },
+      },
+      (err) => {
+        throw err;
+      },
+    );
+    expectTypeOf(outcome).toEqualTypeOf<"A">();
+  });
+
+  it("works data-last (pipeable)", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial(
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (err) => {
+          throw err;
+        },
+      },
+      (_err) => "fallback" as const,
+    )(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+  });
+
+  it("accepts explicit type parameters", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matchErrorPartial<ErrorA | ErrorB, string>(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+        ErrorB: (_err) => "B" as const,
+      },
+      (_err) => "fallback" as const,
+    );
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("narrows fallback type to exclude handled errors", () => {
+    const result = Result.err<void, ErrorA | ErrorB | ErrorC>(new ErrorA());
+    const outcome = matchErrorPartial(
+      result.error,
+      {
+        ErrorA: (_err) => "A" as const,
+      },
+      (err) => {
+        expectTypeOf(err).toEqualTypeOf<ErrorB | ErrorC>();
+        return "fallback" as const;
+      },
+    );
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+  });
+
+  it("fallback error is accessible in data-last form without contextual E", () => {
+    // Should NOT produce `never` — fallback param must be accessible even when
+    // E is deferred (no contextual error type at matchErrorPartial call site).
+    const matcher = matchErrorPartial(
+      {
+        ErrorA: (_err) => "A" as const,
+      },
+      (e) => {
+        expectTypeOf(e._tag).toBeString();
+        return "fallback" as const;
+      },
+    );
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = matcher(result.error);
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+  });
+});

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { matchError, matchErrorPartial, type Ok, Result, TaggedError } from "./index";
+import { type Err, matchError, matchErrorPartial, type Ok, Result, TaggedError } from "./index";
 
 class ErrorA extends TaggedError("ErrorA")<{}> {}
 class ErrorB extends TaggedError("ErrorB")<{}> {}
@@ -357,8 +357,8 @@ describe("matchErrorPartial", () => {
     expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
   });
 
-  it("fallback error is accessible in data-last form without contextual E", () => {
-    // Should NOT produce `never` — fallback param must be accessible even when
+  it("onUnhandled error is accessible in data-last form without contextual E", () => {
+    // Should NOT produce `never` — the onUnhandled parameter must be accessible even when
     // E is deferred (no contextual error type at matchErrorPartial call site).
     const matcher = matchErrorPartial(
       {
@@ -366,11 +366,42 @@ describe("matchErrorPartial", () => {
       },
       (e) => {
         expectTypeOf(e._tag).toBeString();
-        return "fallback" as const;
+        return "onUnhandled" as const;
       },
     );
     const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
     const outcome = matcher(result.error);
-    expectTypeOf(outcome).toEqualTypeOf<"A" | "fallback">();
+    expectTypeOf(outcome).toEqualTypeOf<"A" | "onUnhandled">();
+  });
+
+  it("preserves unhandled errors when the pipeable onUnhandled callback is Result.err", () => {
+    type ApiError = ErrorA | ErrorB | ErrorC;
+    const getError = (): ApiError => new ErrorA();
+    const matcher = matchErrorPartial(
+      {
+        ErrorC: (handled: ErrorC) => Result.ok(handled),
+      },
+      Result.err,
+    );
+
+    const outcome = matcher(getError());
+
+    expectTypeOf(outcome).toEqualTypeOf<Ok<ErrorC, never> | Err<never, ErrorA | ErrorB>>();
+  });
+
+  it("composes a Result.err onUnhandled callback with widening tryRecover", () => {
+    type ApiError = ErrorA | ErrorB | ErrorC;
+    const getResult = (): Result<string, ApiError> => Result.err(new ErrorA());
+
+    const recovered = getResult().tryRecover(
+      matchErrorPartial(
+        {
+          ErrorC: (handled: ErrorC) => Result.ok(handled),
+        },
+        Result.err,
+      ),
+    );
+
+    expectTypeOf(recovered).toEqualTypeOf<Result<string | ErrorC, ErrorA | ErrorB>>();
   });
 });

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -30,6 +30,10 @@ class StructuralTaggedError extends Error {
   readonly _tag = "StructuralTaggedError";
 }
 
+class InheritedPropertyTagError extends Error {
+  readonly _tag = "toString";
+}
+
 describe("TaggedError", () => {
   describe("construction", () => {
     it("sets name to tag", () => {
@@ -335,6 +339,67 @@ describe("TaggedError", () => {
         message: "failed",
       });
       expect(matchPartialAppError(error)).toBe("fallback: NetworkError");
+    });
+
+    it("uses the identity fallback in data-first form", () => {
+      const matchWithIdentity = (error: AppError) =>
+        matchErrorPartial(error, {
+          NotFoundError: (e) => `missing: ${e.id}`,
+        });
+      const handled = new NotFoundError({ id: "123", message: "not found" });
+      const unhandled = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      expect(matchWithIdentity(handled)).toBe("missing: 123");
+      expect(matchWithIdentity(unhandled)).toBe(unhandled);
+    });
+
+    it("uses the identity fallback in data-last form", () => {
+      const matchWithIdentity = matchErrorPartial({
+        NotFoundError: (e) => `handled: ${e._tag}`,
+      });
+      const handled = new NotFoundError({ id: "123", message: "not found" });
+      const unhandled = new ValidationError({ field: "email", message: "invalid" });
+
+      expect(matchWithIdentity(handled)).toBe("handled: NotFoundError");
+      expect(matchWithIdentity(unhandled)).toBe(unhandled);
+    });
+
+    it("is identity for an empty handler map", () => {
+      const error: AppError = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      expect(matchErrorPartial(error, {})).toBe(error);
+      expect(matchErrorPartial({})(error)).toBe(error);
+    });
+
+    it("returns an unhandled structural tagged error unchanged", () => {
+      const error = new StructuralTaggedError("structural");
+
+      expect(matchErrorPartial(error, {})).toBe(error);
+      expect(matchErrorPartial({})(error)).toBe(error);
+    });
+
+    it("ignores inherited handler properties", () => {
+      const error = new InheritedPropertyTagError("prototype collision");
+
+      expect(matchErrorPartial(error, {})).toBe(error);
+      expect(matchErrorPartial({})(error)).toBe(error);
+      expect(matchErrorPartial(error, {}, (unhandled) => unhandled)).toBe(error);
+    });
+
+    it("calls an explicitly defined handler that shares an inherited property name", () => {
+      const error = new InheritedPropertyTagError("own handler");
+
+      expect(
+        matchErrorPartial(error, {
+          toString: (handled) => `handled: ${handled.message}`,
+        }),
+      ).toBe("handled: own handler");
     });
 
     it("propagates an exception from the selected fallback", () => {

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -26,6 +26,10 @@ class NetworkError extends TaggedError("NetworkError")<{
 
 type AppError = NotFoundError | ValidationError | NetworkError;
 
+class StructuralTaggedError extends Error {
+  readonly _tag = "StructuralTaggedError";
+}
+
 describe("TaggedError", () => {
   describe("construction", () => {
     it("sets name to tag", () => {
@@ -241,6 +245,39 @@ describe("TaggedError", () => {
       expect(matchAppError(error)).toBe("network: https://api.example.com");
     });
 
+    it("propagates an exception from the selected handler", () => {
+      const throwSelectedHandler = (error: AppError) =>
+        matchError(error, {
+          NotFoundError: (e) => `missing: ${e.id}`,
+          ValidationError: (e) => `invalid: ${e.field}`,
+          NetworkError: (e) => {
+            throw e;
+          },
+        });
+      const error = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      let thrown: unknown;
+      try {
+        throwSelectedHandler(error);
+      } catch (cause) {
+        thrown = cause;
+      }
+
+      expect(thrown).toBe(error);
+    });
+
+    it("matches structurally tagged errors without requiring TaggedError methods", () => {
+      const error = new StructuralTaggedError("structural");
+      const outcome = matchError(error, {
+        StructuralTaggedError: (e) => e.message,
+      });
+
+      expect(outcome).toBe("structural");
+    });
+
     it("works data-last (pipeable)", () => {
       const error: AppError = new NotFoundError({ id: "456", message: "not found" });
       const matcher = matchError<AppError, string>({
@@ -298,6 +335,26 @@ describe("TaggedError", () => {
         message: "failed",
       });
       expect(matchPartialAppError(error)).toBe("fallback: NetworkError");
+    });
+
+    it("propagates an exception from the selected fallback", () => {
+      const throwSelectedFallback = (error: AppError) =>
+        matchErrorPartial(error, { NotFoundError: (e) => `missing: ${e.id}` }, (e) => {
+          throw e;
+        });
+      const error = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      let thrown: unknown;
+      try {
+        throwSelectedFallback(error);
+      } catch (cause) {
+        thrown = cause;
+      }
+
+      expect(thrown).toBe(error);
     });
 
     it("narrows fallback type to exclude handled errors (data-first)", () => {

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -367,6 +367,25 @@ describe("TaggedError", () => {
       expect(matchWithIdentity(unhandled)).toBe(unhandled);
     });
 
+    it("wraps unhandled errors when Result.err is the pipeable onUnhandled callback", () => {
+      const recoverNotFound = matchErrorPartial(
+        {
+          NotFoundError: (error: NotFoundError) => Result.ok(error.id),
+        },
+        Result.err,
+      );
+      const handled = new NotFoundError({ id: "123", message: "not found" });
+      const unhandled = new ValidationError({ field: "email", message: "invalid" });
+
+      expect(recoverNotFound(handled).unwrap()).toBe("123");
+
+      const unhandledResult = recoverNotFound(unhandled);
+      expect(Result.isError(unhandledResult)).toBe(true);
+      if (Result.isError(unhandledResult)) {
+        expect(unhandledResult.error).toBe(unhandled);
+      }
+    });
+
     it("is identity for an empty handler map", () => {
       const error: AppError = new NetworkError({
         url: "https://api.example.com",

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   TaggedError,
   UnhandledException,
+  ResultDeserializationError,
   matchError,
   matchErrorPartial,
   isTaggedError,
@@ -11,17 +12,17 @@ import { Result, type Result as ResultType } from "./result";
 class NotFoundError extends TaggedError("NotFoundError")<{
   id: string;
   message: string;
-}>() {}
+}> {}
 
 class ValidationError extends TaggedError("ValidationError")<{
   field: string;
   message: string;
-}>() {}
+}> {}
 
 class NetworkError extends TaggedError("NetworkError")<{
   url: string;
   message: string;
-}>() {}
+}> {}
 
 type AppError = NotFoundError | ValidationError | NetworkError;
 
@@ -53,7 +54,7 @@ describe("TaggedError", () => {
       class ErrorWithCause extends TaggedError("ErrorWithCause")<{
         message: string;
         cause: unknown;
-      }>() {}
+      }> {}
 
       const error = new ErrorWithCause({ message: "wrapper", cause });
       expect(error.stack).toContain("Caused by:");
@@ -65,11 +66,11 @@ describe("TaggedError", () => {
       class MiddleError extends TaggedError("MiddleError")<{
         message: string;
         cause: unknown;
-      }>() {}
+      }> {}
       class OuterError extends TaggedError("OuterError")<{
         message: string;
         cause: unknown;
-      }>() {}
+      }> {}
 
       const middle = new MiddleError({ message: "middle", cause: inner });
       const outer = new OuterError({ message: "outer", cause: middle });
@@ -132,22 +133,68 @@ describe("TaggedError", () => {
       expect(NotFoundError.is({ _tag: "NotFoundError" })).toBe(false);
     });
 
+    it("narrows unknown to the concrete TaggedError subclass", () => {
+      const error: unknown = new NotFoundError({ id: "123", message: "not found" });
+
+      if (!NotFoundError.is(error)) {
+        throw new Error("Expected NotFoundError.is to recognize its own instance");
+      }
+
+      const _error: NotFoundError = error;
+      const id: string = error.id;
+      const tag: "NotFoundError" = error._tag;
+      // @ts-expect-error - narrowing must not add properties from another TaggedError subclass
+      void error.field;
+      void _error;
+      expect({ id, tag }).toEqual({ id: "123", tag: "NotFoundError" });
+    });
+
+    it("narrows built-in TaggedError subclasses with custom constructors", () => {
+      const invalidValue = { status: "invalid" };
+      const error: unknown = new ResultDeserializationError({ value: invalidValue });
+
+      if (!ResultDeserializationError.is(error)) {
+        throw new Error("Expected ResultDeserializationError.is to recognize its own instance");
+      }
+
+      const _error: ResultDeserializationError = error;
+      const value: unknown = error.value;
+      void _error;
+      expect(value).toBe(invalidValue);
+    });
+
+    it("distinguishes subclasses that share a TaggedError base class", () => {
+      const SharedError = TaggedError("SharedError");
+      class FooError extends SharedError<{ foo: string }> {}
+      class BarError extends SharedError<{ bar: string }> {}
+      class ChildFooError extends FooError {}
+
+      const fooError = new FooError({ foo: "foo" });
+      const barError = new BarError({ bar: "bar" });
+      const childFooError = new ChildFooError({ foo: "child" });
+
+      expect(FooError.is(fooError)).toBe(true);
+      expect(FooError.is(childFooError)).toBe(true);
+      expect(FooError.is(barError)).toBe(false);
+      expect(BarError.is(fooError)).toBe(false);
+    });
+
     it("FooError.is(fooError) is true", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       expect(FooError.is(fooError)).toBe(true);
     });
 
     it("BarError.is(fooError) is false", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
-      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
+      class BarError extends TaggedError("BarError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       expect(BarError.is(fooError)).toBe(false);
     });
 
     it("isTaggedError(fooError) is true for any TaggedError", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
-      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
+      class BarError extends TaggedError("BarError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       const barError = new BarError({ message: "bar" });
       expect(isTaggedError(fooError)).toBe(true);
@@ -155,8 +202,8 @@ describe("TaggedError", () => {
     });
 
     it("TaggedError.is(fooError) is true for any TaggedError", () => {
-      class FooError extends TaggedError("FooError")<{ message: string }>() {}
-      class BarError extends TaggedError("BarError")<{ message: string }>() {}
+      class FooError extends TaggedError("FooError")<{ message: string }> {}
+      class BarError extends TaggedError("BarError")<{ message: string }> {}
       const fooError = new FooError({ message: "foo" });
       const barError = new BarError({ message: "bar" });
       expect(TaggedError.is(fooError)).toBe(true);

--- a/src/error.ts
+++ b/src/error.ts
@@ -140,8 +140,23 @@ type MatchReturn<H> = {
 /** Partial handler map for non-exhaustive matching */
 type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlersWithReturn<E, R>>;
 
+/** Deferred handlers with explicitly annotated concrete error parameters. */
+type AnnotatedMatchHandlers = Record<string, (err: never) => unknown>;
+
+/** Ensure each annotated handler parameter accepts the tag represented by its key. */
+type ValidateAnnotatedMatchHandlers<H extends AnnotatedMatchHandlers> = {
+  [K in keyof H]: H[K] extends (err: infer E extends TaggedErrorLike) => unknown
+    ? Extract<K, string> extends E["_tag"]
+      ? H[K]
+      : never
+    : never;
+};
+
 /** Extract handled tags from a handlers object */
 type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
+
+/** Error variants not selected by a partial handler map. */
+type UnhandledMatchErrors<E extends TaggedErrorLike, H> = Exclude<E, { _tag: HandledTags<E, H> }>;
 
 /**
  * Exhaustive pattern match on tagged error union.
@@ -176,61 +191,123 @@ export const matchError: {
   return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
 });
 
+const returnTaggedErrorIdentity = (error: TaggedErrorLike): TaggedErrorLike => error;
+
+const applyMatchErrorPartial = (
+  err: TaggedErrorLike,
+  handlers: Partial<MatchHandlers<TaggedErrorLike>>,
+  onUnhandled: (e: TaggedErrorLike) => unknown,
+): unknown => {
+  const handler = Object.hasOwn(handlers, err._tag) ? handlers[err._tag] : undefined;
+  if (typeof handler === "function") {
+    return handler(err);
+  }
+  return onUnhandled(err);
+};
+
 /**
- * Partial pattern match with fallback for unhandled tags.
+ * Partially matches tagged errors, returning unhandled errors unchanged by default.
  *
  * @example
- * matchErrorPartial(err, {
+ * const transformed = matchErrorPartial(err, {
  *   NotFoundError: (e) => `Missing: ${e.id}`,
- * }, (e) => `Unknown: ${e.message}`);
+ * });
+ *
+ * // Annotate variant-specific handlers when using the pipeable form.
+ * const transformError = matchErrorPartial({
+ *   NotFoundError: (e: NotFoundError) => `Missing: ${e.id}`,
+ * });
+ *
+ * // Supply a fallback to transform unhandled errors instead.
+ * const message = matchErrorPartial(
+ *   err,
+ *   { NotFoundError: (e) => `Missing: ${e.id}` },
+ *   (e) => `Unknown: ${e.message}`,
+ * );
  */
-export const matchErrorPartial: {
-  /** Pipeable — E deferred to call site, fallback receives a tagged error-like value */
-  <H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
-    handlers: H,
-    fallback: (e: TaggedErrorLike) => R,
-  ): {
-    <E extends TaggedErrorLike>(err: E): MatchReturn<H> | R;
-  };
-  /** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
-  <
-    E extends TaggedErrorLike,
-    R,
-    const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
-  >(
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): (err: E) => R;
-  /** Data-first with inference — E from err, H from handlers, R from fallback */
-  <E extends TaggedErrorLike, const H extends Partial<MatchHandlers<E>>, R>(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): MatchReturn<H> | R;
-  /** Data-first with explicit R — H inferred via default, fallback narrowed */
-  <
-    E extends TaggedErrorLike,
-    R,
-    const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
-  >(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
-  ): R;
-} = dual(
-  3,
-  (
-    err: TaggedErrorLike,
-    handlers: Partial<MatchHandlers<TaggedErrorLike>>,
-    fallback: (e: TaggedErrorLike) => unknown,
-  ): unknown => {
-    const handler = handlers[err._tag];
-    if (typeof handler === "function") {
-      return handler(err);
-    }
-    return fallback(err);
-  },
-);
+export function matchErrorPartial<H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
+  handlers: H,
+  fallback: (e: TaggedErrorLike) => R,
+): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | R;
+/** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
+>(handlers: H, fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R): (err: E) => R;
+/** Pipeable with identity fallback — E is deferred until the matcher is applied */
+export function matchErrorPartial<const H extends Partial<MatchHandlers<TaggedErrorLike>>>(
+  handlers: H,
+): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | UnhandledMatchErrors<E, H>;
+/** Pipeable with explicitly annotated handler parameters and identity fallback */
+export function matchErrorPartial<const H extends AnnotatedMatchHandlers>(
+  handlers: H & ValidateAnnotatedMatchHandlers<H>,
+): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | UnhandledMatchErrors<E, H>;
+/** Pipeable with explicit E, R and identity fallback — unhandled E remains conservative */
+export function matchErrorPartial<E extends TaggedErrorLike, R>(
+  handlers: PartialMatchHandlers<E, R>,
+): (err: E) => R | E;
+/** Pipeable with exact H and identity fallback — handled variants are excluded */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R>,
+>(handlers: H): (err: E) => R | UnhandledMatchErrors<E, H>;
+/** Data-first with identity fallback — returns handler results or unhandled variants */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  const H extends Partial<MatchHandlers<E>>,
+>(err: E, handlers: H): MatchReturn<H> | UnhandledMatchErrors<E, H>;
+/** Data-first with explicit E, R and identity fallback — unhandled E remains conservative */
+export function matchErrorPartial<E extends TaggedErrorLike, R>(
+  err: E,
+  handlers: PartialMatchHandlers<E, R>,
+): R | E;
+/** Data-first with exact H and identity fallback — handled variants are excluded */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R>,
+>(err: E, handlers: H): R | UnhandledMatchErrors<E, H>;
+/** Data-first with inference — E from err, H from handlers, R from fallback */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  const H extends Partial<MatchHandlers<E>>,
+  R,
+>(
+  err: E,
+  handlers: H,
+  fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+): MatchReturn<H> | R;
+/** Data-first with explicit R — H inferred via default, fallback narrowed */
+export function matchErrorPartial<
+  E extends TaggedErrorLike,
+  R,
+  const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
+>(err: E, handlers: H, fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R): R;
+export function matchErrorPartial(
+  errOrHandlers: TaggedErrorLike | Partial<MatchHandlers<TaggedErrorLike>>,
+  handlersOrFallback?: Partial<MatchHandlers<TaggedErrorLike>> | ((e: TaggedErrorLike) => unknown),
+  fallback?: (e: TaggedErrorLike) => unknown,
+): unknown {
+  if (typeof handlersOrFallback === "function") {
+    // SAFETY: In the two-argument pipeable overload, the first argument is the handler map.
+    const handlers = errOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
+    return (err: TaggedErrorLike): unknown =>
+      applyMatchErrorPartial(err, handlers, handlersOrFallback);
+  }
+
+  if (handlersOrFallback === undefined) {
+    // SAFETY: In the one-argument pipeable overload, the first argument is the handler map.
+    const handlers = errOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
+    return (err: TaggedErrorLike): unknown =>
+      applyMatchErrorPartial(err, handlers, returnTaggedErrorIdentity);
+  }
+
+  // SAFETY: In data-first overloads, the first argument is the tagged error.
+  const err = errOrHandlers as TaggedErrorLike;
+  return applyMatchErrorPartial(err, handlersOrFallback, fallback ?? returnTaggedErrorIdentity);
+}
 
 /**
  * Type guard for tagged error instances.

--- a/src/error.ts
+++ b/src/error.ts
@@ -207,6 +207,7 @@ const applyMatchErrorPartial = (
 
 /**
  * Partially matches tagged errors, returning unhandled errors unchanged by default.
+ * Passing `Result.err` as the pipeable `onUnhandled` callback preserves unhandled variants.
  *
  * @example
  * const transformed = matchErrorPartial(err, {
@@ -218,95 +219,113 @@ const applyMatchErrorPartial = (
  *   NotFoundError: (e: NotFoundError) => `Missing: ${e.id}`,
  * });
  *
- * // Supply a fallback to transform unhandled errors instead.
+ * // Supply an onUnhandled callback to transform unhandled errors instead.
  * const message = matchErrorPartial(
  *   err,
  *   { NotFoundError: (e) => `Missing: ${e.id}` },
  *   (e) => `Unknown: ${e.message}`,
  * );
  */
+export function matchErrorPartial<const H extends AnnotatedMatchHandlers>(
+  handlers: H & ValidateAnnotatedMatchHandlers<H>,
+  onUnhandled: typeof err,
+): <E extends TaggedErrorLike>(error: E) => MatchReturn<H> | Err<never, UnhandledMatchErrors<E, H>>;
+/** Pipeable with a general onUnhandled callback while deferring E until application. */
 export function matchErrorPartial<H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
   handlers: H,
-  fallback: (e: TaggedErrorLike) => R,
-): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | R;
-/** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
+  onUnhandled: (error: TaggedErrorLike) => R,
+): <E extends TaggedErrorLike>(error: E) => MatchReturn<H> | R;
+/** Pipeable with explicit E, R — H inferred via default, onUnhandled narrowed */
 export function matchErrorPartial<
   E extends TaggedErrorLike,
   R,
   const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
->(handlers: H, fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R): (err: E) => R;
-/** Pipeable with identity fallback — E is deferred until the matcher is applied */
+>(
+  handlers: H,
+  onUnhandled: (error: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+): (error: E) => R;
+/** Pipeable with identity onUnhandled behavior — E is deferred until application */
 export function matchErrorPartial<const H extends Partial<MatchHandlers<TaggedErrorLike>>>(
   handlers: H,
 ): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | UnhandledMatchErrors<E, H>;
-/** Pipeable with explicitly annotated handler parameters and identity fallback */
+/** Pipeable with annotated handler parameters and identity onUnhandled behavior */
 export function matchErrorPartial<const H extends AnnotatedMatchHandlers>(
   handlers: H & ValidateAnnotatedMatchHandlers<H>,
 ): <E extends TaggedErrorLike>(err: E) => MatchReturn<H> | UnhandledMatchErrors<E, H>;
-/** Pipeable with explicit E, R and identity fallback — unhandled E remains conservative */
+/** Pipeable with explicit E, R and identity onUnhandled behavior; E remains conservative */
 export function matchErrorPartial<E extends TaggedErrorLike, R>(
   handlers: PartialMatchHandlers<E, R>,
 ): (err: E) => R | E;
-/** Pipeable with exact H and identity fallback — handled variants are excluded */
+/** Pipeable with exact H and identity onUnhandled behavior; handled variants are excluded */
 export function matchErrorPartial<
   E extends TaggedErrorLike,
   R,
   const H extends PartialMatchHandlers<E, R>,
 >(handlers: H): (err: E) => R | UnhandledMatchErrors<E, H>;
-/** Data-first with identity fallback — returns handler results or unhandled variants */
+/** Data-first with identity onUnhandled behavior; returns results or unhandled variants */
 export function matchErrorPartial<
   E extends TaggedErrorLike,
   const H extends Partial<MatchHandlers<E>>,
 >(err: E, handlers: H): MatchReturn<H> | UnhandledMatchErrors<E, H>;
-/** Data-first with explicit E, R and identity fallback — unhandled E remains conservative */
+/** Data-first with explicit E, R and identity onUnhandled behavior; E remains conservative */
 export function matchErrorPartial<E extends TaggedErrorLike, R>(
   err: E,
   handlers: PartialMatchHandlers<E, R>,
 ): R | E;
-/** Data-first with exact H and identity fallback — handled variants are excluded */
+/** Data-first with exact H and identity onUnhandled behavior; handled variants are excluded */
 export function matchErrorPartial<
   E extends TaggedErrorLike,
   R,
   const H extends PartialMatchHandlers<E, R>,
 >(err: E, handlers: H): R | UnhandledMatchErrors<E, H>;
-/** Data-first with inference — E from err, H from handlers, R from fallback */
+/** Data-first with inference — E from error, H from handlers, R from onUnhandled */
 export function matchErrorPartial<
   E extends TaggedErrorLike,
   const H extends Partial<MatchHandlers<E>>,
   R,
 >(
-  err: E,
+  error: E,
   handlers: H,
-  fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+  onUnhandled: (error: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
 ): MatchReturn<H> | R;
-/** Data-first with explicit R — H inferred via default, fallback narrowed */
+/** Data-first with explicit R — H inferred via default, onUnhandled narrowed */
 export function matchErrorPartial<
   E extends TaggedErrorLike,
   R,
   const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
->(err: E, handlers: H, fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R): R;
+>(
+  error: E,
+  handlers: H,
+  onUnhandled: (error: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+): R;
 export function matchErrorPartial(
-  errOrHandlers: TaggedErrorLike | Partial<MatchHandlers<TaggedErrorLike>>,
-  handlersOrFallback?: Partial<MatchHandlers<TaggedErrorLike>> | ((e: TaggedErrorLike) => unknown),
-  fallback?: (e: TaggedErrorLike) => unknown,
+  errorOrHandlers: TaggedErrorLike | Partial<MatchHandlers<TaggedErrorLike>>,
+  handlersOrOnUnhandled?:
+    | Partial<MatchHandlers<TaggedErrorLike>>
+    | ((error: TaggedErrorLike) => unknown),
+  onUnhandled?: (error: TaggedErrorLike) => unknown,
 ): unknown {
-  if (typeof handlersOrFallback === "function") {
+  if (typeof handlersOrOnUnhandled === "function") {
     // SAFETY: In the two-argument pipeable overload, the first argument is the handler map.
-    const handlers = errOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
-    return (err: TaggedErrorLike): unknown =>
-      applyMatchErrorPartial(err, handlers, handlersOrFallback);
+    const handlers = errorOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
+    return (error: TaggedErrorLike): unknown =>
+      applyMatchErrorPartial(error, handlers, handlersOrOnUnhandled);
   }
 
-  if (handlersOrFallback === undefined) {
+  if (handlersOrOnUnhandled === undefined) {
     // SAFETY: In the one-argument pipeable overload, the first argument is the handler map.
-    const handlers = errOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
-    return (err: TaggedErrorLike): unknown =>
-      applyMatchErrorPartial(err, handlers, returnTaggedErrorIdentity);
+    const handlers = errorOrHandlers as Partial<MatchHandlers<TaggedErrorLike>>;
+    return (error: TaggedErrorLike): unknown =>
+      applyMatchErrorPartial(error, handlers, returnTaggedErrorIdentity);
   }
 
   // SAFETY: In data-first overloads, the first argument is the tagged error.
-  const err = errOrHandlers as TaggedErrorLike;
-  return applyMatchErrorPartial(err, handlersOrFallback, fallback ?? returnTaggedErrorIdentity);
+  const error = errorOrHandlers as TaggedErrorLike;
+  return applyMatchErrorPartial(
+    error,
+    handlersOrOnUnhandled,
+    onUnhandled ?? returnTaggedErrorIdentity,
+  );
 }
 
 /**

--- a/src/error.ts
+++ b/src/error.ts
@@ -33,7 +33,7 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * class NotFoundError extends TaggedError("NotFoundError")<{
  *   id: string;
  *   message: string;
- * }>() {}
+ * }> {}
  *
  * const err = new NotFoundError({ id: "123", message: "Not found: 123" });
  * err._tag    // "NotFoundError"
@@ -43,71 +43,60 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * // Check if any tagged error
  * TaggedError.is(err) // true
  */
-export const TaggedError: {
-  <Tag extends string>(
-    tag: Tag,
-  ): <Props extends Record<string, unknown> = {}>() => TaggedErrorClass<Tag, Props>;
-  /** Type guard for any TaggedError instance */
-  is(value: unknown): value is AnyTaggedError;
-} = Object.assign(
-  <Tag extends string>(tag: Tag) =>
-    <Props extends Record<string, unknown> = {}>(): TaggedErrorClass<Tag, Props> => {
-      class Base extends Error {
-        readonly _tag: Tag = tag;
+export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag> => {
+  class Base<Props extends Record<string, unknown> = {}> extends Error {
+    readonly _tag: Tag = tag;
 
-        /** Type guard for this error class */
-        static is(value: unknown): value is Base {
-          return value instanceof Base;
-        }
+    constructor(args?: Props) {
+      const message =
+        args && "message" in args && typeof args.message === "string" ? args.message : undefined;
+      const cause = args && "cause" in args ? args.cause : undefined;
 
-        constructor(args?: Props) {
-          const message =
-            args && "message" in args && typeof args.message === "string"
-              ? args.message
-              : undefined;
-          const cause = args && "cause" in args ? args.cause : undefined;
+      super(message, cause !== undefined ? { cause } : undefined);
 
-          super(message, cause !== undefined ? { cause } : undefined);
-
-          if (args) {
-            Object.assign(this, args);
-          }
-
-          Object.setPrototypeOf(this, new.target.prototype);
-          this.name = tag;
-
-          if (cause instanceof Error && cause.stack) {
-            const indented = cause.stack.replace(/\n/g, "\n  ");
-            this.stack = `${this.stack}\nCaused by: ${indented}`;
-          }
-        }
-
-        toJSON(): object {
-          return {
-            ...this,
-            _tag: this._tag,
-            name: this.name,
-            message: this.message,
-            cause: serializeCause(this.cause),
-            stack: this.stack,
-          };
-        }
-
-        /**
-         * Makes this TaggedError yieldable in Result.gen blocks.
-         * Yielding short-circuits with this error, matching Err semantics.
-         */
-        *[Symbol.iterator](): Generator<Err<never, this>, never, unknown> {
-          yield* err(this);
-          return panic("Unreachable: Err yielded in TaggedError but generator continued", this);
-        }
+      if (args) {
+        Object.assign(this, args);
       }
 
-      // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
-      return Base as unknown as TaggedErrorClass<Tag, Props>;
-    },
-  { is: isAnyTaggedError },
-);
+      Object.setPrototypeOf(this, new.target.prototype);
+      this.name = tag;
+
+      if (cause instanceof Error && cause.stack) {
+        const indented = cause.stack.replace(/\n/g, "\n  ");
+        this.stack = `${this.stack}\nCaused by: ${indented}`;
+      }
+    }
+
+    toJSON(): object {
+      return {
+        ...this,
+        _tag: this._tag,
+        name: this.name,
+        message: this.message,
+        cause: serializeCause(this.cause),
+        stack: this.stack,
+      };
+    }
+
+    /**
+     * Makes this TaggedError yieldable in Result.gen blocks.
+     * Yielding short-circuits with this error, matching Err semantics.
+     */
+    *[Symbol.iterator](): Generator<Err<never, this>, never, unknown> {
+      yield* err(this);
+      return panic("Unreachable: Err yielded in TaggedError but generator continued", this);
+    }
+
+    /** Type guard for the concrete error class on which this method is called. */
+    static is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C> {
+      return value instanceof this;
+    }
+  }
+
+  // SAFETY: Cast needed for factory pattern - Props are assigned via Object.assign
+  return Base as unknown as TaggedErrorClass<Tag>;
+};
+TaggedError.is = isAnyTaggedError;
 
 interface IterableError extends Error {
   /** Makes TaggedError instances yieldable in Result.gen blocks. */
@@ -120,13 +109,16 @@ export type TaggedErrorInstance<Tag extends string, Props> = IterableError & {
   toJSON(): object;
 } & Readonly<Props>;
 
+/** Constructor used to infer the concrete class for static TaggedError guards. */
+type TaggedErrorConstructor = abstract new (...args: never[]) => object;
+
 /** Class type produced by TaggedError factory */
-export type TaggedErrorClass<Tag extends string, Props> = {
-  new (
+export type TaggedErrorClass<Tag extends string> = {
+  new <Props extends Record<string, unknown> = {}>(
     ...args: keyof Props extends never ? [args?: {}] : [args: Props]
   ): TaggedErrorInstance<Tag, Props>;
-  /** Type guard for this error class */
-  is(value: unknown): value is TaggedErrorInstance<Tag, Props>;
+  /** Type guard for the concrete error class on which this method is called. */
+  is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C>;
 };
 
 /** Handler map for exhaustive matching */
@@ -220,7 +212,7 @@ export const isTaggedError = isAnyTaggedError;
 export class UnhandledException extends TaggedError("UnhandledException")<{
   message: string;
   cause: unknown;
-}>() {
+}> {
   constructor(args: { cause: unknown }) {
     const message =
       args.cause instanceof Error
@@ -242,7 +234,7 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
 export class ResultDeserializationError extends TaggedError("ResultDeserializationError")<{
   message: string;
   value: unknown;
-}>() {
+}> {
   constructor(args: { value: unknown }) {
     super({
       message: `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,

--- a/src/error.ts
+++ b/src/error.ts
@@ -121,13 +121,23 @@ export type TaggedErrorClass<Tag extends string> = {
   is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C>;
 };
 
-/** Handler map for exhaustive matching */
-type MatchHandlers<E extends TaggedErrorLike, R> = {
+/** Handler map for exhaustive matching (returns inferred per-handler) */
+type MatchHandlers<E extends TaggedErrorLike> = {
+  [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => unknown;
+};
+
+/** Handler map constraining every handler to return `R` */
+type MatchHandlersWithReturn<E extends TaggedErrorLike, R> = {
   [K in E["_tag"]]: (err: Extract<E, { _tag: K }>) => R;
 };
 
+/** Union of every handler's return type */
+type MatchReturn<H> = {
+  [K in keyof H]: H[K] extends (err: never) => infer R ? R : never;
+}[keyof H];
+
 /** Partial handler map for non-exhaustive matching */
-type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlers<E, R>>;
+type PartialMatchHandlers<E extends TaggedErrorLike, R> = Partial<MatchHandlersWithReturn<E, R>>;
 
 /** Extract handled tags from a handlers object */
 type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
@@ -149,11 +159,19 @@ type HandledTags<E extends TaggedErrorLike, H> = Extract<keyof H, E["_tag"]>;
  * }));
  */
 export const matchError: {
-  <E extends TaggedErrorLike, R>(handlers: MatchHandlers<E, R>): (err: E) => R;
-  <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlers<E, R>): R;
-} = dual(2, <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlers<E, R>): R => {
+  /** Data-last, E deferred to application; returns the union of handler returns */
+  <H extends MatchHandlers<TaggedErrorLike>>(
+    handlers: H,
+  ): <E extends TaggedErrorLike & { _tag: keyof H }>(err: E) => MatchReturn<H>;
+  /** Data-last with explicit E, R constraining every handler return */
+  <E extends TaggedErrorLike, R>(handlers: MatchHandlersWithReturn<E, R>): (err: E) => R;
+  /** Data-first, inferred; returns the union of handler returns */
+  <E extends TaggedErrorLike, H extends MatchHandlers<E>>(err: E, handlers: H): MatchReturn<H>;
+  /** Data-first with explicit R constraining every handler return */
+  <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlersWithReturn<E, R>): R;
+} = dual(2, <E extends TaggedErrorLike>(err: E, handlers: MatchHandlers<E>): unknown => {
   const handler = handlers[err._tag as E["_tag"]];
-  // SAFETY: handler exists if handlers satisfies MatchHandlers<E, R>
+  // SAFETY: exhaustiveness is enforced at the type level
   return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
 });
 
@@ -166,6 +184,14 @@ export const matchError: {
  * }, (e) => `Unknown: ${e.message}`);
  */
 export const matchErrorPartial: {
+  /** Pipeable — E deferred to call site, fallback receives a tagged error-like value */
+  <H extends Partial<MatchHandlers<TaggedErrorLike>>, R>(
+    handlers: H,
+    fallback: (e: TaggedErrorLike) => R,
+  ): {
+    <E extends TaggedErrorLike>(err: E): MatchReturn<H> | R;
+  };
+  /** Pipeable with explicit E, R — H inferred via default, fallback narrowed */
   <
     E extends TaggedErrorLike,
     R,
@@ -174,26 +200,34 @@ export const matchErrorPartial: {
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): (err: E) => R;
-  <E extends TaggedErrorLike, R, const H extends PartialMatchHandlers<E, R>>(
+  /** Data-first with inference — E from err, H from handlers, R from fallback */
+  <E extends TaggedErrorLike, const H extends Partial<MatchHandlers<E>>, R>(
+    err: E,
+    handlers: H,
+    fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
+  ): MatchReturn<H> | R;
+  /** Data-first with explicit R — H inferred via default, fallback narrowed */
+  <
+    E extends TaggedErrorLike,
+    R,
+    const H extends PartialMatchHandlers<E, R> = PartialMatchHandlers<E, R>,
+  >(
     err: E,
     handlers: H,
     fallback: (e: Exclude<E, { _tag: NoInfer<HandledTags<E, H>> }>) => R,
   ): R;
 } = dual(
   3,
-  <E extends TaggedErrorLike, R, H extends PartialMatchHandlers<E, R>>(
-    err: E,
-    handlers: H,
-    fallback: (e: Exclude<E, { _tag: HandledTags<E, H> }>) => R,
-  ): R => {
-    type K = HandledTags<E, H>;
-    const handler = handlers[err._tag as K];
+  (
+    err: TaggedErrorLike,
+    handlers: Partial<MatchHandlers<TaggedErrorLike>>,
+    fallback: (e: TaggedErrorLike) => unknown,
+  ): unknown => {
+    const handler = handlers[err._tag];
     if (typeof handler === "function") {
-      // SAFETY: handler exists and matches the tag
-      return handler(err as Parameters<NonNullable<typeof handler>>[0]);
+      return handler(err);
     }
-    // SAFETY: If no handler matched, err is in the Exclude type
-    return fallback(err as Exclude<E, { _tag: K }>);
+    return fallback(err);
   },
 );
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,6 @@
 import { dual } from "./dual";
 import { err, panic, type Err } from "./core";
+import { type StandardSchemaV1 } from "./standard-schema";
 
 /** Serialize cause for JSON output */
 const serializeCause = (cause: unknown): unknown => {
@@ -256,11 +257,14 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
   }
 }
 
+/** A Standard Schema validation issue reported while encoding or decoding a Result payload. */
+export type ResultCodecIssue = StandardSchemaV1.Issue;
+
 /**
- * Returned when Result.deserialize receives invalid input.
+ * Returned when Result codec deserialization receives an invalid envelope or payload.
  *
  * @example
- * const result = Result.deserialize(invalidData);
+ * const result = UserResultCodec.deserialize(invalidData);
  * if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
  *   console.log("Invalid input:", result.error.value);
  * }
@@ -268,11 +272,38 @@ export class UnhandledException extends TaggedError("UnhandledException")<{
 export class ResultDeserializationError extends TaggedError("ResultDeserializationError")<{
   message: string;
   value: unknown;
+  issues?: ReadonlyArray<ResultCodecIssue>;
 }> {
-  constructor(args: { value: unknown }) {
+  constructor(args: { value: unknown; issues?: ReadonlyArray<ResultCodecIssue> }) {
     super({
-      message: `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,
+      message: args.issues
+        ? "Failed to deserialize Result payload"
+        : `Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }`,
       value: args.value,
+      issues: args.issues,
+    });
+  }
+}
+
+/**
+ * Returned when a Result codec cannot serialize an Ok or Err payload.
+ *
+ * @example
+ * const result = UserResultCodec.serialize(Result.ok(value));
+ * if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+ *   console.log("Invalid output:", result.error.value);
+ * }
+ */
+export class ResultSerializationError extends TaggedError("ResultSerializationError")<{
+  message: string;
+  value: unknown;
+  issues?: ReadonlyArray<ResultCodecIssue>;
+}> {
+  constructor(args: { value: unknown; issues?: ReadonlyArray<ResultCodecIssue> }) {
+    super({
+      message: "Failed to serialize Result payload",
+      value: args.value,
+      issues: args.issues,
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
   SerializedOk,
   SerializedErr,
   TryContext,
+  TryPromiseContext,
 } from "./result";
 export {
   Panic,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,17 @@ export { Result, Ok, Err } from "./result";
 export type {
   InferOk,
   InferErr,
+  ResultCodec,
+  ResultCodecConfig,
   SerializedResult,
   SerializedOk,
   SerializedErr,
+  StandardSchemaInput,
+  StandardSchemaIssue,
+  StandardSchemaOutput,
+  StandardSchemaPathSegment,
+  StandardSchemaResult,
+  StandardSchemaV1,
   TryContext,
   TryPromiseContext,
 } from "./result";
@@ -15,8 +23,14 @@ export {
   TaggedError,
   UnhandledException,
   ResultDeserializationError,
+  ResultSerializationError,
   matchError,
   matchErrorPartial,
   isTaggedError,
 } from "./error";
-export type { AnyTaggedError, TaggedErrorInstance, TaggedErrorClass } from "./error";
+export type {
+  AnyTaggedError,
+  ResultCodecIssue,
+  TaggedErrorInstance,
+  TaggedErrorClass,
+} from "./error";

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -912,6 +912,82 @@ describe("Result", () => {
       }
     });
 
+    it("uses the typed error and failed-attempt context to choose each delay", async () => {
+      let attempts = 0;
+      const delayContexts: TryPromiseContext[] = [];
+      const start = Date.now();
+
+      const result = await Result.tryPromise(
+        {
+          try: () => {
+            attempts++;
+            if (attempts === 1) throw new Error("rate limited");
+            return Promise.resolve("success");
+          },
+          catch: () => ({ kind: "rate-limit" as const, retryAfterMs: 20 }),
+        },
+        {
+          retry: {
+            times: 1,
+            delayMs: (error, context) => {
+              expectTypeOf(error).toEqualTypeOf<{
+                kind: "rate-limit";
+                retryAfterMs: number;
+              }>();
+              expectTypeOf(context).toEqualTypeOf<TryPromiseContext>();
+              delayContexts.push(context);
+              return error.retryAfterMs;
+            },
+          },
+        },
+      );
+
+      expect(result.unwrap()).toBe("success");
+      expect(attempts).toBe(2);
+      expect(delayContexts.map(({ attempt }) => attempt)).toEqual([1]);
+      expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+    });
+
+    it("enforces times when delayMs is dynamic", async () => {
+      let attempts = 0;
+      let delayCalculations = 0;
+
+      const result = await Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          retry: {
+            times: 3,
+            delayMs: (error, context) => {
+              expectTypeOf(error).toEqualTypeOf<UnhandledException>();
+              expectTypeOf(context).toEqualTypeOf<TryPromiseContext>();
+              delayCalculations++;
+              return 0;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(4);
+      expect(delayCalculations).toBe(3);
+    });
+
+    it("throws Panic when a dynamic delay callback throws", async () => {
+      await expect(
+        Result.tryPromise(() => Promise.reject(new Error("fail")), {
+          retry: {
+            times: 1,
+            delayMs: () => {
+              throw new Error("delay callback bug");
+            },
+          },
+        }),
+      ).rejects.toBeInstanceOf(Panic);
+    });
+
     it("respects shouldRetry predicate", async () => {
       let attempts = 0;
       const result = await Result.tryPromise(
@@ -2987,6 +3063,29 @@ describe("Type Inference", () => {
           },
         );
         expectTypeOf(custom).toEqualTypeOf<Promise<ResultType<string, ErrorA>>>();
+      };
+
+      expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();
+    });
+
+    it("keeps backoff and jitter exclusive to static delays", () => {
+      const compileTimeOnly = () => {
+        // @ts-expect-error dynamic delayMs cannot be combined with static backoff.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: () => 100,
+            backoff: "constant",
+          },
+        });
+        // @ts-expect-error dynamic delayMs cannot be combined with static jitter.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: () => 100,
+            jitter: true,
+          },
+        });
       };
 
       expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -3306,6 +3306,11 @@ describe("Type Inference", () => {
         const recovered = myResult.tryRecover<ErrorB>(() => Result.err(new ErrorB()));
         expectTypeOf(recovered).toEqualTypeOf<Result<{ name: string }, ErrorB>>();
 
+        const recoveredWithWidening = myResult.tryRecover<ErrorB, number>(() => Result.ok(1));
+        expectTypeOf(recoveredWithWidening).toEqualTypeOf<
+          Result<{ name: string } | number, ErrorB>
+        >();
+
         const chainedAsync = myResult.andThenAsync<string, ErrorB>(async (value) =>
           Result.ok<string, ErrorB>(value.name),
         );
@@ -3335,6 +3340,12 @@ describe("Type Inference", () => {
 
         const errMappedError = errDirect.mapError((error) => error._tag);
         expectTypeOf(errMappedError).toEqualTypeOf<Err<string, "ErrorA">>();
+
+        const okRecovered = okDirect.tryRecover(() => Result.ok(123));
+        expectTypeOf(okRecovered).toEqualTypeOf<Ok<string, never>>();
+
+        const errRecovered = errDirect.tryRecover(() => Result.ok(123));
+        expectTypeOf(errRecovered).toEqualTypeOf<Result<number, never>>();
       };
 
       expect(typeof compileTimeOnly).toBe("function");
@@ -3417,7 +3428,7 @@ describe("Type Inference", () => {
     });
   });
 
-  describe("tryRecover type preservation", () => {
+  describe("tryRecover type inference", () => {
     it("preserves success type while allowing error type change", () => {
       const r: Result<number, ErrorA> = Result.err(new ErrorA());
 
@@ -3476,33 +3487,28 @@ describe("Type Inference", () => {
       expect(dataLastOk.unwrap()).toBe(0);
     });
 
-    it("does not allow the success channel to change", () => {
-      const r: Result<string, ErrorA> = Result.err(new ErrorA());
+    it("widens the success channel", () => {
+      const getString = (): Result<string, ErrorA> => Result.err(new ErrorA());
+      const r = getString();
 
-      const compileTimeOnly = () => {
-        // @ts-expect-error tryRecover matches Gleam semantics: it may change E, not T.
-        r.tryRecover(() => Result.ok(123));
+      const methodResult = r.tryRecover(() => Result.ok(123));
+      const dataFirst = Result.tryRecover(r, () => Result.ok(123));
+      const unannotatedErr = Result.tryRecover(Result.err(new ErrorA()), () => Result.ok(123));
+      const recoverNumber = Result.tryRecover((_: ErrorA) => Result.ok(123));
+      const dataLast = recoverNumber(r);
 
-        // @ts-expect-error data-first tryRecover may not map the success channel.
-        Result.tryRecover(r, () => Result.ok(123));
-
-        // @ts-expect-error an unannotated Err has success type never; the callback cannot infer it.
-        Result.tryRecover(Result.err(new ErrorA()), () => Result.ok(123));
-
-        const recoverNumber = Result.tryRecover((_: ErrorA) => Result.ok(123));
-        const okString: Result<string, ErrorA> = Result.ok("ok");
-        // @ts-expect-error data-last tryRecover is fixed to the callback success type.
-        recoverNumber(okString);
-      };
-      expect(typeof compileTimeOnly).toBe("function");
-
-      const recovered = r.tryRecover(() => Result.ok("fallback"));
-      expectTypeOf(recovered).toEqualTypeOf<Result<string, never>>();
-      expect(recovered.unwrap()).toBe("fallback");
+      expectTypeOf(methodResult).toEqualTypeOf<Result<string | number, never>>();
+      expectTypeOf(dataFirst).toEqualTypeOf<Result<string | number, never>>();
+      expectTypeOf(unannotatedErr).toEqualTypeOf<Result<number, never>>();
+      expectTypeOf(dataLast).toEqualTypeOf<Result<string | number, never>>();
+      expect(methodResult.unwrap()).toBe(123);
+      expect(dataFirst.unwrap()).toBe(123);
+      expect(unannotatedErr.unwrap()).toBe(123);
+      expect(dataLast.unwrap()).toBe(123);
     });
   });
 
-  describe("tryRecoverAsync type preservation", () => {
+  describe("tryRecoverAsync type inference", () => {
     it("preserves success type while allowing error type change", async () => {
       const r: Result<number, ErrorA> = Result.err(new ErrorA());
 
@@ -3561,29 +3567,26 @@ describe("Type Inference", () => {
       expect(dataLastOk.unwrap()).toBe(0);
     });
 
-    it("does not allow the success channel to change", async () => {
-      const r: Result<string, ErrorA> = Result.err(new ErrorA());
+    it("widens the success channel", async () => {
+      const getString = (): Result<string, ErrorA> => Result.err(new ErrorA());
+      const r = getString();
 
-      const compileTimeOnly = () => {
-        // @ts-expect-error tryRecoverAsync matches Gleam semantics: it may change E, not T.
-        r.tryRecoverAsync(async () => Result.ok(123));
+      const methodResult = await r.tryRecoverAsync(async () => Result.ok(123));
+      const dataFirst = await Result.tryRecoverAsync(r, async () => Result.ok(123));
+      const unannotatedErr = await Result.tryRecoverAsync(Result.err(new ErrorA()), async () =>
+        Result.ok(123),
+      );
+      const recoverNumber = Result.tryRecoverAsync(async (_: ErrorA) => Result.ok(123));
+      const dataLast = await recoverNumber(r);
 
-        // @ts-expect-error data-first tryRecoverAsync may not map the success channel.
-        Result.tryRecoverAsync(r, async () => Result.ok(123));
-
-        // @ts-expect-error an unannotated Err has success type never; the callback cannot infer it.
-        Result.tryRecoverAsync(Result.err(new ErrorA()), async () => Result.ok(123));
-
-        const recoverNumber = Result.tryRecoverAsync(async (_: ErrorA) => Result.ok(123));
-        const okString: Result<string, ErrorA> = Result.ok("ok");
-        // @ts-expect-error data-last tryRecoverAsync is fixed to the callback success type.
-        recoverNumber(okString);
-      };
-      expect(typeof compileTimeOnly).toBe("function");
-
-      const recovered = await r.tryRecoverAsync(async () => Result.ok("fallback"));
-      expectTypeOf(recovered).toEqualTypeOf<Result<string, never>>();
-      expect(recovered.unwrap()).toBe("fallback");
+      expectTypeOf(methodResult).toEqualTypeOf<Result<string | number, never>>();
+      expectTypeOf(dataFirst).toEqualTypeOf<Result<string | number, never>>();
+      expectTypeOf(unannotatedErr).toEqualTypeOf<Result<number, never>>();
+      expectTypeOf(dataLast).toEqualTypeOf<Result<string | number, never>>();
+      expect(methodResult.unwrap()).toBe(123);
+      expect(dataFirst.unwrap()).toBe(123);
+      expect(unannotatedErr.unwrap()).toBe(123);
+      expect(dataLast.unwrap()).toBe(123);
     });
   });
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,6 +1,22 @@
+import fc from "fast-check";
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { Result, Ok, Err, type TryContext, type TryPromiseContext } from "./result";
-import { Panic, ResultDeserializationError, UnhandledException } from "./error";
+import {
+  Result,
+  Ok,
+  Err,
+  type Result as ResultType,
+  type SerializedResult,
+  type StandardSchemaResult,
+  type StandardSchemaV1,
+  type TryContext,
+  type TryPromiseContext,
+} from "./result";
+import {
+  Panic,
+  ResultDeserializationError,
+  ResultSerializationError,
+  UnhandledException,
+} from "./error";
 
 const longConstantRetryConfig = {
   times: 3,
@@ -14,6 +30,52 @@ const createDeferred = () => {
     resolve = resolvePromise;
   });
   return { promise, resolve } as const;
+};
+
+type SchemaResult<T> = StandardSchemaResult<T>;
+type SyncSchema<Input, Output> = StandardSchemaV1<Input, Output> & {
+  readonly "~standard": StandardSchemaV1.Props<Input, Output> & {
+    readonly validate: (value: unknown) => SchemaResult<Output>;
+  };
+};
+type AsyncSchema<Input, Output> = StandardSchemaV1<Input, Output> & {
+  readonly "~standard": StandardSchemaV1.Props<Input, Output> & {
+    readonly validate: (value: unknown) => Promise<SchemaResult<Output>>;
+  };
+};
+
+const makeSchema = <Input, Output>(
+  vendor: string,
+  validate: (value: unknown) => SchemaResult<Output>,
+): SyncSchema<Input, Output> => ({
+  "~standard": {
+    version: 1,
+    vendor,
+    types: undefined as unknown as {
+      input: Input;
+      output: Output;
+    },
+    validate,
+  },
+});
+
+const makeAsyncSchema = <Input, Output>(
+  vendor: string,
+  validate: (value: unknown) => Promise<SchemaResult<Output>>,
+): AsyncSchema<Input, Output> => ({
+  "~standard": {
+    version: 1,
+    vendor,
+    types: undefined as unknown as {
+      input: Input;
+      output: Output;
+    },
+    validate,
+  },
+});
+
+const identitySchema = <T>(vendor: string): SyncSchema<T, T> => {
+  return makeSchema<T, T>(vendor, (value) => ({ value: value as T }));
 };
 
 describe("Result", () => {
@@ -81,8 +143,21 @@ describe("Result", () => {
       expect(matched).toBe("matched");
     });
 
-    it("Ok<void> serializes correctly", () => {
-      expect(Result.serialize(Result.ok())).toEqual({ status: "ok", value: undefined });
+    it("Ok<void> roundtrips through a JSON transport with a codec", () => {
+      const VoidCodec = Result.codec({
+        serialize: { ok: identitySchema<void>("void-ok"), err: identitySchema<never>("void-err") },
+        deserialize: {
+          ok: identitySchema<void>("void-ok-in"),
+          err: identitySchema<never>("void-err-in"),
+        },
+      });
+      const serialized = VoidCodec.serialize(Result.ok()).unwrap();
+      const json = JSON.stringify(serialized);
+      const received: unknown = JSON.parse(json);
+
+      expect(serialized).toEqual({ status: "ok", value: undefined });
+      expect(json).toBe('{"status":"ok"}');
+      expect(VoidCodec.deserialize(received)).toEqual(Result.ok());
     });
   });
 
@@ -98,6 +173,26 @@ describe("Result", () => {
       const error = new Error("oops");
       const result = Result.err(error);
       expect(result.error).toBe(error);
+    });
+
+    it("Err<undefined> roundtrips through a JSON transport with a codec", () => {
+      const UndefinedErrorCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<never>("never-ok"),
+          err: identitySchema<undefined>("undefined-err"),
+        },
+        deserialize: {
+          ok: identitySchema<never>("never-ok-in"),
+          err: identitySchema<undefined>("undefined-err-in"),
+        },
+      });
+      const serialized = UndefinedErrorCodec.serialize(Result.err(undefined)).unwrap();
+      const json = JSON.stringify(serialized);
+      const received: unknown = JSON.parse(json);
+
+      expect(serialized).toEqual({ status: "error", error: undefined });
+      expect(json).toBe('{"status":"error"}');
+      expect(UndefinedErrorCodec.deserialize(received)).toEqual(Result.err(undefined));
     });
   });
 
@@ -1909,138 +2004,598 @@ describe("Result", () => {
     });
   });
 
-  describe("serialize", () => {
-    it("serializes Ok to plain object", () => {
-      const result = Result.ok(42);
-      const serialized = Result.serialize(result);
-      expect(serialized).toEqual({ status: "ok", value: 42 });
+  describe("codec", () => {
+    type User = {
+      id: string;
+      name: string;
+      createdAt: Date;
+    };
+
+    type UserWire = {
+      id: string;
+      display_name: string;
+      created_at_iso: string;
+    };
+
+    type AppError = {
+      code: "NOT_FOUND" | "BAD_INPUT";
+      message: string;
+      retryable: boolean;
+    };
+
+    type AppErrorWire = {
+      type: AppError["code"];
+      message: string;
+      retryable: boolean;
+    };
+
+    const userToWire = makeSchema<User, UserWire>("user-to-wire", (value) => {
+      const user = value as User;
+      return {
+        value: {
+          id: user.id,
+          display_name: user.name,
+          created_at_iso: user.createdAt.toISOString(),
+        },
+      };
     });
 
-    it("serializes Err to plain object", () => {
-      const result = Result.err("fail");
-      const serialized = Result.serialize(result);
-      expect(serialized).toEqual({ status: "error", error: "fail" });
+    const errorToWire = makeSchema<AppError, AppErrorWire>("error-to-wire", (value) => {
+      const error = value as AppError;
+      return {
+        value: {
+          type: error.code,
+          message: error.message,
+          retryable: error.retryable,
+        },
+      };
     });
 
-    it("serializes complex values", () => {
-      const result = Result.ok({ id: 1, name: "test", nested: { a: [1, 2, 3] } });
-      const serialized = Result.serialize(result);
-      expect(serialized).toEqual({
+    const wireToUser = makeSchema<unknown, User>("wire-to-user", (value) => {
+      if (value === null || typeof value !== "object") {
+        return { issues: [{ message: "Expected object" }] };
+      }
+
+      const input = value as Record<string, unknown>;
+      if (
+        typeof input.id !== "string" ||
+        typeof input.display_name !== "string" ||
+        typeof input.created_at_iso !== "string"
+      ) {
+        return {
+          issues: [
+            ...(typeof input.id !== "string" ? [{ message: "Expected string", path: ["id"] }] : []),
+            ...(typeof input.display_name !== "string"
+              ? [{ message: "Expected string", path: ["display_name"] }]
+              : []),
+            ...(typeof input.created_at_iso !== "string"
+              ? [{ message: "Expected string", path: ["created_at_iso"] }]
+              : []),
+          ],
+        };
+      }
+
+      const createdAt = new Date(input.created_at_iso);
+      if (Number.isNaN(createdAt.getTime())) {
+        return { issues: [{ message: "Expected valid ISO timestamp", path: ["created_at_iso"] }] };
+      }
+
+      return {
+        value: {
+          id: input.id,
+          name: input.display_name,
+          createdAt,
+        },
+      };
+    });
+
+    const wireToError = makeSchema<unknown, AppError>("wire-to-error", (value) => {
+      if (value === null || typeof value !== "object") {
+        return { issues: [{ message: "Expected object" }] };
+      }
+
+      const input = value as Record<string, unknown>;
+      const code = input.type;
+      const validCode = code === "NOT_FOUND" || code === "BAD_INPUT";
+      if (!validCode || typeof input.message !== "string" || typeof input.retryable !== "boolean") {
+        return {
+          issues: [
+            ...(!validCode
+              ? [{ message: 'Expected "NOT_FOUND" | "BAD_INPUT"', path: ["type"] }]
+              : []),
+            ...(typeof input.message !== "string"
+              ? [{ message: "Expected string", path: ["message"] }]
+              : []),
+            ...(typeof input.retryable !== "boolean"
+              ? [{ message: "Expected boolean", path: ["retryable"] }]
+              : []),
+          ],
+        };
+      }
+
+      return {
+        value: {
+          code,
+          message: input.message,
+          retryable: input.retryable,
+        },
+      };
+    });
+
+    const UserResultCodec = Result.codec({
+      serialize: { ok: userToWire, err: errorToWire },
+      deserialize: { ok: wireToUser, err: wireToError },
+    });
+
+    it("serializes Ok with outbound schema", () => {
+      const serialized = UserResultCodec.serialize(
+        Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
+      );
+      expect(serialized).toBeInstanceOf(Ok);
+      expect(serialized.unwrap()).toEqual({
         status: "ok",
-        value: { id: 1, name: "test", nested: { a: [1, 2, 3] } },
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
       });
     });
 
-    it("serializes null and undefined values", () => {
-      expect(Result.serialize(Result.ok(null))).toEqual({ status: "ok", value: null });
-      expect(Result.serialize(Result.ok(undefined))).toEqual({ status: "ok", value: undefined });
-    });
-  });
-
-  describe("deserialize", () => {
-    it("deserializes Ok object to Ok instance", () => {
-      const serialized = { status: "ok" as const, value: 42 };
-      const result = Result.deserialize<number, string>(serialized);
-      expect(Result.isOk(result)).toBe(true);
-      expect(result).toBeInstanceOf(Ok);
-      expect(result.unwrap()).toBe(42);
+    it("serializes Err with outbound schema", () => {
+      const serialized = UserResultCodec.serialize(
+        Result.err({ code: "NOT_FOUND", message: "missing", retryable: false }),
+      );
+      expect(serialized).toBeInstanceOf(Ok);
+      expect(serialized.unwrap()).toEqual({
+        status: "error",
+        error: { type: "NOT_FOUND", message: "missing", retryable: false },
+      });
     });
 
-    it("deserializes Err object to Err instance", () => {
-      const serialized = { status: "error" as const, error: "fail" };
-      const result = Result.deserialize<number, string>(serialized);
+    it("returns ResultSerializationError with ok payload issues", () => {
+      const RejectingOkCodec = Result.codec({
+        serialize: {
+          ok: makeSchema<unknown, UserWire>("reject-ok-to-wire", () => ({
+            issues: [{ message: "Expected serializable user", path: ["createdAt"] }],
+          })),
+          err: errorToWire,
+        },
+        deserialize: { ok: wireToUser, err: wireToError },
+      });
+
+      const result = RejectingOkCodec.serialize(Result.ok({ createdAt: "nope" }));
       expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to serialize Result payload");
+        expect(result.error.value).toEqual({ createdAt: "nope" });
+        expect(result.error.issues).toEqual([
+          { message: "Expected serializable user", path: ["createdAt"] },
+        ]);
+      }
+    });
+
+    it("returns ResultSerializationError with err payload issues", () => {
+      const RejectingErrCodec = Result.codec({
+        serialize: {
+          ok: userToWire,
+          err: makeSchema<unknown, AppErrorWire>("reject-error-to-wire", () => ({
+            issues: [{ message: "Expected serializable app error", path: ["code"] }],
+          })),
+        },
+        deserialize: { ok: wireToUser, err: wireToError },
+      });
+
+      const result = RejectingErrCodec.serialize(Result.err({ code: "NOPE" }));
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultSerializationError.is(result.error)) {
+        expect(result.error.value).toEqual({ code: "NOPE" });
+        expect(result.error.issues).toEqual([
+          { message: "Expected serializable app error", path: ["code"] },
+        ]);
+      }
+    });
+
+    it("deserializes Ok payload with inbound schema", () => {
+      const result = UserResultCodec.deserialize({
+        status: "ok",
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
+      });
+
+      expect(result).toBeInstanceOf(Ok);
+      expect(result.unwrap()).toEqual({
+        id: "1",
+        name: "Ada",
+        createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      });
+    });
+
+    it("deserializes Err payload with inbound schema", () => {
+      const result = UserResultCodec.deserialize({
+        status: "error",
+        error: {
+          type: "BAD_INPUT",
+          message: "bad email",
+          retryable: false,
+        },
+      });
+
       expect(result).toBeInstanceOf(Err);
       if (Result.isError(result)) {
-        expect(result.error).toBe("fail");
+        expect(result.error).toEqual({ code: "BAD_INPUT", message: "bad email", retryable: false });
       }
     });
 
-    it("returns ResultDeserializationError for non-Result objects", () => {
-      const testCases = [
-        { foo: "bar" },
-        null,
-        42,
-        { status: "ok" }, // missing value
-        { status: "error" }, // missing error
-      ];
-
-      for (const input of testCases) {
-        const result = Result.deserialize(input);
-        expect(Result.isError(result)).toBe(true);
-        if (Result.isError(result)) {
-          expect(result.error).toBeInstanceOf(ResultDeserializationError);
-          expect((result.error as ResultDeserializationError).value).toBe(input);
-        }
+    it("returns ResultDeserializationError for invalid outer shape", () => {
+      const result = UserResultCodec.deserialize({ foo: "bar" });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe(
+          'Failed to deserialize value as Result: expected { status: "ok", value } or { status: "error", error }',
+        );
+        expect(result.error.value).toEqual({ foo: "bar" });
       }
     });
 
-    it("deserializes complex values", () => {
-      const serialized = { status: "ok" as const, value: { id: 1, items: [1, 2] } };
-      const result = Result.deserialize<{ id: number; items: number[] }, string>(serialized);
-      expect(result.unwrap()).toEqual({ id: 1, items: [1, 2] });
-    });
-  });
+    it("passes a missing Ok payload to its schema as undefined", () => {
+      const result = UserResultCodec.deserialize({ status: "ok" });
 
-  describe("serialize/deserialize roundtrip", () => {
-    it("roundtrips Ok", () => {
-      const original = Result.ok({ id: 42, name: "test" });
-      const serialized = Result.serialize(original);
-      const deserialized = Result.deserialize<{ id: number; name: string }, never>(serialized);
-
-      expect(deserialized).toBeInstanceOf(Ok);
-      expect(deserialized.unwrap()).toEqual({ id: 42, name: "test" });
-    });
-
-    it("roundtrips Err", () => {
-      const original = Result.err({ code: "NOT_FOUND", message: "User not found" });
-      const serialized = Result.serialize(original);
-      const deserialized = Result.deserialize<never, { code: string; message: string }>(serialized);
-
-      expect(deserialized).toBeInstanceOf(Err);
-      if (Result.isError(deserialized)) {
-        expect(deserialized.error).toEqual({ code: "NOT_FOUND", message: "User not found" });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to deserialize Result payload");
+        expect(result.error.value).toBe(undefined);
+        expect(result.error.issues).toEqual([{ message: "Expected object" }]);
       }
     });
 
-    it("roundtrips through JSON.stringify/parse", () => {
-      const original = Result.ok({ id: 1, data: [1, 2, 3] });
-      const json = JSON.stringify(Result.serialize(original));
+    it("passes a missing Err payload to its schema as undefined", () => {
+      const result = UserResultCodec.deserialize({ status: "error" });
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to deserialize Result payload");
+        expect(result.error.value).toBe(undefined);
+        expect(result.error.issues).toEqual([{ message: "Expected object" }]);
+      }
+    });
+
+    it("returns ResultDeserializationError with ok payload issues", () => {
+      const result = UserResultCodec.deserialize({
+        status: "ok",
+        value: { id: "1", display_name: 42, created_at_iso: "nope" },
+      });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.message).toBe("Failed to deserialize Result payload");
+        expect(result.error.issues).toEqual([
+          { message: "Expected string", path: ["display_name"] },
+        ]);
+      }
+    });
+
+    it("returns ResultDeserializationError with err payload issues", () => {
+      const result = UserResultCodec.deserialize({
+        status: "error",
+        error: { type: "NOPE", message: 123, retryable: "sometimes" },
+      });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result) && ResultDeserializationError.is(result.error)) {
+        expect(result.error.issues).toEqual([
+          { message: 'Expected "NOT_FOUND" | "BAD_INPUT"', path: ["type"] },
+          { message: "Expected string", path: ["message"] },
+          { message: "Expected boolean", path: ["retryable"] },
+        ]);
+      }
+    });
+
+    it("roundtrips through JSON stringify/parse", () => {
+      const original = Result.ok({
+        id: "1",
+        name: "Ada",
+        createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      });
+      const serialized = UserResultCodec.serialize(original).unwrap();
+      const json = JSON.stringify(serialized);
       const parsed = JSON.parse(json);
-      const deserialized = Result.deserialize<{ id: number; data: number[] }, never>(parsed);
+      const deserialized = UserResultCodec.deserialize(parsed);
 
-      expect(deserialized?.unwrap()).toEqual({ id: 1, data: [1, 2, 3] });
-    });
-  });
-
-  describe("hydrate (deprecated)", () => {
-    it("hydrates serialized Ok", () => {
-      const serialized = { status: "ok" as const, value: 42 };
-      const result = Result.hydrate<number, string>(serialized);
-      expect(Result.isOk(result)).toBe(true);
-      expect(result).toBeInstanceOf(Ok);
-      expect(result.unwrap()).toBe(42);
+      expect(deserialized.unwrap()).toEqual({
+        id: "1",
+        name: "Ada",
+        createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      });
     });
 
-    it("hydrates serialized Err", () => {
-      const serialized = { status: "error" as const, error: "fail" };
-      const result = Result.hydrate<number, string>(serialized);
-      expect(Result.isError(result)).toBe(true);
+    it("roundtrips arbitrary Ok and Err payloads through JSON", () => {
+      fc.assert(
+        fc.property(
+          fc.record({
+            id: fc.string(),
+            name: fc.string(),
+            createdAt: fc.date({ noInvalidDate: true }),
+          }),
+          (user) => {
+            const serialized = UserResultCodec.serialize(Result.ok(user)).unwrap();
+            const deserialized = UserResultCodec.deserialize(
+              JSON.parse(JSON.stringify(serialized)),
+            );
+            expect(deserialized).toEqual(Result.ok(user));
+          },
+        ),
+      );
+      fc.assert(
+        fc.property(
+          fc.record({
+            code: fc.constantFrom("NOT_FOUND" as const, "BAD_INPUT" as const),
+            message: fc.string(),
+            retryable: fc.boolean(),
+          }),
+          (appError) => {
+            const serialized = UserResultCodec.serialize(Result.err(appError)).unwrap();
+            const deserialized = UserResultCodec.deserialize(
+              JSON.parse(JSON.stringify(serialized)),
+            );
+            expect(deserialized).toEqual(Result.err(appError));
+          },
+        ),
+      );
+    });
+
+    it("supports async Standard Schema validators and infers Promise return types", async () => {
+      const AsyncUserResultCodec = Result.codec({
+        serialize: {
+          ok: makeAsyncSchema<User, UserWire>("async-user-to-wire", async (value) => {
+            const user = value as User;
+            return {
+              value: {
+                id: user.id,
+                display_name: user.name,
+                created_at_iso: user.createdAt.toISOString(),
+              },
+            };
+          }),
+          err: errorToWire,
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, User>("async-wire-to-user", async (value) => {
+            return wireToUser["~standard"].validate(value);
+          }),
+          err: wireToError,
+        },
+      });
+
+      const serialized = AsyncUserResultCodec.serialize(
+        Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
+      );
+      const deserialized = AsyncUserResultCodec.deserialize({
+        status: "ok",
+        value: {
+          id: "1",
+          display_name: "Ada",
+          created_at_iso: "2026-05-28T12:00:00.000Z",
+        },
+      });
+
+      expectTypeOf(serialized).toEqualTypeOf<
+        Promise<ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>>
+      >();
+      expectTypeOf(deserialized).toEqualTypeOf<
+        Promise<ResultType<User, AppError | ResultDeserializationError>>
+      >();
+      await expect(serialized).resolves.toBeInstanceOf(Ok);
+      await expect(serialized).resolves.toEqual(
+        Result.ok({
+          status: "ok",
+          value: {
+            id: "1",
+            display_name: "Ada",
+            created_at_iso: "2026-05-28T12:00:00.000Z",
+          },
+        }),
+      );
+      await expect(deserialized).resolves.toBeInstanceOf(Ok);
+    });
+
+    it("infers serialization and deserialization async behavior independently", async () => {
+      const SyncSerializeAsyncDeserializeCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<string>("sync-ok-serializer"),
+          err: identitySchema<number>("sync-err-serializer"),
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, string>("async-ok-deserializer", async (value) => ({
+            value: String(value),
+          })),
+          err: makeAsyncSchema<unknown, number>("async-err-deserializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+      });
+      const AsyncSerializeSyncDeserializeCodec = Result.codec({
+        serialize: {
+          ok: makeAsyncSchema<string, string>("async-ok-serializer", async (value) => ({
+            value: String(value),
+          })),
+          err: makeAsyncSchema<number, number>("async-err-serializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+        deserialize: {
+          ok: identitySchema<string>("sync-ok-deserializer"),
+          err: identitySchema<number>("sync-err-deserializer"),
+        },
+      });
+
+      const syncSerialized = SyncSerializeAsyncDeserializeCodec.serialize(Result.ok("value"));
+      const asyncDeserialized = SyncSerializeAsyncDeserializeCodec.deserialize({
+        status: "ok",
+        value: "value",
+      });
+      const asyncSerialized = AsyncSerializeSyncDeserializeCodec.serialize(Result.err(42));
+      const syncDeserialized = AsyncSerializeSyncDeserializeCodec.deserialize({
+        status: "error",
+        error: 42,
+      });
+
+      expectTypeOf(syncSerialized).toEqualTypeOf<
+        ResultType<SerializedResult<string, number>, ResultSerializationError>
+      >();
+      expectTypeOf(asyncDeserialized).toEqualTypeOf<
+        Promise<ResultType<string, number | ResultDeserializationError>>
+      >();
+      expectTypeOf(asyncSerialized).toEqualTypeOf<
+        Promise<ResultType<SerializedResult<string, number>, ResultSerializationError>>
+      >();
+      expectTypeOf(syncDeserialized).toEqualTypeOf<
+        ResultType<string, number | ResultDeserializationError>
+      >();
+      expect(syncSerialized).toEqual(Result.ok({ status: "ok", value: "value" }));
+      await expect(asyncDeserialized).resolves.toEqual(Result.ok("value"));
+      await expect(asyncSerialized).resolves.toEqual(Result.ok({ status: "error", error: 42 }));
+      expect(syncDeserialized).toEqual(Result.err(42));
+    });
+
+    it("infers mixed Result branches without runtime mode configuration", async () => {
+      const MixedBranchCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<string>("sync-ok-serializer"),
+          err: makeAsyncSchema<number, number>("async-err-serializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+        deserialize: {
+          ok: identitySchema<string>("sync-ok-deserializer"),
+          err: makeAsyncSchema<unknown, number>("async-err-deserializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+      });
+      const getResult = (): ResultType<string, number> => Result.ok("value");
+      const unknownEnvelope: unknown = { status: "error", error: 42 };
+
+      const serializedOk = MixedBranchCodec.serialize(Result.ok("value"));
+      const serializedErr = MixedBranchCodec.serialize(Result.err(42));
+      const serializedUnknownBranch = MixedBranchCodec.serialize(getResult());
+      const deserializedOk = MixedBranchCodec.deserialize({ status: "ok", value: "value" });
+      const deserializedErr = MixedBranchCodec.deserialize({ status: "error", error: 42 });
+      const deserializedUnknownEnvelope = MixedBranchCodec.deserialize(unknownEnvelope);
+
+      type Serialized = ResultType<SerializedResult<string, number>, ResultSerializationError>;
+      type Deserialized = ResultType<string, number | ResultDeserializationError>;
+      expectTypeOf(serializedOk).toEqualTypeOf<Serialized>();
+      expectTypeOf(serializedErr).toEqualTypeOf<Promise<Serialized>>();
+      expectTypeOf(serializedUnknownBranch).toEqualTypeOf<Serialized | Promise<Serialized>>();
+      expectTypeOf(deserializedOk).toEqualTypeOf<Deserialized>();
+      expectTypeOf(deserializedErr).toEqualTypeOf<Promise<Deserialized>>();
+      expectTypeOf(deserializedUnknownEnvelope).toEqualTypeOf<
+        Deserialized | Promise<Deserialized>
+      >();
+      expect(serializedOk).toEqual(Result.ok({ status: "ok", value: "value" }));
+      await expect(serializedErr).resolves.toEqual(Result.ok({ status: "error", error: 42 }));
+      expect(deserializedOk).toEqual(Result.ok("value"));
+      await expect(deserializedErr).resolves.toEqual(Result.err(42));
+      await expect(deserializedUnknownEnvelope).resolves.toEqual(Result.err(42));
+    });
+
+    it("returns a synchronous envelope error even when payload schemas are async", () => {
+      const AsyncCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<string>("sync-ok-serializer"),
+          err: identitySchema<number>("sync-err-serializer"),
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, string>("async-ok-deserializer", async (value) => ({
+            value: String(value),
+          })),
+          err: makeAsyncSchema<unknown, number>("async-err-deserializer", async (value) => ({
+            value: Number(value),
+          })),
+        },
+      });
+      const invalidEnvelope: unknown = { nope: true };
+
+      const result = AsyncCodec.deserialize(invalidEnvelope);
+
+      expectTypeOf(result).toEqualTypeOf<
+        | ResultType<string, number | ResultDeserializationError>
+        | Promise<ResultType<string, number | ResultDeserializationError>>
+      >();
       expect(result).toBeInstanceOf(Err);
-      if (Result.isError(result)) {
-        expect(result.error).toBe("fail");
-      }
     });
 
-    it("returns ResultDeserializationError for non-Result objects", () => {
-      const testCases = [{ foo: "bar" }, null, 42];
-      for (const input of testCases) {
-        const result = Result.hydrate(input);
-        expect(Result.isError(result)).toBe(true);
-        if (Result.isError(result)) {
-          expect(result.error).toBeInstanceOf(ResultDeserializationError);
-        }
-      }
+    it("panics when an async serialization schema rejects", async () => {
+      const cause = new Error("async serialization failed");
+      const RejectingSerializationCodec = Result.codec({
+        serialize: {
+          ok: makeAsyncSchema<unknown, unknown>("rejecting-serializer", async () => {
+            throw cause;
+          }),
+          err: identitySchema<never>("identity-error-serializer"),
+        },
+        deserialize: {
+          ok: identitySchema<unknown>("identity-ok-deserializer"),
+          err: identitySchema<never>("identity-error-deserializer"),
+        },
+      });
+
+      await expect(RejectingSerializationCodec.serialize(Result.ok("value"))).rejects.toMatchObject(
+        {
+          _tag: "Panic",
+          message: "Result.codec serialize schema threw",
+          cause,
+        },
+      );
+    });
+
+    it("panics when an async deserialization schema rejects", async () => {
+      const cause = new Error("async deserialization failed");
+      const RejectingDeserializationCodec = Result.codec({
+        serialize: {
+          ok: identitySchema<unknown>("identity-ok-serializer"),
+          err: identitySchema<never>("identity-error-serializer"),
+        },
+        deserialize: {
+          ok: makeAsyncSchema<unknown, unknown>("rejecting-deserializer", async () => {
+            throw cause;
+          }),
+          err: identitySchema<never>("identity-error-deserializer"),
+        },
+      });
+
+      await expect(
+        RejectingDeserializationCodec.deserialize({ status: "ok", value: "value" }),
+      ).rejects.toMatchObject({
+        _tag: "Panic",
+        message: "Result.codec deserialize schema threw",
+        cause,
+      });
+    });
+
+    it("preserves strong type inference for serialize and deserialize", () => {
+      const outbound = UserResultCodec.serialize(
+        Result.ok({ id: "1", name: "Ada", createdAt: new Date("2026-05-28T12:00:00.000Z") }),
+      );
+      const inbound = UserResultCodec.deserialize({
+        status: "error",
+        error: { type: "NOT_FOUND", message: "missing", retryable: false },
+      });
+
+      expectTypeOf(outbound).toEqualTypeOf<
+        ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>
+      >();
+      expectTypeOf(inbound).toEqualTypeOf<
+        ResultType<User, AppError | ResultDeserializationError>
+      >();
+
+      const serializeInvalidUser = (): void => {
+        // @ts-expect-error -- The Ok serializer requires the complete User input type.
+        UserResultCodec.serialize(Result.ok({ id: "missing-name-and-date" }));
+      };
+      expectTypeOf(serializeInvalidUser).toEqualTypeOf<() => void>();
     });
   });
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { Result, Ok, Err } from "./result";
+import { Result, Ok, Err, type TryContext, type TryPromiseContext } from "./result";
 import { Panic, ResultDeserializationError, UnhandledException } from "./error";
+
+const longConstantRetryConfig = {
+  times: 3,
+  delayMs: 10_000,
+  backoff: "constant",
+} as const;
+
+const createDeferred = () => {
+  let resolve = () => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve } as const;
+};
 
 describe("Result", () => {
   describe("ok", () => {
@@ -299,6 +313,268 @@ describe("Result", () => {
     it("returns Err when promise rejects", async () => {
       const result = await Result.tryPromise(() => Promise.reject(new Error("boom")));
       expect(Result.isError(result)).toBe(true);
+    });
+
+    it("passes the configured abort signal to the try context without retries", async () => {
+      const abortController = new AbortController();
+      type TryContextHasSignal = "signal" extends keyof TryContext ? true : false;
+
+      expectTypeOf<TryContextHasSignal>().toEqualTypeOf<false>();
+      expectTypeOf<TryPromiseContext["signal"]>().toEqualTypeOf<AbortSignal | undefined>();
+
+      const result = await Result.tryPromise(
+        ({ signal }) => {
+          expectTypeOf(signal).toEqualTypeOf<AbortSignal | undefined>();
+          expect(signal).toBe(abortController.signal);
+          return Promise.resolve(42);
+        },
+        { signal: abortController.signal },
+      );
+
+      expect(result.unwrap()).toBe(42);
+    });
+
+    it("passes the configured abort signal to the object overload", async () => {
+      const abortController = new AbortController();
+
+      const result = await Result.tryPromise(
+        {
+          try: ({ signal }) => {
+            expectTypeOf(signal).toEqualTypeOf<AbortSignal | undefined>();
+            expect(signal).toBe(abortController.signal);
+            return Promise.resolve(42);
+          },
+          catch: () => new Error("failed"),
+        },
+        { signal: abortController.signal },
+      );
+
+      expect(result.unwrap()).toBe(42);
+    });
+
+    it("still invokes the try callback when the abort signal is already aborted", async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      let invoked = false;
+
+      const result = await Result.tryPromise(
+        ({ signal }) => {
+          invoked = true;
+          expect(signal?.aborted).toBe(true);
+          return Promise.resolve(42);
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+          },
+        },
+      );
+
+      expect(invoked).toBe(true);
+      expect(result.unwrap()).toBe(42);
+    });
+
+    it("cancels an in-flight abort-aware operation and prevents retries", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+
+      const pending = Result.tryPromise(
+        ({ signal }) => {
+          attempts++;
+          return new Promise<never>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("operation aborted")), {
+              once: true,
+            });
+          });
+        },
+        {
+          signal: abortController.signal,
+          retry: longConstantRetryConfig,
+        },
+      );
+
+      abortController.abort();
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+      if (Result.isError(result)) {
+        expect(result.error.cause).toBeInstanceOf(Error);
+      }
+    });
+
+    it("automatically stops retries when the abort signal is aborted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      let retryDecisions = 0;
+
+      const result = await Result.tryPromise(
+        {
+          try: ({ signal }) => {
+            attempts++;
+            expect(signal).toBe(abortController.signal);
+            abortController.abort();
+            return Promise.reject(new Error("cancelled"));
+          },
+          catch: (cause) => ({ kind: "request-failure" as const, cause }),
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+            shouldRetry: (error, context) => {
+              expectTypeOf(error).toEqualTypeOf<{
+                kind: "request-failure";
+                cause: unknown;
+              }>();
+              expectTypeOf(context.signal).toEqualTypeOf<AbortSignal | undefined>();
+              retryDecisions++;
+              return true;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+      expect(retryDecisions).toBe(0);
+      if (Result.isError(result)) {
+        expect(result.error.kind).toBe("request-failure");
+      }
+    });
+
+    it("interrupts a pending retry delay when the abort signal is aborted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      const retryApproved = createDeferred();
+
+      const pending = Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            ...longConstantRetryConfig,
+            shouldRetry: () => {
+              retryApproved.resolve();
+              return true;
+            },
+          },
+        },
+      );
+
+      await retryApproved.promise;
+      abortController.abort();
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+    });
+
+    it("does not start a retry when shouldRetry aborts the signal", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      let retryDecisions = 0;
+
+      const result = await Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            ...longConstantRetryConfig,
+            shouldRetry: (_error, { signal }) => {
+              retryDecisions++;
+              abortController.abort();
+              expect(signal?.aborted).toBe(true);
+              return true;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(1);
+      expect(retryDecisions).toBe(1);
+    });
+
+    it("returns the latest typed error when a later retry delay is interrupted", async () => {
+      const abortController = new AbortController();
+      let attempts = 0;
+      const secondFailureObserved = createDeferred();
+
+      const pending = Result.tryPromise(
+        () => {
+          attempts++;
+          return Promise.reject(new Error(`attempt ${attempts} failed`));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 3,
+            delayMs: 1,
+            backoff: "constant",
+            shouldRetry: (_error, { attempt }) => {
+              if (attempt === 2) secondFailureObserved.resolve();
+              return true;
+            },
+          },
+        },
+      );
+
+      await secondFailureObserved.promise;
+      abortController.abort();
+      const result = await pending;
+
+      expect(Result.isError(result)).toBe(true);
+      expect(attempts).toBe(2);
+      if (Result.isError(result)) {
+        expect(result.error.cause).toBeInstanceOf(Error);
+        if (result.error.cause instanceof Error) {
+          expect(result.error.cause.message).toBe("attempt 2 failed");
+        }
+      }
+    });
+
+    it("passes the abort signal and failed attempt to shouldRetry", async () => {
+      const abortController = new AbortController();
+      const tryContexts: Array<{ attempt: number; signal?: AbortSignal }> = [];
+      const retryContexts: Array<{ attempt: number; signal?: AbortSignal }> = [];
+
+      const result = await Result.tryPromise(
+        (context) => {
+          tryContexts.push(context);
+          return Promise.reject(new Error("fail"));
+        },
+        {
+          signal: abortController.signal,
+          retry: {
+            times: 2,
+            delayMs: 1,
+            backoff: "constant",
+            shouldRetry: (_error, context) => {
+              expectTypeOf(context.signal).toEqualTypeOf<AbortSignal | undefined>();
+              retryContexts.push(context);
+              return true;
+            },
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      expect(tryContexts.map(({ attempt }) => attempt)).toEqual([1, 2, 3]);
+      expect(retryContexts.map(({ attempt }) => attempt)).toEqual([1, 2]);
+      expect(tryContexts.every(({ signal }) => signal === abortController.signal)).toBe(true);
+      expect(retryContexts.every(({ signal }) => signal === abortController.signal)).toBe(true);
     });
 
     it("supports retry with exponential backoff", async () => {

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -4,7 +4,6 @@ import {
   Result,
   Ok,
   Err,
-  type Result as ResultType,
   type SerializedResult,
   type StandardSchemaResult,
   type StandardSchemaV1,
@@ -2605,10 +2604,10 @@ describe("Result", () => {
       });
 
       expectTypeOf(serialized).toEqualTypeOf<
-        Promise<ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>>
+        Promise<Result<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>>
       >();
       expectTypeOf(deserialized).toEqualTypeOf<
-        Promise<ResultType<User, AppError | ResultDeserializationError>>
+        Promise<Result<User, AppError | ResultDeserializationError>>
       >();
       await expect(serialized).resolves.toBeInstanceOf(Ok);
       await expect(serialized).resolves.toEqual(
@@ -2666,16 +2665,16 @@ describe("Result", () => {
       });
 
       expectTypeOf(syncSerialized).toEqualTypeOf<
-        ResultType<SerializedResult<string, number>, ResultSerializationError>
+        Result<SerializedResult<string, number>, ResultSerializationError>
       >();
       expectTypeOf(asyncDeserialized).toEqualTypeOf<
-        Promise<ResultType<string, number | ResultDeserializationError>>
+        Promise<Result<string, number | ResultDeserializationError>>
       >();
       expectTypeOf(asyncSerialized).toEqualTypeOf<
-        Promise<ResultType<SerializedResult<string, number>, ResultSerializationError>>
+        Promise<Result<SerializedResult<string, number>, ResultSerializationError>>
       >();
       expectTypeOf(syncDeserialized).toEqualTypeOf<
-        ResultType<string, number | ResultDeserializationError>
+        Result<string, number | ResultDeserializationError>
       >();
       expect(syncSerialized).toEqual(Result.ok({ status: "ok", value: "value" }));
       await expect(asyncDeserialized).resolves.toEqual(Result.ok("value"));
@@ -2698,7 +2697,7 @@ describe("Result", () => {
           })),
         },
       });
-      const getResult = (): ResultType<string, number> => Result.ok("value");
+      const getResult = (): Result<string, number> => Result.ok("value");
       const unknownEnvelope: unknown = { status: "error", error: 42 };
 
       const serializedOk = MixedBranchCodec.serialize(Result.ok("value"));
@@ -2708,8 +2707,8 @@ describe("Result", () => {
       const deserializedErr = MixedBranchCodec.deserialize({ status: "error", error: 42 });
       const deserializedUnknownEnvelope = MixedBranchCodec.deserialize(unknownEnvelope);
 
-      type Serialized = ResultType<SerializedResult<string, number>, ResultSerializationError>;
-      type Deserialized = ResultType<string, number | ResultDeserializationError>;
+      type Serialized = Result<SerializedResult<string, number>, ResultSerializationError>;
+      type Deserialized = Result<string, number | ResultDeserializationError>;
       expectTypeOf(serializedOk).toEqualTypeOf<Serialized>();
       expectTypeOf(serializedErr).toEqualTypeOf<Promise<Serialized>>();
       expectTypeOf(serializedUnknownBranch).toEqualTypeOf<Serialized | Promise<Serialized>>();
@@ -2745,8 +2744,8 @@ describe("Result", () => {
       const result = AsyncCodec.deserialize(invalidEnvelope);
 
       expectTypeOf(result).toEqualTypeOf<
-        | ResultType<string, number | ResultDeserializationError>
-        | Promise<ResultType<string, number | ResultDeserializationError>>
+        | Result<string, number | ResultDeserializationError>
+        | Promise<Result<string, number | ResultDeserializationError>>
       >();
       expect(result).toBeInstanceOf(Err);
     });
@@ -2809,11 +2808,9 @@ describe("Result", () => {
       });
 
       expectTypeOf(outbound).toEqualTypeOf<
-        ResultType<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>
+        Result<SerializedResult<UserWire, AppErrorWire>, ResultSerializationError>
       >();
-      expectTypeOf(inbound).toEqualTypeOf<
-        ResultType<User, AppError | ResultDeserializationError>
-      >();
+      expectTypeOf(inbound).toEqualTypeOf<Result<User, AppError | ResultDeserializationError>>();
 
       const serializeInvalidUser = (): void => {
         // @ts-expect-error -- The Ok serializer requires the complete User input type.
@@ -3647,6 +3644,114 @@ describe("Type Inference", () => {
     });
   });
 
+  describe("all", () => {
+    it("returns an empty tuple for empty input", () => {
+      const result = Result.all([]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[], never>>();
+      expect(result).toEqual(Result.ok([]));
+    });
+
+    it("collects Ok values in input order and preserves tuple types", () => {
+      const getNumberResult = (): Result<number, ErrorA> => Result.ok(1);
+      const getStringResult = (): Result<string, ErrorB> => Result.ok("hello");
+      const result = Result.all([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+
+    it("returns the first error and unions tuple error types", () => {
+      const firstError = new ErrorA("first");
+      const secondError = new ErrorB("second");
+      const getNumberResult = (): Result<number, ErrorA> => Result.err(firstError);
+      const getStringResult = (): Result<string, ErrorB> => Result.err(secondError);
+      const result = Result.all([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error).toBe(firstError);
+      }
+    });
+
+    it("infers homogeneous array value and error types", () => {
+      const results: Array<Result<number, ErrorA>> = [Result.ok(1), Result.ok(2)];
+      const result = Result.all(results);
+
+      expectTypeOf(result).toEqualTypeOf<Result<number[], ErrorA>>();
+      expect(result).toEqual(Result.ok([1, 2]));
+    });
+
+    it("accepts readonly tuples and returns a mutable value tuple", () => {
+      const results = [Result.ok(1), Result.ok("hello")] as const;
+      const result = Result.all(results);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], never>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+  });
+
+  describe("allAsync", () => {
+    it("returns an empty tuple for empty input", async () => {
+      const result = await Result.allAsync([]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[], never>>();
+      expect(result).toEqual(Result.ok([]));
+    });
+
+    it("collects asynchronous Ok values and preserves tuple types", async () => {
+      const getNumberResult = async (): Promise<Result<number, ErrorA>> => Result.ok(1);
+      const getStringResult = async (): Promise<Result<string, ErrorB>> => Result.ok("hello");
+      const result = await Result.allAsync([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+
+    it("returns the first error by input order", async () => {
+      const firstError = new ErrorA("first");
+      const secondError = new ErrorB("second");
+      const getNumberResult = async (): Promise<Result<number, ErrorA>> => Result.err(firstError);
+      const getStringResult = async (): Promise<Result<string, ErrorB>> => Result.err(secondError);
+      const result = await Result.allAsync([getNumberResult(), getStringResult()]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], ErrorA | ErrorB>>();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error).toBe(firstError);
+      }
+    });
+
+    it("infers homogeneous asynchronous array types", async () => {
+      const results: Array<Promise<Result<number, ErrorA>>> = [
+        Promise.resolve(Result.ok(1)),
+        Promise.resolve(Result.ok(2)),
+      ];
+      const result = await Result.allAsync(results);
+
+      expectTypeOf(result).toEqualTypeOf<Result<number[], ErrorA>>();
+      expect(result).toEqual(Result.ok([1, 2]));
+    });
+
+    it("accepts mixed Result and Promise<Result> inputs", async () => {
+      const result = await Result.allAsync([Result.ok(1), Promise.resolve(Result.ok("hello"))]);
+
+      expectTypeOf(result).toEqualTypeOf<Result<[number, string], never>>();
+      expect(result).toEqual(Result.ok([1, "hello"]));
+    });
+
+    it("panics when an input promise rejects", async () => {
+      const cause = new Error("input rejected");
+
+      await expect(Result.allAsync([Promise.reject(cause)])).rejects.toMatchObject({
+        _tag: "Panic",
+        message: "Result.allAsync input promise rejected",
+        cause,
+      });
+    });
+  });
+
   describe("partition", () => {
     it("returns empty arrays for empty input", () => {
       expect(Result.partition([])).toEqual([[], []]);
@@ -3668,6 +3773,77 @@ describe("Type Inference", () => {
         [1, 2],
         ["a", "b"],
       ]);
+    });
+
+    it("infers heterogeneous success and error unions", () => {
+      const getNumberResult = (): Result<number, ErrorA> => Result.ok(1);
+      const getStringResult = (): Result<string, ErrorB> => Result.err(new ErrorB("failed"));
+      const partitioned = Result.partition([getNumberResult(), getStringResult()] as const);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[Array<number | string>, Array<ErrorA | ErrorB>]>();
+      expect(partitioned).toEqual([[1], [new ErrorB("failed")]]);
+    });
+  });
+
+  describe("partitionAsync", () => {
+    it("returns empty arrays for empty input", async () => {
+      const partitioned = await Result.partitionAsync([]);
+
+      const expected: [never[], never[]] = partitioned;
+      expect(expected).toEqual([[], []]);
+    });
+
+    it("partitions asynchronous heterogeneous Results and preserves order", async () => {
+      const errorA = new ErrorA("a");
+      const errorB = new ErrorB("b");
+      const getFirstNumber = async (): Promise<Result<number, ErrorA>> => Result.ok(1);
+      const getFirstString = async (): Promise<Result<string, ErrorA>> => Result.err(errorA);
+      const getSecondNumber = async (): Promise<Result<number, ErrorB>> => Result.ok(2);
+      const getSecondString = async (): Promise<Result<string, ErrorB>> => Result.err(errorB);
+      const partitioned = await Result.partitionAsync([
+        getFirstNumber(),
+        getFirstString(),
+        getSecondNumber(),
+        getSecondString(),
+      ]);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[Array<number | string>, Array<ErrorA | ErrorB>]>();
+      expect(partitioned).toEqual([
+        [1, 2],
+        [errorA, errorB],
+      ]);
+    });
+
+    it("infers homogeneous asynchronous array types", async () => {
+      const results: Array<Promise<Result<number, ErrorA>>> = [
+        Promise.resolve(Result.ok(1)),
+        Promise.resolve(Result.err(new ErrorA("failed"))),
+      ];
+      const partitioned = await Result.partitionAsync(results);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[number[], ErrorA[]]>();
+      expect(partitioned[0]).toEqual([1]);
+      expect(partitioned[1]).toEqual([new ErrorA("failed")]);
+    });
+
+    it("accepts mixed Result and Promise<Result> inputs", async () => {
+      const partitioned = await Result.partitionAsync([
+        Result.ok(1),
+        Promise.resolve(Result.err("failed")),
+      ]);
+
+      expectTypeOf(partitioned).toEqualTypeOf<[number[], string[]]>();
+      expect(partitioned).toEqual([[1], ["failed"]]);
+    });
+
+    it("panics when an input promise rejects", async () => {
+      const cause = new Error("input rejected");
+
+      await expect(Result.partitionAsync([Promise.reject(cause)])).rejects.toMatchObject({
+        _tag: "Panic",
+        message: "Result.partitionAsync input promise rejected",
+        cause,
+      });
     });
   });
 

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -191,7 +191,11 @@ describe("Result", () => {
 
       expect(serialized).toEqual({ status: "error", error: undefined });
       expect(json).toBe('{"status":"error"}');
-      expect(UndefinedErrorCodec.deserialize(received)).toEqual(Result.err(undefined));
+      const deserialized = UndefinedErrorCodec.deserialize(received);
+      expect(Result.isError(deserialized)).toBe(true);
+      if (Result.isError(deserialized)) {
+        expect(deserialized.error).toBeUndefined();
+      }
     });
   });
 
@@ -2562,7 +2566,10 @@ describe("Result", () => {
             const deserialized = UserResultCodec.deserialize(
               JSON.parse(JSON.stringify(serialized)),
             );
-            expect(deserialized).toEqual(Result.err(appError));
+            expect(Result.isError(deserialized)).toBe(true);
+            if (Result.isError(deserialized)) {
+              expect(deserialized.error).toEqual(appError);
+            }
           },
         ),
       );
@@ -2679,7 +2686,10 @@ describe("Result", () => {
       expect(syncSerialized).toEqual(Result.ok({ status: "ok", value: "value" }));
       await expect(asyncDeserialized).resolves.toEqual(Result.ok("value"));
       await expect(asyncSerialized).resolves.toEqual(Result.ok({ status: "error", error: 42 }));
-      expect(syncDeserialized).toEqual(Result.err(42));
+      expect(Result.isError(syncDeserialized)).toBe(true);
+      if (Result.isError(syncDeserialized)) {
+        expect(syncDeserialized.error).toBe(42);
+      }
     });
 
     it("infers mixed Result branches without runtime mode configuration", async () => {
@@ -2720,8 +2730,16 @@ describe("Result", () => {
       expect(serializedOk).toEqual(Result.ok({ status: "ok", value: "value" }));
       await expect(serializedErr).resolves.toEqual(Result.ok({ status: "error", error: 42 }));
       expect(deserializedOk).toEqual(Result.ok("value"));
-      await expect(deserializedErr).resolves.toEqual(Result.err(42));
-      await expect(deserializedUnknownEnvelope).resolves.toEqual(Result.err(42));
+      const resolvedDeserializedErr = await deserializedErr;
+      const resolvedUnknownEnvelope = await deserializedUnknownEnvelope;
+      expect(Result.isError(resolvedDeserializedErr)).toBe(true);
+      expect(Result.isError(resolvedUnknownEnvelope)).toBe(true);
+      if (Result.isError(resolvedDeserializedErr)) {
+        expect(resolvedDeserializedErr.error).toBe(42);
+      }
+      if (Result.isError(resolvedUnknownEnvelope)) {
+        expect(resolvedUnknownEnvelope.error).toBe(42);
+      }
     });
 
     it("returns a synchronous envelope error even when payload schemas are async", () => {
@@ -3038,7 +3056,7 @@ describe("Type Inference", () => {
         const automatic = Result.tryPromise(() => Promise.resolve(42), {
           retry: { times: 1, delayMs: 100, backoff: "constant", jitter: true },
         });
-        expectTypeOf(automatic).toEqualTypeOf<Promise<ResultType<number, UnhandledException>>>();
+        expectTypeOf(automatic).toEqualTypeOf<Promise<Result<number, UnhandledException>>>();
 
         const custom = Result.tryPromise(
           {
@@ -3059,7 +3077,7 @@ describe("Type Inference", () => {
             },
           },
         );
-        expectTypeOf(custom).toEqualTypeOf<Promise<ResultType<string, ErrorA>>>();
+        expectTypeOf(custom).toEqualTypeOf<Promise<Result<string, ErrorA>>>();
       };
 
       expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,5 +1,5 @@
 import fc from "fast-check";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   Result,
   Ok,
@@ -688,6 +688,154 @@ describe("Result", () => {
       expect(attempts).toBe(3);
       // exponential: 10ms + 20ms = 30ms minimum
       expect(elapsed).toBeGreaterThanOrEqual(25);
+    });
+
+    describe("retry jitter", () => {
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      const recordRetryDelays = (): number[] => {
+        const delays: number[] = [];
+        const clearedTimeout = setTimeout(() => {}, 0);
+        clearTimeout(clearedTimeout);
+        vi.spyOn(globalThis, "setTimeout").mockImplementation((handler, delay) => {
+          delays.push(delay ?? 0);
+          if (typeof handler === "function") handler();
+          return clearedTimeout;
+        });
+        return delays;
+      };
+
+      it.each([true, 1] as const)(
+        "applies full jitter for %s without exceeding the base delay",
+        async (jitter) => {
+          const delays = recordRetryDelays();
+          vi.spyOn(Math, "random").mockReturnValue(0.25);
+          let attempts = 0;
+
+          const pending = Result.tryPromise(
+            () => {
+              attempts++;
+              return attempts === 1
+                ? Promise.reject(new Error("fail"))
+                : Promise.resolve("success");
+            },
+            { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
+          );
+
+          await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+          expect(attempts).toBe(2);
+          expect(delays).toEqual([25]);
+        },
+      );
+
+      it.each([
+        { random: 0, expectedDelay: 0 },
+        { random: 0.999_999, expectedDelay: 99.999_9 },
+      ])(
+        "keeps full jitter within its lower and upper bounds for random=$random",
+        async ({ random, expectedDelay }) => {
+          const delays = recordRetryDelays();
+          vi.spyOn(Math, "random").mockReturnValue(random);
+          let attempts = 0;
+
+          const pending = Result.tryPromise(
+            () => {
+              attempts++;
+              return attempts === 1
+                ? Promise.reject(new Error("fail"))
+                : Promise.resolve("success");
+            },
+            { retry: { times: 1, delayMs: 100, backoff: "constant", jitter: true } },
+          );
+
+          await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+          expect(delays).toHaveLength(1);
+          expect(delays[0]).toBeCloseTo(expectedDelay, 8);
+        },
+      );
+
+      it("uses a numeric jitter factor as the maximum delay reduction", async () => {
+        const delays = recordRetryDelays();
+        vi.spyOn(Math, "random").mockReturnValue(0.5);
+        let attempts = 0;
+
+        const pending = Result.tryPromise(
+          () => {
+            attempts++;
+            return attempts === 1 ? Promise.reject(new Error("fail")) : Promise.resolve("success");
+          },
+          { retry: { times: 1, delayMs: 100, backoff: "constant", jitter: 0.5 } },
+        );
+
+        await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+        expect(attempts).toBe(2);
+        expect(delays).toEqual([75]);
+      });
+
+      it.each([
+        { backoff: "constant" as const, expectedDelays: [50, 50, 50] },
+        { backoff: "linear" as const, expectedDelays: [50, 100, 150] },
+        { backoff: "exponential" as const, expectedDelays: [50, 100, 200] },
+      ])("applies jitter after $backoff backoff", async ({ backoff, expectedDelays }) => {
+        const delays = recordRetryDelays();
+        const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+        let attempts = 0;
+
+        const pending = Result.tryPromise(
+          () => {
+            attempts++;
+            return attempts <= 3 ? Promise.reject(new Error("fail")) : Promise.resolve("success");
+          },
+          { retry: { times: 3, delayMs: 100, backoff, jitter: true } },
+        );
+
+        await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+        expect(attempts).toBe(4);
+        expect(delays).toEqual(expectedDelays);
+        expect(random).toHaveBeenCalledTimes(3);
+      });
+
+      it.each([false, 0] as const)("disables jitter for %s", async (jitter) => {
+        const delays = recordRetryDelays();
+        const random = vi.spyOn(Math, "random");
+        let attempts = 0;
+
+        const pending = Result.tryPromise(
+          () => {
+            attempts++;
+            return attempts === 1 ? Promise.reject(new Error("fail")) : Promise.resolve("success");
+          },
+          { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
+        );
+
+        await expect(pending).resolves.toMatchObject({ status: "ok", value: "success" });
+        expect(attempts).toBe(2);
+        expect(delays).toEqual([100]);
+        expect(random).not.toHaveBeenCalled();
+      });
+
+      it.each([-0.1, 1.1, Number.NaN, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY])(
+        "panics before execution when jitter is outside [0, 1]: %s",
+        async (jitter) => {
+          let attempts = 0;
+
+          const pending = Result.tryPromise(
+            () => {
+              attempts++;
+              return Promise.resolve("success");
+            },
+            { retry: { times: 1, delayMs: 100, backoff: "constant", jitter } },
+          );
+
+          await expect(pending).rejects.toBeInstanceOf(Panic);
+          await expect(pending).rejects.toThrow(
+            "Result.tryPromise retry jitter must be a finite number between 0 and 1",
+          );
+          expect(attempts).toBe(0);
+        },
+      );
     });
 
     it("passes 1-based attempt context to function overload", async () => {
@@ -2810,6 +2958,74 @@ describe("Type Inference", () => {
   class ErrorC extends Error {
     readonly _tag = "ErrorC" as const;
   }
+
+  describe("tryPromise retry jitter config", () => {
+    it("preserves return and callback inference through both overloads", () => {
+      const compileTimeOnly = () => {
+        const automatic = Result.tryPromise(() => Promise.resolve(42), {
+          retry: { times: 1, delayMs: 100, backoff: "constant", jitter: true },
+        });
+        expectTypeOf(automatic).toEqualTypeOf<Promise<ResultType<number, UnhandledException>>>();
+
+        const custom = Result.tryPromise(
+          {
+            try: () => Promise.resolve("success"),
+            catch: () => new ErrorA(),
+          },
+          {
+            retry: {
+              times: 1,
+              delayMs: 100,
+              backoff: "exponential",
+              jitter: 0.5,
+              shouldRetry: (error, context) => {
+                expectTypeOf(error).toEqualTypeOf<ErrorA>();
+                expectTypeOf(context).toEqualTypeOf<TryPromiseContext>();
+                return true;
+              },
+            },
+          },
+        );
+        expectTypeOf(custom).toEqualTypeOf<Promise<ResultType<string, ErrorA>>>();
+      };
+
+      expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();
+    });
+
+    it("rejects unsupported jitter config types", () => {
+      const compileTimeOnly = () => {
+        // @ts-expect-error jitter accepts only booleans and numbers.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: 100,
+            backoff: "constant",
+            jitter: "full",
+          },
+        });
+        // @ts-expect-error null does not disable jitter; use false or omit the field.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: 100,
+            backoff: "constant",
+            jitter: null,
+          },
+        });
+        // @ts-expect-error jitter does not accept an options object.
+        Result.tryPromise(() => Promise.resolve(42), {
+          retry: {
+            times: 1,
+            delayMs: 100,
+            backoff: "constant",
+            jitter: { factor: 0.5 },
+          },
+        });
+      };
+
+      expectTypeOf(compileTimeOnly).toEqualTypeOf<() => void>();
+    });
+  });
 
   describe("Result instance callback inference", () => {
     type Expect<T extends true> = T;

--- a/src/result.ts
+++ b/src/result.ts
@@ -104,22 +104,39 @@ const tryFn: {
   return result;
 };
 
+type RetryPredicate<E> = (error: E, context: TryPromiseContext) => boolean;
+
+type RetryOptions<E> =
+  | {
+      times: number;
+      delayMs: number;
+      backoff: "linear" | "constant" | "exponential";
+      /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
+      shouldRetry?: RetryPredicate<E>;
+      /**
+       * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
+       * A number from 0 through 1 is the maximum reduction — e.g. `0.3` may shave up to
+       * 30% off each delay. `true` allows full reduction (down to 0). Defaults to no jitter.
+       */
+      jitter?: boolean | number;
+    }
+  | {
+      times: number;
+      /** Returns the final delay in milliseconds for the next retry. */
+      delayMs: (error: E, context: TryPromiseContext) => number;
+      /** Dynamic delays cannot be combined with static backoff. */
+      backoff?: never;
+      /** Dynamic delays cannot be combined with static jitter. */
+      jitter?: never;
+      /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
+      shouldRetry?: RetryPredicate<E>;
+    };
+
 type RetryConfig<E = unknown> = {
   /** Abort signal forwarded unchanged to every try and retry-decision context. */
   signal?: AbortSignal;
-  retry?: {
-    times: number;
-    delayMs: number;
-    backoff: "linear" | "constant" | "exponential";
-    /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
-    shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
-    /**
-     * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
-     * A number from 0 through 1 is the maximum reduction — e.g. `0.3` may shave up to
-     * 30% off each delay. `true` allows full reduction (down to 0). Defaults to no jitter.
-     */
-    jitter?: boolean | number;
-  };
+  /** Bounded retry configuration with either a static backoff or error-dependent delay. */
+  retry?: RetryOptions<E>;
 };
 
 const tryPromise: {
@@ -171,14 +188,18 @@ const tryPromise: {
     return execute({ attempt: 1, signal: config?.signal });
   }
 
-  const getBaseDelay = (retryAttempt: number): number => {
-    switch (retry.backoff) {
+  const getStaticRetryDelay = (
+    delayMs: number,
+    backoff: "linear" | "constant" | "exponential",
+    retryAttempt: number,
+  ): number => {
+    switch (backoff) {
       case "constant":
-        return retry.delayMs;
+        return delayMs;
       case "linear":
-        return retry.delayMs * (retryAttempt + 1);
+        return delayMs * (retryAttempt + 1);
       case "exponential":
-        return retry.delayMs * 2 ** retryAttempt;
+        return delayMs * 2 ** retryAttempt;
     }
   };
 
@@ -188,10 +209,9 @@ const tryPromise: {
   }
   const jitterFactor = jitter === true ? 1 : jitter === false ? 0 : jitter;
 
-  const getDelay = (retryAttempt: number): number => {
-    const baseDelay = getBaseDelay(retryAttempt);
-    if (jitterFactor === 0) return baseDelay;
-    return baseDelay * (1 - jitterFactor + Math.random() * jitterFactor);
+  const applyStaticRetryJitter = (baseDelayMs: number): number => {
+    if (jitterFactor === 0) return baseDelayMs;
+    return baseDelayMs * (1 - jitterFactor + Math.random() * jitterFactor);
   };
 
   const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>
@@ -215,7 +235,6 @@ const tryPromise: {
 
   let context: TryPromiseContext = { attempt: 1, signal: config.signal };
   let result = await execute(context);
-
   const shouldRetryFn = retry.shouldRetry ?? (() => true);
 
   for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
@@ -226,7 +245,24 @@ const tryPromise: {
       "shouldRetry predicate threw",
     );
     if (!shouldContinue) break;
-    const delayCompleted = await sleepForRetryDelay(getDelay(retryAttempt), context.signal);
+
+    let delayMs: number;
+    if (typeof retry.delayMs === "function") {
+      const getDynamicRetryDelay = retry.delayMs;
+      delayMs = tryOrPanic(
+        () => getDynamicRetryDelay(error, context),
+        "Result.tryPromise delayMs callback threw",
+      );
+    } else {
+      if (retry.backoff === undefined) {
+        throw panic("Result.tryPromise static retry delay requires backoff");
+      }
+      delayMs = applyStaticRetryJitter(
+        getStaticRetryDelay(retry.delayMs, retry.backoff, retryAttempt),
+      );
+    }
+
+    const delayCompleted = await sleepForRetryDelay(delayMs, context.signal);
     if (!delayCompleted || context.signal?.aborted) break;
     context = { attempt: context.attempt + 1, signal: config.signal };
     result = await execute(context);
@@ -929,6 +965,18 @@ export const Result = {
    *     delayMs: 100,
    *     backoff: "exponential",
    *     shouldRetry: e => e._tag === "RetryableError"
+   *   }
+   * })
+   *
+   * @example
+   * // Dynamic delay: the typed error determines when the next retry runs
+   * await Result.tryPromise({
+   *   try: () => callApi(url),
+   *   catch: e => new ApiError({ cause: e, retryAfterMs: readRetryAfter(e) })
+   * }, {
+   *   retry: {
+   *     times: 3,
+   *     delayMs: error => error.retryAfterMs
    *   }
    * })
    *

--- a/src/result.ts
+++ b/src/result.ts
@@ -113,6 +113,12 @@ type RetryConfig<E = unknown> = {
     backoff: "linear" | "constant" | "exponential";
     /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
     shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
+    /**
+     * Shortens each delay by a random amount so simultaneous retries don't fire in lockstep.
+     * A number from 0 through 1 is the maximum reduction — e.g. `0.3` may shave up to
+     * 30% off each delay. `true` allows full reduction (down to 0). Defaults to no jitter.
+     */
+    jitter?: boolean | number;
   };
 };
 
@@ -165,7 +171,7 @@ const tryPromise: {
     return execute({ attempt: 1, signal: config?.signal });
   }
 
-  const getDelay = (retryAttempt: number): number => {
+  const getBaseDelay = (retryAttempt: number): number => {
     switch (retry.backoff) {
       case "constant":
         return retry.delayMs;
@@ -174,6 +180,18 @@ const tryPromise: {
       case "exponential":
         return retry.delayMs * 2 ** retryAttempt;
     }
+  };
+
+  const jitter = retry.jitter ?? false;
+  if (typeof jitter === "number" && (!Number.isFinite(jitter) || jitter < 0 || jitter > 1)) {
+    throw panic("Result.tryPromise retry jitter must be a finite number between 0 and 1");
+  }
+  const jitterFactor = jitter === true ? 1 : jitter === false ? 0 : jitter;
+
+  const getDelay = (retryAttempt: number): number => {
+    const baseDelay = getBaseDelay(retryAttempt);
+    if (jitterFactor === 0) return baseDelay;
+    return baseDelay * (1 - jitterFactor + Math.random() * jitterFactor);
   };
 
   const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>
@@ -925,6 +943,8 @@ export const Result = {
    * }, {
    *   retry: { times: 3, delayMs: 100, backoff: "exponential", shouldRetry: e => !e.rateLimited }
    * })
+   *
+   * @throws {Panic} When retry jitter is not a finite number between 0 and 1.
    */
   tryPromise,
   /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -871,17 +871,93 @@ const codec = <
   } satisfies ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>;
 };
 
-const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {
-  const oks: T[] = [];
-  const errs: E[] = [];
-  for (const r of results) {
-    if (r.status === "ok") {
-      oks.push(r.value);
+type AllResultValues<Results extends readonly AnyResult[]> = {
+  -readonly [Index in keyof Results]: InferOk<Results[Index]>;
+};
+
+type AnyAsyncResult = AnyResult | PromiseLike<AnyResult>;
+type AwaitedResults<Results extends readonly AnyAsyncResult[]> = {
+  -readonly [Index in keyof Results]: Awaited<Results[Index]>;
+};
+
+type ResultValueUnion<Results extends readonly AnyResult[]> = InferOk<Results[number]>;
+type ResultErrorUnion<Results extends readonly AnyResult[]> = InferErr<Results[number]>;
+
+type PartitionedResults<Results extends readonly AnyResult[]> = [
+  Array<ResultValueUnion<Results>>,
+  Array<ResultErrorUnion<Results>>,
+];
+
+/** Awaits Result inputs concurrently and converts an unexpected rejection into a Panic. */
+const awaitResultsOrPanic = async <const Results extends readonly AnyAsyncResult[]>(
+  results: Results,
+  panicMessage: string,
+): Promise<AwaitedResults<Results>> => {
+  try {
+    return await Promise.all(results);
+  } catch (cause) {
+    return panic(panicMessage, cause);
+  }
+};
+
+/** Collects success values in input order or returns the first error. */
+const all = <const Results extends readonly AnyResult[]>(
+  results: Results,
+): Result<AllResultValues<Results>, ResultErrorUnion<Results>> => {
+  const values: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "error") {
+      // SAFETY: The input constraint guarantees this error belongs to Results[number].
+      // TypeScript cannot correlate the narrowed indexed element with ResultErrorUnion<Results>.
+      return result as unknown as Err<AllResultValues<Results>, ResultErrorUnion<Results>>;
+    }
+    values.push(result.value);
+  }
+  // SAFETY: Every input was Ok and values were appended once in input order, so this
+  // mutable array has exactly the mapped tuple or homogeneous array shape.
+  return ok(values as unknown as AllResultValues<Results>);
+};
+
+/** Concurrently awaits Results, then collects success values or returns the first input-order error. */
+const allAsync = async <const Results extends readonly AnyAsyncResult[]>(
+  results: Results,
+): Promise<
+  Result<AllResultValues<AwaitedResults<Results>>, ResultErrorUnion<AwaitedResults<Results>>>
+> => {
+  const awaitedResults = await awaitResultsOrPanic(
+    results,
+    "Result.allAsync input promise rejected",
+  );
+  return all(awaitedResults);
+};
+
+/** Splits success values and errors into separate arrays while preserving input order. */
+const partition = <const Results extends readonly AnyResult[]>(
+  results: Results,
+): PartitionedResults<Results> => {
+  const oks: unknown[] = [];
+  const errs: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "ok") {
+      oks.push(result.value);
     } else {
-      errs.push(r.error);
+      errs.push(result.error);
     }
   }
-  return [oks, errs];
+  // SAFETY: Each payload came from the corresponding branch of Results[number].
+  // Both arrays preserve the relative input order of their branch.
+  return [oks, errs] as unknown as PartitionedResults<Results>;
+};
+
+/** Concurrently awaits Results, then splits success values and errors into ordered arrays. */
+const partitionAsync = async <const Results extends readonly AnyAsyncResult[]>(
+  results: Results,
+): Promise<PartitionedResults<AwaitedResults<Results>>> => {
+  const awaitedResults = await awaitResultsOrPanic(
+    results,
+    "Result.partitionAsync input promise rejected",
+  );
+  return partition(awaitedResults);
 };
 
 /**
@@ -1160,12 +1236,40 @@ export const Result = {
    */
   codec,
   /**
-   * Splits array of Results into tuple of [okValues, errorValues].
+   * Collects success values in input order or returns the first error.
+   * Tuple inputs preserve each success value type and union their error types.
    *
    * @example
-   * partition([ok(1), err("a"), ok(2)]) // [[1, 2], ["a"]]
+   * Result.all([Result.ok(1), Result.ok("hello")]) // Ok([1, "hello"])
+   * Result.all([Result.ok(1), Result.err("failed")]) // Err("failed")
+   */
+  all,
+  /**
+   * Concurrently awaits Results, then collects success values or returns the first input-order error.
+   * Tuple inputs preserve each success value type and union their error types.
+   * A rejected input promise is an unrecoverable defect and throws `Panic`.
+   *
+   * @example
+   * await Result.allAsync([fetchUser(), fetchAccount()]) // Result<[User, Account], UserError | AccountError>
+   */
+  allAsync,
+  /**
+   * Splits Results into [successValues, errorValues], preserving relative input order.
+   * Heterogeneous inputs produce unions in their corresponding output arrays.
+   *
+   * @example
+   * Result.partition([Result.ok(1), Result.err("a"), Result.ok(2)]) // [[1, 2], ["a"]]
    */
   partition,
+  /**
+   * Concurrently awaits Results, then splits successes and errors into ordered arrays.
+   * Heterogeneous inputs produce unions in their corresponding output arrays.
+   * A rejected input promise is an unrecoverable defect and throws `Panic`.
+   *
+   * @example
+   * await Result.partitionAsync([fetchUser(), fetchAccount()]) // [[User], [AccountError]]
+   */
+  partitionAsync,
   /**
    * Flattens nested Result into single Result.
    *

--- a/src/result.ts
+++ b/src/result.ts
@@ -19,8 +19,16 @@ export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
 export type Result<T, E> = import("./core").Result<T, E>;
 
+/** Context passed to each `Result.try` attempt. */
 export type TryContext = {
+  /** One-based execution count, including the initial attempt. */
   readonly attempt: number;
+};
+
+/** Context passed to each `Result.tryPromise` attempt and retry decision. */
+export type TryPromiseContext = TryContext & {
+  /** Abort signal supplied through the top-level `Result.tryPromise` config. */
+  readonly signal?: AbortSignal;
 };
 
 /** Executes fn, panics if it throws. */
@@ -89,34 +97,41 @@ const tryFn: {
 };
 
 type RetryConfig<E = unknown> = {
+  /** Abort signal forwarded unchanged to every try and retry-decision context. */
+  signal?: AbortSignal;
   retry?: {
     times: number;
     delayMs: number;
     backoff: "linear" | "constant" | "exponential";
     /** Predicate to determine if an error should trigger a retry. Defaults to always retry. */
-    shouldRetry?: (error: E) => boolean;
+    shouldRetry?: (error: E, context: TryPromiseContext) => boolean;
   };
 };
 
 const tryPromise: {
   <A, E>(
     options: {
-      try: (context: TryContext) => Promise<A>;
+      try: (context: TryPromiseContext) => Promise<A>;
       catch: (cause: unknown) => E | Promise<E>;
     },
     config?: RetryConfig<E>,
   ): Promise<Result<A, E>>;
   <A>(
-    thunk: (context: TryContext) => Promise<A>,
+    thunk: (context: TryPromiseContext) => Promise<A>,
     config?: RetryConfig<UnhandledException>,
   ): Promise<Result<A, UnhandledException>>;
 } = async <A, E>(
   options:
-    | ((context: TryContext) => Promise<A>)
-    | { try: (context: TryContext) => Promise<A>; catch: (cause: unknown) => E | Promise<E> },
+    | ((context: TryPromiseContext) => Promise<A>)
+    | {
+        try: (context: TryPromiseContext) => Promise<A>;
+        catch: (cause: unknown) => E | Promise<E>;
+      },
   config?: RetryConfig<E | UnhandledException>,
 ): Promise<Result<A, E | UnhandledException>> => {
-  const execute = async (context: TryContext): Promise<Result<A, E | UnhandledException>> => {
+  const execute = async (
+    context: TryPromiseContext,
+  ): Promise<Result<A, E | UnhandledException>> => {
     if (typeof options === "function") {
       try {
         return ok(await options(context));
@@ -139,7 +154,7 @@ const tryPromise: {
   const retry = config?.retry;
 
   if (!retry) {
-    return execute({ attempt: 1 });
+    return execute({ attempt: 1, signal: config?.signal });
   }
 
   const getDelay = (retryAttempt: number): number => {
@@ -153,21 +168,42 @@ const tryPromise: {
     }
   };
 
-  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const sleepForRetryDelay = (ms: number, signal?: AbortSignal): Promise<boolean> =>
+    new Promise((resolve) => {
+      if (signal?.aborted) {
+        resolve(false);
+        return;
+      }
 
-  let attempt = 1;
-  let result = await execute({ attempt });
+      const onAbort = () => {
+        clearTimeout(timeout);
+        resolve(false);
+      };
+      const timeout = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve(true);
+      }, ms);
+
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+
+  let context: TryPromiseContext = { attempt: 1, signal: config.signal };
+  let result = await execute(context);
 
   const shouldRetryFn = retry.shouldRetry ?? (() => true);
 
   for (let retryAttempt = 0; retryAttempt < retry.times; retryAttempt++) {
-    if (result.status !== "error") break;
+    if (result.status !== "error" || context.signal?.aborted) break;
     const error = result.error;
-    const shouldContinue = tryOrPanic(() => shouldRetryFn(error), "shouldRetry predicate threw");
+    const shouldContinue = tryOrPanic(
+      () => shouldRetryFn(error, context),
+      "shouldRetry predicate threw",
+    );
     if (!shouldContinue) break;
-    await sleep(getDelay(retryAttempt));
-    attempt++;
-    result = await execute({ attempt });
+    const delayCompleted = await sleepForRetryDelay(getDelay(retryAttempt), context.signal);
+    if (!delayCompleted || context.signal?.aborted) break;
+    context = { attempt: context.attempt + 1, signal: config.signal };
+    result = await execute(context);
   }
 
   return result;
@@ -553,8 +589,9 @@ export const Result = {
    * Executes async function, wraps result/error in Result with retry support.
    *
    * @example
-   * // Basic retry
-   * await Result.tryPromise(() => fetch(url), {
+   * // Basic retry with cancellation forwarded to each attempt and retry delay
+   * await Result.tryPromise(({ signal }) => fetch(url, { signal }), {
+   *   signal: abortController.signal,
    *   retry: { times: 3, delayMs: 100, backoff: "exponential" }
    * })
    *

--- a/src/result.ts
+++ b/src/result.ts
@@ -55,8 +55,6 @@ const tryOrPanic = <T>(fn: () => T, message: string): T => {
  */
 type InferYieldErr<Y> = Y extends Err<never, infer E> ? E : never;
 
-type NoInfer<T> = [T][T extends unknown ? 0 : never];
-
 const tryFn: {
   <A, E>(
     options: { try: (context: TryContext) => Awaited<A>; catch: (cause: unknown) => Awaited<E> },
@@ -286,12 +284,12 @@ const mapError: {
 });
 
 const tryRecover: {
-  <A, E, E2>(result: Result<A, E>, fn: (e: E) => Result<NoInfer<A>, E2>): Result<A, E2>;
+  <A, E, E2, B = A>(result: Result<A, E>, fn: (e: E) => Result<B, E2>): Result<A | B, E2>;
   <E, E2>(fn: (e: E) => Result<never, E2>): <A>(result: Result<A, E>) => Result<A, E2>;
-  <E, A, E2>(fn: (e: E) => Result<A, E2>): (result: Result<A, E>) => Result<A, E2>;
+  <E, B, E2>(fn: (e: E) => Result<B, E2>): <A>(result: Result<A, E>) => Result<A | B, E2>;
 } = dual(
   2,
-  <A, E, E2>(result: Result<A, E>, fn: (e: E) => Result<NoInfer<A>, E2>): Result<A, E2> => {
+  <A, E, E2, B = A>(result: Result<A, E>, fn: (e: E) => Result<B, E2>): Result<A | B, E2> => {
     return result.tryRecover(fn);
   },
 );
@@ -304,22 +302,22 @@ const andThen: {
 });
 
 const tryRecoverAsync: {
-  <A, E, E2>(
+  <A, E, E2, B = A>(
     result: Result<A, E>,
-    fn: (e: E) => Promise<Result<NoInfer<A>, E2>>,
-  ): Promise<Result<A, E2>>;
+    fn: (e: E) => Promise<Result<B, E2>>,
+  ): Promise<Result<A | B, E2>>;
   <E, E2>(
     fn: (e: E) => Promise<Result<never, E2>>,
   ): <A>(result: Result<A, E>) => Promise<Result<A, E2>>;
-  <E, A, E2>(
-    fn: (e: E) => Promise<Result<A, E2>>,
-  ): (result: Result<A, E>) => Promise<Result<A, E2>>;
+  <E, B, E2>(
+    fn: (e: E) => Promise<Result<B, E2>>,
+  ): <A>(result: Result<A, E>) => Promise<Result<A | B, E2>>;
 } = dual(
   2,
-  <A, E, E2>(
+  <A, E, E2, B = A>(
     result: Result<A, E>,
-    fn: (e: E) => Promise<Result<NoInfer<A>, E2>>,
-  ): Promise<Result<A, E2>> => {
+    fn: (e: E) => Promise<Result<B, E2>>,
+  ): Promise<Result<A | B, E2>> => {
     return result.tryRecoverAsync(fn);
   },
 );
@@ -1087,7 +1085,7 @@ export const Result = {
    */
   mapError,
   /**
-   * Attempts to recover from an error into the same success type.
+   * Recovers from an error, widening the success type when recovery returns a new type.
    *
    * @example
    * Result.tryRecover(err("fail"), e => ok(e.length)) // Ok(4)
@@ -1102,7 +1100,7 @@ export const Result = {
    */
   andThen,
   /**
-   * Attempts to recover from an error into the same success type asynchronously.
+   * Recovers from an error asynchronously, widening success when recovery returns a new type.
    *
    * @example
    * await Result.tryRecoverAsync(err("fail"), async e => ok(e.length)) // Ok(4)

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,6 @@
 import { dual } from "./dual";
-import { ResultDeserializationError, UnhandledException } from "./error";
+import { ResultDeserializationError, ResultSerializationError, UnhandledException } from "./error";
+import { type StandardSchemaV1 } from "./standard-schema";
 import {
   Err,
   Ok,
@@ -17,7 +18,14 @@ import {
 
 export { Err, Ok } from "./core";
 export type { InferErr, InferOk } from "./core";
+export type { StandardSchemaV1 } from "./standard-schema";
 export type Result<T, E> = import("./core").Result<T, E>;
+/** A validation issue reported by a Standard Schema-compatible schema. */
+export type StandardSchemaIssue = StandardSchemaV1.Issue;
+/** A property key wrapper used in Standard Schema validation paths. */
+export type StandardSchemaPathSegment = StandardSchemaV1.PathSegment;
+/** The success or issue result returned by a Standard Schema-compatible validator. */
+export type StandardSchemaResult<Output> = StandardSchemaV1.Result<Output>;
 
 /** Context passed to each `Result.try` attempt. */
 export type TryContext = {
@@ -481,35 +489,332 @@ export interface SerializedErr<E> {
 /** Shape of a serialized Result over RPC. */
 export type SerializedResult<T, E> = SerializedOk<T> | SerializedErr<E>;
 
-function isSerializedResult(obj: unknown): obj is SerializedResult<unknown, unknown> {
+type SerializedOkEnvelope = {
+  readonly status: "ok";
+  readonly value?: unknown;
+};
+
+type SerializedErrEnvelope = {
+  readonly status: "error";
+  readonly error?: unknown;
+};
+
+type SerializedResultEnvelope = SerializedOkEnvelope | SerializedErrEnvelope;
+
+/** Infers the input accepted by a Standard Schema-compatible schema. */
+export type StandardSchemaInput<TSchema extends StandardSchemaV1> =
+  StandardSchemaV1.InferInput<TSchema>;
+
+/** Infers the output produced by a Standard Schema-compatible schema. */
+export type StandardSchemaOutput<TSchema extends StandardSchemaV1> =
+  StandardSchemaV1.InferOutput<TSchema>;
+
+type StandardSchemaValidationResult<TSchema extends StandardSchemaV1> = ReturnType<
+  TSchema["~standard"]["validate"]
+>;
+
+type StandardSchemaAsyncValidation<TSchema extends StandardSchemaV1> = Extract<
+  StandardSchemaValidationResult<TSchema>,
+  PromiseLike<unknown>
+>;
+
+type StandardSchemaSyncValidation<TSchema extends StandardSchemaV1> = Exclude<
+  StandardSchemaValidationResult<TSchema>,
+  PromiseLike<unknown>
+>;
+
+type StandardSchemaOperationResult<T, TSchema extends StandardSchemaV1> = [
+  StandardSchemaAsyncValidation<TSchema>,
+] extends [never]
+  ? T
+  : [StandardSchemaSyncValidation<TSchema>] extends [never]
+    ? Promise<T>
+    : T | Promise<T>;
+
+type SerializedCodecResult<
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+> = Result<
+  SerializedResult<StandardSchemaOutput<TOkSerialize>, StandardSchemaOutput<TErrSerialize>>,
+  ResultSerializationError
+>;
+
+type SerializedCodecOperationResult<
+  TResult extends Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+> =
+  TResult extends Ok<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>
+    ? StandardSchemaOperationResult<
+        SerializedCodecResult<TOkSerialize, TErrSerialize>,
+        TOkSerialize
+      >
+    : TResult extends Err<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>
+      ? StandardSchemaOperationResult<
+          SerializedCodecResult<TOkSerialize, TErrSerialize>,
+          TErrSerialize
+        >
+      : never;
+
+type DeserializedCodecResult<
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+> = Result<
+  StandardSchemaOutput<TOkDeserialize>,
+  StandardSchemaOutput<TErrDeserialize> | ResultDeserializationError
+>;
+
+type UnknownDeserializationResult<
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+> =
+  | DeserializedCodecResult<TOkDeserialize, TErrDeserialize>
+  | StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TOkDeserialize
+    >
+  | StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TErrDeserialize
+    >;
+
+/** Standard Schema serializers and deserializers for both Result branches. */
+export interface ResultCodecConfig<
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+> {
+  /** Schemas that convert in-memory Result payloads into wire payloads. */
+  readonly serialize: {
+    /** Serializes an Ok value. */
+    readonly ok: TOkSerialize;
+    /** Serializes an Err value. */
+    readonly err: TErrSerialize;
+  };
+  /** Schemas that parse wire payloads back into in-memory Result payloads. */
+  readonly deserialize: {
+    /** Deserializes a serialized Ok value. */
+    readonly ok: TOkDeserialize;
+    /** Deserializes a serialized Err value. */
+    readonly err: TErrDeserialize;
+  };
+}
+
+/** Converts Result values to and from a validated serialized representation. */
+export interface ResultCodec<
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+> {
+  /** Serializes the selected Result branch, preserving that branch schema's sync or async return. */
+  readonly serialize: <
+    TResult extends Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>,
+  >(
+    result: TResult,
+  ) => SerializedCodecOperationResult<TResult, TOkSerialize, TErrSerialize>;
+  /** Deserializes a known branch precisely, including status-only envelopes produced when JSON omits undefined payloads. */
+  readonly deserialize: {
+    (
+      value: SerializedOkEnvelope,
+    ): StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TOkDeserialize
+    >;
+    (
+      value: SerializedErrEnvelope,
+    ): StandardSchemaOperationResult<
+      DeserializedCodecResult<TOkDeserialize, TErrDeserialize>,
+      TErrDeserialize
+    >;
+    (value: unknown): UnknownDeserializationResult<TOkDeserialize, TErrDeserialize>;
+  };
+}
+
+/** Checks only the Result envelope; the selected codec schema validates its optional payload. */
+function isSerializedResultEnvelope(value: unknown): value is SerializedResultEnvelope {
   return (
-    obj !== null &&
-    typeof obj === "object" &&
-    "status" in obj &&
-    ((obj.status === "ok" && "value" in obj) || (obj.status === "error" && "error" in obj))
+    value !== null &&
+    typeof value === "object" &&
+    "status" in value &&
+    (value.status === "ok" || value.status === "error")
   );
 }
 
-const serialize = <T, E>(result: Result<T, E>): SerializedResult<T, E> => {
-  return result.status === "ok"
-    ? { status: "ok", value: result.value }
-    : { status: "error", error: result.error };
+const isPromiseLike = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
 };
 
-const deserialize = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
-  if (isSerializedResult(value)) {
-    return value.status === "ok"
-      ? (new Ok(value.value) as Result<T, E>)
-      : (new Err(value.error) as Result<T, E>);
+const runStandardSchemaValidation = <TResult>(
+  validate: () => TResult,
+  panicMessage: string,
+): TResult => {
+  return tryOrPanic(validate, panicMessage);
+};
+
+const mapStandardSchemaValidation = <T, U>(
+  validation: StandardSchemaV1.Result<T> | PromiseLike<StandardSchemaV1.Result<T>>,
+  panicMessage: string,
+  mapValidation: (validation: StandardSchemaV1.Result<T>) => U,
+): U | Promise<U> => {
+  if (isPromiseLike(validation)) {
+    return Promise.resolve(validation)
+      .catch((cause: unknown) => {
+        throw panic(panicMessage, cause);
+      })
+      .then(mapValidation);
   }
-  return err(new ResultDeserializationError({ value }));
+  return mapValidation(validation);
 };
 
-/**
- * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
- */
-const hydrate = <T, E>(value: unknown): Result<T, E | ResultDeserializationError> => {
-  return deserialize(value);
+const unwrapCodecValidation = <T, E>(
+  validation: StandardSchemaV1.Result<T>,
+  makeError: (issues: ReadonlyArray<StandardSchemaV1.Issue>) => E,
+): Result<T, E> => {
+  if ("issues" in validation && validation.issues) {
+    return err(makeError(validation.issues));
+  }
+  return ok(validation.value);
+};
+
+const serializeWithSchema = <TSchema extends StandardSchemaV1>(
+  schema: TSchema,
+  value: StandardSchemaInput<TSchema>,
+):
+  | Result<StandardSchemaOutput<TSchema>, ResultSerializationError>
+  | Promise<Result<StandardSchemaOutput<TSchema>, ResultSerializationError>> => {
+  const validation = runStandardSchemaValidation(
+    () => schema["~standard"].validate(value),
+    "Result.codec serialize schema threw",
+  );
+  return mapStandardSchemaValidation(
+    validation,
+    "Result.codec serialize schema threw",
+    (resolved) =>
+      unwrapCodecValidation(resolved, (issues) => new ResultSerializationError({ value, issues })),
+  );
+};
+
+const deserializeWithSchema = <TSchema extends StandardSchemaV1>(
+  schema: TSchema,
+  value: unknown,
+):
+  | Result<StandardSchemaOutput<TSchema>, ResultDeserializationError>
+  | Promise<Result<StandardSchemaOutput<TSchema>, ResultDeserializationError>> => {
+  const validation = runStandardSchemaValidation(
+    () => schema["~standard"].validate(value),
+    "Result.codec deserialize schema threw",
+  );
+  return mapStandardSchemaValidation(
+    validation,
+    "Result.codec deserialize schema threw",
+    (resolved) =>
+      unwrapCodecValidation(
+        resolved,
+        (issues) => new ResultDeserializationError({ value, issues }),
+      ),
+  );
+};
+
+const codec = <
+  TOkSerialize extends StandardSchemaV1,
+  TErrSerialize extends StandardSchemaV1,
+  TOkDeserialize extends StandardSchemaV1,
+  TErrDeserialize extends StandardSchemaV1,
+>(
+  config: ResultCodecConfig<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>,
+): ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize> => {
+  type SerializeResult = SerializedCodecResult<TOkSerialize, TErrSerialize>;
+  type DeserializeResult = DeserializedCodecResult<TOkDeserialize, TErrDeserialize>;
+  type InputResult = Result<StandardSchemaInput<TOkSerialize>, StandardSchemaInput<TErrSerialize>>;
+
+  const finishOkSerialization = (
+    resolved: Result<StandardSchemaOutput<TOkSerialize>, ResultSerializationError>,
+  ): SerializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return ok({ status: "ok", value: resolved.value });
+  };
+
+  const finishErrSerialization = (
+    resolved: Result<StandardSchemaOutput<TErrSerialize>, ResultSerializationError>,
+  ): SerializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return ok({ status: "error", error: resolved.value });
+  };
+
+  function serializeResult<TResult extends InputResult>(
+    result: TResult,
+  ): SerializedCodecOperationResult<TResult, TOkSerialize, TErrSerialize>;
+  function serializeResult(result: InputResult): SerializeResult | Promise<SerializeResult> {
+    if (result.status === "ok") {
+      const serialized = serializeWithSchema(config.serialize.ok, result.value);
+      return isPromiseLike(serialized)
+        ? Promise.resolve(serialized).then(finishOkSerialization)
+        : finishOkSerialization(serialized);
+    }
+    const serialized = serializeWithSchema(config.serialize.err, result.error);
+    return isPromiseLike(serialized)
+      ? Promise.resolve(serialized).then(finishErrSerialization)
+      : finishErrSerialization(serialized);
+  }
+
+  const finishOkDeserialization = (
+    resolved: Result<StandardSchemaOutput<TOkDeserialize>, ResultDeserializationError>,
+  ): DeserializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return ok(resolved.value);
+  };
+
+  const finishErrDeserialization = (
+    resolved: Result<StandardSchemaOutput<TErrDeserialize>, ResultDeserializationError>,
+  ): DeserializeResult => {
+    if (resolved.status === "error") {
+      return err(resolved.error);
+    }
+    return err(resolved.value);
+  };
+
+  function deserializeResult(
+    value: SerializedOkEnvelope,
+  ): StandardSchemaOperationResult<DeserializeResult, TOkDeserialize>;
+  function deserializeResult(
+    value: SerializedErrEnvelope,
+  ): StandardSchemaOperationResult<DeserializeResult, TErrDeserialize>;
+  function deserializeResult(
+    value: unknown,
+  ): UnknownDeserializationResult<TOkDeserialize, TErrDeserialize>;
+  function deserializeResult(value: unknown): DeserializeResult | Promise<DeserializeResult> {
+    if (!isSerializedResultEnvelope(value)) {
+      return err(new ResultDeserializationError({ value }));
+    }
+    if (value.status === "ok") {
+      const deserialized = deserializeWithSchema(config.deserialize.ok, value.value);
+      return isPromiseLike(deserialized)
+        ? Promise.resolve(deserialized).then(finishOkDeserialization)
+        : finishOkDeserialization(deserialized);
+    }
+    const deserialized = deserializeWithSchema(config.deserialize.err, value.error);
+    return isPromiseLike(deserialized)
+      ? Promise.resolve(deserialized).then(finishErrDeserialization)
+      : finishErrDeserialization(deserialized);
+  }
+
+  return {
+    serialize: serializeResult,
+    deserialize: deserializeResult,
+  } satisfies ResultCodec<TOkSerialize, TErrSerialize, TOkDeserialize, TErrDeserialize>;
 };
 
 const partition = <T, E>(results: readonly Result<T, E>[]): [T[], E[]] => {
@@ -774,34 +1079,18 @@ export const Result = {
    */
   await: resultAwait,
   /**
-   * Converts a Result to a plain object for serialization (e.g., RPC, server actions).
+   * Builds a Result-level codec from Standard Schema-compatible serializers/deserializers.
    *
    * @example
-   * const serialized = Result.serialize(ok(42)); // { status: "ok", value: 42 }
-   */
-  serialize,
-  /**
-   * Rehydrates serialized Result from RPC back into Ok/Err instances.
-   * Returns `Err<ResultDeserializationError>` if the input is not a valid serialized Result.
+   * const UserResultCodec = Result.codec({
+   *   serialize: { ok: UserToWireSchema, err: AppErrorToWireSchema },
+   *   deserialize: { ok: WireToUserSchema, err: WireToAppErrorSchema },
+   * });
    *
-   * @example
-   * // Valid serialized Result
-   * const result = Result.deserialize<User, AppError>(rpcResponse);
-   * if (Result.isOk(result)) {
-   *   console.log(result.value); // User
-   * }
-   *
-   * // Invalid input returns ResultDeserializationError
-   * const invalid = Result.deserialize({ foo: "bar" });
-   * if (Result.isError(invalid) && ResultDeserializationError.is(invalid.error)) {
-   *   console.log("Bad input:", invalid.error.value);
-   * }
+   * const outbound = UserResultCodec.serialize(Result.ok(user));
+   * const inbound = outbound.andThen((wire) => UserResultCodec.deserialize(wire));
    */
-  deserialize,
-  /**
-   * @deprecated Use `Result.deserialize` instead. Will be removed in 3.0.
-   */
-  hydrate,
+  codec,
   /**
    * Splits array of Results into tuple of [okValues, errorValues].
    *

--- a/src/standard-schema.ts
+++ b/src/standard-schema.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendored Standard Schema interface.
+ *
+ * Source: https://standardschema.dev/schema#the-interface
+ */
+
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1;
+    /** The vendor name of the schema library. */
+    readonly vendor: string;
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown,
+      options?: StandardSchemaV1.Options | undefined,
+    ) => Result<Output> | Promise<Result<Output>>;
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output;
+    /** A falsy value for `issues` indicates success. */
+    readonly issues?: undefined;
+  }
+
+  export interface Options {
+    /** Explicit support for additional vendor-specific parameters, if needed. */
+    readonly libraryOptions?: Record<string, unknown> | undefined;
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input;
+    /** The output type of the schema. */
+    readonly output: Output;
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["input"];
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["output"];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    typecheck: {
+      enabled: true,
+      checker: "tsc",
+      include: ["src/**/*.test-d.ts"],
+      tsconfig: "./tsconfig.json",
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- allow `tryRecover` and `tryRecoverAsync` to widen the success channel while replacing the handled error channel
- add a pipeable `matchErrorPartial(..., Result.err)` overload that preserves the exact unhandled error variants
- keep concrete `Ok`/`Err` precision and existing explicit generic usage
- standardize the project test entrypoint and type tests on Vitest

## Why this direction

Rather than introduce another recovery operation such as `reroute`, this deepens the existing `tryRecover` contract:

```ts
Result<A, E>.tryRecover(
  (error: E) => Result<B, E2>,
): Result<A | B, E2>
```

An existing `Ok<A>` still passes through untouched. An `Err<E>` invokes the recovery callback, which can now return a different success type `B` and a different remaining error type `E2`.

`matchErrorPartial` also recognizes `Result.err` as an error-preserving `onUnhandled` callback. That lets TypeScript defer the original error union until the matcher is applied and then exclude the handled variants precisely.

## Issue #54 example

```ts
const result: Result<
  string,
  InvalidInputError | UnauthorizedError | NameAlreadyTakenError
> = await api.closeIssue(issueId);

const recovered = result.tryRecover(
  matchErrorPartial(
    {
      NameAlreadyTakenError: (error: NameAlreadyTakenError) =>
        Result.ok(error),
    },
    Result.err,
  ),
);

// Result<
//   string | NameAlreadyTakenError,
//   InvalidInputError | UnauthorizedError
// >

return recovered.unwrap();
```

`NameAlreadyTakenError` becomes data for the custom UI. The remaining unexpected errors stay in the error channel, so `.unwrap()` throws them for the application's existing error instrumentation.

## Compatibility

- existing same-success recovery calls retain their inferred type
- existing explicit calls such as `result.tryRecover<ErrorB>(...)` remain valid
- all existing `matchErrorPartial` forms and runtime behavior remain intact
- `tryRecoverAsync`, data-first, and data-last forms follow the same widening semantics

## Validation

- `bun run test` — 331 tests passed, no type errors
- `bun run check`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`
- `npm pack --dry-run`
- audited known Prisma and Better T Stack dependents; no affected call sites found

Closes #54
