### PR TITLE
docs: add better-result 3 migration skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -2,9 +2,10 @@
 
 Portable skills for adopting `better-result` with compatible coding agents.
 
-## Available skill
+## Available skills
 
 - [`adopt-better-result`](adopt-better-result/SKILL.md) — audit repository-wide error handling and propose an adoption plan, or implement one named vertical migration slice.
+- [`migrate-better-result-3`](migrate-better-result-3/SKILL.md) — migrate a TypeScript codebase from better-result 2.x to 3.0, including TaggedError syntax and validated Result codecs.
 
 ## Install
 
@@ -12,12 +13,14 @@ With skills.sh-compatible tooling:
 
 ```sh
 npx skills add dmmulroy/better-result@adopt-better-result
+npx skills add dmmulroy/better-result@migrate-better-result-3
 ```
 
 For a global non-interactive installation:
 
 ```sh
 npx skills add dmmulroy/better-result@adopt-better-result -g -y
+npx skills add dmmulroy/better-result@migrate-better-result-3 -g -y
 ```
 
-For manual installation, copy `skills/adopt-better-result/` into the agent's configured skills directory. The skill is self-contained; its context pointers resolve files under `references/` only when their branch needs them.
+For manual installation, copy the selected directory under `skills/` into the agent's configured skills directory. Each skill is self-contained; its context pointers resolve bundled references and scripts only when needed.

--- a/skills/migrate-better-result-3/SKILL.md
+++ b/skills/migrate-better-result-3/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: migrate-better-result-3
+description: Migrate a TypeScript codebase from better-result 2.x to 3.0. Use when upgrading better-result across the TaggedError syntax, removed Result serialization helpers, recovery inference, matching, or retry APIs.
+---
+
+# Migrate better-result to 3.0
+
+Treat the compiler as the migration ledger: inventory first, make mechanical changes, then resolve each remaining error by API branch.
+
+## 1. Establish the migration surface
+
+Read repository instructions, package manifests, lockfiles, TypeScript configuration, and validation commands. Verify that the source version is `better-result` 2.x and inspect the installed 3.0 declarations when available; package source outranks remembered APIs.
+
+Search production code and tests for:
+
+```sh
+rg -n --glob '*.{ts,tsx,mts,cts}' \
+  'TaggedError|Result\.(serialize|deserialize|hydrate|tryRecover|tryRecoverAsync|tryPromise|partition)|matchError(Partial)?|TaggedErrorClass|Serialized(Result|Ok|Err)'
+```
+
+Classify every hit under the audited API changes in [references/v3-api-diff.md](references/v3-api-diff.md). Record generated or vendored hits separately rather than editing them.
+
+**Complete when:** the installed source version, target 3.0 API, validation commands, and every matching production/test site are accounted for by file and migration branch.
+
+## 2. Apply the TaggedError codemod
+
+List safe trailing-call edits:
+
+```sh
+node <skill-dir>/scripts/migrate-tagged-error-v3.mjs . --list
+```
+
+Review the listed class heritage expressions, then apply them:
+
+```sh
+node <skill-dir>/scripts/migrate-tagged-error-v3.mjs . --write
+node <skill-dir>/scripts/migrate-tagged-error-v3.mjs . --check
+```
+
+The transform changes only the v2 class heritage shape:
+
+```ts
+class NotFoundError extends TaggedError("NotFoundError")<{ id: string }>() {}
+// becomes
+class NotFoundError extends TaggedError("NotFoundError")<{ id: string }> {}
+```
+
+It preserves constructors, properties, formatting, and call sites. Manually update exported `TaggedErrorClass<Tag, Props>` annotations to the v3 class type `TaggedErrorClass<Tag>`; move payload typing to the subclass application shown above.
+
+**Complete when:** the script's check exits successfully and searches find no v2 trailing factory calls or two-argument `TaggedErrorClass` uses outside generated/vendor code.
+
+## 3. Replace removed serialization helpers
+
+If the inventory contains `Result.serialize`, `Result.deserialize`, or `Result.hydrate`, follow [references/result-codec-migration.md](references/result-codec-migration.md). Design codecs at each transport or persistence boundary instead of creating one unvalidated global compatibility shim.
+
+Account for changed control flow: serialization can now return `ResultSerializationError`; deserialization adds `ResultDeserializationError`; sync/async schemas determine whether codec operations return a `Result` or `Promise<Result>`.
+
+**Complete when:** every removed-helper call has an owning codec with schemas for both Result branches, and every codec error and async return is handled at its boundary.
+
+## 4. Reconcile changed inference and optional APIs
+
+Type-check after the mechanical and codec changes. Resolve diagnostics using [references/v3-api-diff.md](references/v3-api-diff.md), especially:
+
+- `tryRecover` and `tryRecoverAsync` now preserve the original success and union it with a different recovered success type.
+- `matchError` and `matchErrorPartial` infer unions from divergent handler returns.
+- `matchErrorPartial` may omit its fallback; an unhandled tagged error is then returned unchanged.
+- `Result.partition` now supports heterogeneous inputs; `all`, `allAsync`, and `partitionAsync` are new.
+- `Result.tryPromise` adds abort context, dynamic delays, and jitter while retaining valid v2 static retry configurations.
+
+Keep existing runtime behavior unless the user requested adoption of a new 3.0 capability. Prefer accurate widened types and explicit narrowing over casts.
+
+**Complete when:** every compiler diagnostic caused by a changed 3.0 signature is resolved, every intentional inferred union reaches an explicit handling point, and unrelated behavior remains unchanged.
+
+## 5. Upgrade and prove the migration
+
+Update the direct dependency and lockfile to the requested stable or prerelease 3.0 version. Run formatting, lint, type-check, tests, and build commands required by the repository. Repeat the inventory search and the codemod check.
+
+Report the version change, files migrated by branch, codec/error-handling decisions, adopted optional features, and validation evidence.
+
+**Complete when:** no removed API or v2 TaggedError syntax remains outside recorded generated/vendor code, all inventoried sites are closed, and every repository check passes or has a concrete reported failure.

--- a/skills/migrate-better-result-3/references/result-codec-migration.md
+++ b/skills/migrate-better-result-3/references/result-codec-migration.md
@@ -1,0 +1,105 @@
+# Migrate Result serialization to codecs
+
+Use this branch for every removed `Result.serialize`, `Result.deserialize`, or `Result.hydrate` call.
+
+## 1. Find the boundary contract
+
+For each call, trace the serialized value to its consumer or producer. Record:
+
+- the in-memory Ok and Err payload types
+- the wire/storage Ok and Err payload shapes
+- whether either direction transforms values such as `Date`, branded values, or error classes
+- who handles malformed envelopes and payloads
+- whether the chosen Standard Schema validators are synchronous or asynchronous
+
+Create one named codec per coherent boundary contract. Reuse it only where all four payload contracts are identical.
+
+## 2. Define all four schemas
+
+`Result.codec` requires an Ok and Err schema for both directions:
+
+```ts
+import { Result, ResultDeserializationError } from "better-result";
+import { z } from "zod";
+
+const UserWireSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+});
+
+const ValidationErrorWireSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+
+const UserResultCodec = Result.codec({
+  serialize: {
+    ok: UserWireSchema,
+    err: ValidationErrorWireSchema,
+  },
+  deserialize: {
+    ok: UserWireSchema,
+    err: ValidationErrorWireSchema,
+  },
+});
+```
+
+Identity-like schemas must still validate. When in-memory and wire types differ, use schema transforms in each direction rather than casting the envelope.
+
+## 3. Replace serialization
+
+```ts
+// 2.x: cannot fail
+const envelope = Result.serialize(result);
+
+// 3.0: payload validation is explicit
+const encoded = await UserResultCodec.serialize(result);
+```
+
+`encoded` is a `Result<SerializedResult<...>, ResultSerializationError>`. Keep it in Result composition or explicitly handle the error before sending/writing the envelope.
+
+```ts
+if (Result.isError(encoded)) {
+  reportInvalidOutboundPayload(encoded.error.value, encoded.error.issues);
+  return encoded;
+}
+
+await transport.send(encoded.value);
+```
+
+## 4. Replace deserialization and hydration
+
+```ts
+// 2.x
+const decoded = Result.deserialize<UserWire, ValidationErrorWire>(input);
+// Result.hydrate(...) was an alias
+
+// 3.0
+const decoded = await UserResultCodec.deserialize(input);
+```
+
+Remove explicit payload type arguments; the schemas infer them. Invalid envelopes and payloads return `ResultDeserializationError`. Handle that variant alongside the decoded Err payload type:
+
+```ts
+if (Result.isError(decoded)) {
+  if (ResultDeserializationError.is(decoded.error)) {
+    reportInvalidInboundPayload(decoded.error.value, decoded.error.issues);
+  } else {
+    handleRemoteValidationError(decoded.error);
+  }
+}
+```
+
+Import `ResultDeserializationError` where the boundary distinguishes malformed input from a valid serialized Err payload.
+
+## 5. Preserve honest sync/async behavior
+
+Each selected schema determines whether that branch's operation returns `Result` or `Promise<Result>`. Mixed schema configurations can produce `Result | Promise<Result>` when the branch is not statically known. `await` accepts both and is the simplest boundary control flow when callers do not need a synchronous contract.
+
+A schema that reports issues yields `ResultSerializationError` or `ResultDeserializationError`. A schema that throws or rejects is a defect and becomes `Panic`; preserve the repository's defect reporting behavior.
+
+JSON omits properties with `undefined` values. A codec accepts `{ status: "ok" }` or `{ status: "error" }` and passes `undefined` to the selected deserialization schema. Use a schema that accepts `undefined` for `void`/`undefined` payloads; other schemas correctly return `ResultDeserializationError`.
+
+## Completion check
+
+The serialization branch is complete when every old helper call is gone, each boundary has four validating schemas, in-memory/wire transforms are represented by schemas, serialization and deserialization errors are handled, and async behavior is reflected in callers and tests.

--- a/skills/migrate-better-result-3/references/v3-api-diff.md
+++ b/skills/migrate-better-result-3/references/v3-api-diff.md
@@ -1,0 +1,117 @@
+# Audited 2.10.0 → 3.0 API diff
+
+This reference is derived from the public source and tests between `v2.10.0` and the `3.0` branch at `a43cead`. Verify the installed target declarations when migrating to a later 3.x release.
+
+## Required source changes
+
+### TaggedError factory
+
+The empty call after the props type is removed.
+
+```ts
+// 2.x
+class ApiError extends TaggedError("ApiError")<{
+  status: number;
+  message: string;
+}>() {}
+
+// 3.0
+class ApiError extends TaggedError("ApiError")<{
+  status: number;
+  message: string;
+}> {}
+```
+
+Construction remains object-based: `new ApiError({ status, message })`. Custom constructors continue to call `super(props)`. `TaggedError.is(value)` still checks any tagged error, while `ApiError.is(value)` now narrows to that concrete subclass more accurately.
+
+The exported class helper changed from `TaggedErrorClass<Tag, Props>` to `TaggedErrorClass<Tag>`. The resulting base class is generic in props, so reusable bases can use this shape:
+
+```ts
+const HttpError = TaggedError("HttpError");
+class NotFoundError extends HttpError<{ resource: string; message: string }> {}
+```
+
+### Result serialization
+
+`Result.serialize`, `Result.deserialize`, and deprecated `Result.hydrate` are removed. `Result.codec(config)` replaces them with Standard Schema validation for the Ok and Err payloads in each direction. Follow [result-codec-migration.md](result-codec-migration.md) for boundary design and error handling.
+
+The plain envelope types `SerializedResult`, `SerializedOk`, and `SerializedErr` remain exported. They describe wire shapes; they do not validate or hydrate unknown values.
+
+## Inference changes to review
+
+### Recovery may widen success
+
+Both static and instance forms of `tryRecover` and `tryRecoverAsync` now allow a recovered success type `B` different from the original `A`.
+
+```ts
+const recovered = result.tryRecover(() => Result.ok("fallback"));
+// Result<A | string, NewError>
+```
+
+On an `Ok`, the callback remains uncalled and the original `A` survives. On a concrete `Err`, recovery returns `Result<B, NewError>`. Remove workarounds that coerced recovery back to `A`, then ensure downstream code handles the honest `A | B` union.
+
+### Tagged-error matching
+
+`matchError` infers the union of independent handler returns; explicit `<ErrorUnion, Return>` parameters still constrain all handlers to one return type.
+
+`matchErrorPartial` also unions handler and fallback returns. Its fallback is now optional. Without one, handled variants are transformed and unhandled variants pass through unchanged:
+
+```ts
+const output = matchErrorPartial(error, {
+  NotFoundError: () => "missing" as const,
+});
+// "missing" | remaining error variants
+```
+
+In pipeable recovery code, pass `Result.err` when unhandled variants must remain in the Result error channel:
+
+```ts
+const recoverNotFound = matchErrorPartial(
+  { NotFoundError: (error: NotFoundError) => Result.ok(error.cachedValue) },
+  Result.err,
+);
+```
+
+Existing three-argument data-first and two-argument pipeable calls with a fallback remain supported.
+
+### Partition typing
+
+`Result.partition` still returns `[okValues, errValues]`, but now accepts heterogeneous tuples/arrays and infers unions for both arrays. Review exact type assertions that depended on a homogeneous signature.
+
+## Additive 3.0 APIs
+
+These additions require no migration unless the codebase chooses to adopt them.
+
+### Validated codecs and errors
+
+- `Result.codec(config)`
+- `ResultSerializationError`
+- `ResultDeserializationError` now optionally carries Standard Schema `issues`
+- `ResultCodec`, `ResultCodecConfig`, `ResultCodecIssue`, and Standard Schema helper types
+
+### Result collections
+
+- `Result.all(results)` collects all Ok values in tuple order or returns the first Err in input order.
+- `Result.allAsync(results)` concurrently accepts Results and promises, then uses input order; a rejected input promise throws `Panic`.
+- `Result.partitionAsync(results)` concurrently partitions Results and promises in input order; a rejected input promise throws `Panic`.
+
+### Async retry controls
+
+`Result.tryPromise` callbacks now receive `TryPromiseContext`, which extends the 1-based `{ attempt }` context with `signal?: AbortSignal`. Synchronous `Result.try` continues to receive `TryContext` without a signal.
+
+A top-level `signal` is forwarded to every attempt and retry decision. Aborting interrupts retry delays and prevents later attempts, but the callback must pass the signal to an abort-aware operation to cancel in-flight work. The latest typed error is returned when retrying stops.
+
+`shouldRetry(error, context)` may use the failed attempt and signal. A dynamic `delayMs(error, context)` is supported, but it cannot be combined with `backoff` or `jitter`. Static delays retain required `backoff` and may add `jitter: boolean | number`; numeric jitter must be finite and between 0 and 1. Retry callbacks remain synchronous and throw `Panic` on defects.
+
+A valid v2 static retry object remains valid in 3.0:
+
+```ts
+{
+  retry: {
+    times: 3,
+    delayMs: 100,
+    backoff: "exponential",
+    shouldRetry: (error) => error.retryable,
+  },
+}
+```

--- a/skills/migrate-better-result-3/scripts/migrate-tagged-error-v3.mjs
+++ b/skills/migrate-better-result-3/scripts/migrate-tagged-error-v3.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+const loadTypeScript = () => {
+  const projectRequire = createRequire(path.join(process.cwd(), "package.json"));
+  try {
+    return projectRequire("typescript");
+  } catch (projectError) {
+    try {
+      return createRequire(import.meta.url)("typescript");
+    } catch {
+      console.error(
+        "TaggedError v3 migration: install TypeScript in the target project before running this codemod",
+      );
+      if (process.env.DEBUG) console.error(projectError);
+      process.exit(2);
+    }
+  }
+};
+
+const ts = loadTypeScript();
+
+const sourceExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const excludedDirectoryNames = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "vendor",
+]);
+
+const args = process.argv.slice(2);
+const modes = args.filter((arg) => arg === "--list" || arg === "--write" || arg === "--check");
+if (modes.length > 1) {
+  console.error("TaggedError v3 migration: choose one of --list, --write, or --check");
+  process.exit(2);
+}
+
+const mode = modes[0] ?? "--list";
+const roots = args.filter((arg) => !arg.startsWith("--"));
+if (roots.length === 0) roots.push(".");
+
+const isTaggedErrorFactory = (expression) => {
+  if (!ts.isCallExpression(expression) || expression.arguments.length !== 1) return false;
+
+  if (ts.isIdentifier(expression.expression)) {
+    return expression.expression.text === "TaggedError";
+  }
+
+  return (
+    ts.isPropertyAccessExpression(expression.expression) &&
+    expression.expression.name.text === "TaggedError"
+  );
+};
+
+const findTrailingCallEdits = (sourceFile) => {
+  const edits = [];
+
+  const visit = (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.arguments.length === 0 &&
+      node.typeArguments !== undefined &&
+      node.typeArguments.length > 0 &&
+      isTaggedErrorFactory(node.expression)
+    ) {
+      const typeArgumentsEnd = node.typeArguments.end;
+      const deleteEnd = node.end;
+      const trailingText = sourceFile.text.slice(typeArgumentsEnd, deleteEnd);
+      if (/^>\s*\(\s*\)$/.test(trailingText)) {
+        const deleteStart = typeArgumentsEnd + 1;
+        const location = sourceFile.getLineAndCharacterOfPosition(deleteStart);
+        edits.push({
+          start: deleteStart,
+          end: deleteEnd,
+          line: location.line + 1,
+          column: location.character + 1,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return edits;
+};
+
+const collectSourceFiles = async (entryPath) => {
+  const absolutePath = path.resolve(entryPath);
+  const entries = await readdir(absolutePath, { withFileTypes: true }).catch((error) => {
+    if (error?.code === "ENOTDIR" && sourceExtensions.has(path.extname(absolutePath))) {
+      return undefined;
+    }
+    throw error;
+  });
+
+  if (entries === undefined) return [absolutePath];
+
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory() && excludedDirectoryNames.has(entry.name)) continue;
+
+    const childPath = path.join(absolutePath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectSourceFiles(childPath)));
+    } else if (entry.isFile() && sourceExtensions.has(path.extname(entry.name))) {
+      files.push(childPath);
+    }
+  }
+  return files;
+};
+
+const files = [...new Set((await Promise.all(roots.map(collectSourceFiles))).flat())].sort();
+let matchCount = 0;
+let fileCount = 0;
+
+for (const filePath of files) {
+  const sourceText = await readFile(filePath, "utf8");
+  const scriptKind = filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  const edits = findTrailingCallEdits(sourceFile);
+  if (edits.length === 0) continue;
+
+  matchCount += edits.length;
+  fileCount++;
+
+  for (const edit of edits) {
+    console.log(`${path.relative(process.cwd(), filePath)}:${edit.line}:${edit.column}`);
+  }
+
+  if (mode === "--write") {
+    let migratedText = sourceText;
+    for (const edit of edits.sort((left, right) => right.start - left.start)) {
+      migratedText = migratedText.slice(0, edit.start) + migratedText.slice(edit.end);
+    }
+    await writeFile(filePath, migratedText);
+  }
+}
+
+if (mode === "--write") {
+  console.log(`Migrated ${matchCount} TaggedError declaration(s) in ${fileCount} file(s).`);
+} else if (matchCount === 0) {
+  console.log("No better-result 2.x TaggedError trailing calls found.");
+} else {
+  console.log(
+    `Found ${matchCount} better-result 2.x TaggedError trailing call(s) in ${fileCount} file(s).`,
+  );
+}
+
+if (mode === "--check" && matchCount > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- add a deterministic skill for migrating TypeScript codebases from better-result 2.x to 3.0
- document the audited TaggedError, serialization, recovery, matching, collection, and retry API changes
- add boundary-focused guidance for replacing removed serialization helpers with validated `Result.codec` contracts
- include a TypeScript AST codemod for detecting and removing v2 TaggedError trailing factory calls
- publish the new skill in the skills README

## Validation

- `bun run fmt:check`
- `bun run lint`
- `bun run check`
- `bun test` (296 passed)
- codemod fixture tests for list, write, check, multiline, namespace-qualified, and unrelated factory usage
- codemod audit against v2.10.0 source (15 declarations detected)
- portable TypeScript resolution check from outside the repository
- `git diff --check`

## Stack

This PR is based on #99, which establishes the redesigned portable skill layout. Only the 3.0 migration skill changes are included in this diff.
