### PR TITLE
feat: add TaggedError match method

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,16 +497,16 @@ Build exhaustive error handling with discriminated unions:
 ```ts
 import { Result, TaggedError, matchError, matchErrorPartial } from "better-result";
 
-// Factory API: TaggedError("Tag")<Props>()
+// Factory API: TaggedError("Tag")<Props>
 class NotFoundError extends TaggedError("NotFoundError")<{
   id: string;
   message: string;
-}>() {}
+}> {}
 
 class ValidationError extends TaggedError("ValidationError")<{
   field: string;
   message: string;
-}>() {}
+}> {}
 
 type AppError = NotFoundError | ValidationError;
 
@@ -526,6 +526,16 @@ const describeErrorDirectly = (error: AppError) =>
     NotFoundError: (e) => `Missing: ${e.id}`,
     ValidationError: (e) => `Bad field: ${e.field}`,
   });
+
+// Result error handlers infer the union, so no annotation is needed
+const response = result.match({
+  ok: (user) => ({ status: 200, body: user }),
+  err: (error) =>
+    error.match({
+      NotFoundError: () => ({ status: 404, body: null }),
+      ValidationError: () => ({ status: 400, body: null }),
+    }),
+});
 
 // Partial matching leaves unhandled errors unchanged by default
 const transformed = matchErrorPartial(error, {

--- a/README.md
+++ b/README.md
@@ -513,11 +513,19 @@ type AppError = NotFoundError | ValidationError;
 // Create errors with object args
 const err = new NotFoundError({ id: "123", message: "User not found" });
 
-// Exhaustive matching
-matchError(error, {
-  NotFoundError: (e) => `Missing: ${e.id}`,
-  ValidationError: (e) => `Bad field: ${e.field}`,
-});
+// Exhaustive matching with a standalone function
+const describeError = (error: AppError) =>
+  matchError(error, {
+    NotFoundError: (e) => `Missing: ${e.id}`,
+    ValidationError: (e) => `Bad field: ${e.field}`,
+  });
+
+// TaggedError instances can match directly
+const describeErrorDirectly = (error: AppError) =>
+  error.match({
+    NotFoundError: (e) => `Missing: ${e.id}`,
+    ValidationError: (e) => `Bad field: ${e.field}`,
+  });
 
 // Partial matching leaves unhandled errors unchanged by default
 const transformed = matchErrorPartial(error, {
@@ -791,7 +799,8 @@ Migration differences:
 | -------------------------------------------------- | ------------------------------------------------------- |
 | `TaggedError(tag)<Props>()`                        | Factory for tagged error class                          |
 | `TaggedError.is(value)`                            | Type guard for any TaggedError                          |
-| `matchError(err, handlers)`                        | Exhaustive pattern match by `_tag`                      |
+| `error.match(handlers)`                            | Exhaustive instance pattern match by `_tag`             |
+| `matchError(err, handlers)`                        | Exhaustive standalone pattern match by `_tag`           |
 | `matchErrorPartial(error, handlers, onUnhandled?)` | Partial match; unhandled errors pass through by default |
 | `isTaggedError(value)`                             | Type guard (standalone function)                        |
 | `panic(message, cause?)`                           | Throw unrecoverable Panic                               |

--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ Errors from all yielded Results are automatically collected into the final error
 Use `mapError` on the output of `Result.gen()` to unify multiple error types into a single type:
 
 ```ts
-class ParseError extends TaggedError("ParseError")<{ message: string }>() {}
-class ValidationError extends TaggedError("ValidationError")<{ message: string }>() {}
-class AppError extends TaggedError("AppError")<{ source: string; message: string }>() {}
+class ParseError extends TaggedError("ParseError")<{ message: string }> {}
+class ValidationError extends TaggedError("ValidationError")<{ message: string }> {}
+class AppError extends TaggedError("AppError")<{ source: string; message: string }> {}
 
 const result = Result.gen(function* () {
   const parsed = yield* parseInput(input); // Err: ParseError
@@ -290,8 +290,8 @@ The same signal and failed attempt number are available as the second `shouldRet
 Retry only for specific error types using `shouldRetry`:
 
 ```ts
-class NetworkError extends TaggedError("NetworkError")<{ message: string }>() {}
-class ValidationError extends TaggedError("ValidationError")<{ message: string }>() {}
+class NetworkError extends TaggedError("NetworkError")<{ message: string }> {}
+class ValidationError extends TaggedError("ValidationError")<{ message: string }> {}
 
 const result = await Result.tryPromise(
   {
@@ -342,7 +342,7 @@ Retry callbacks are synchronous. For decisions that require async operations (ra
 class ApiError extends TaggedError("ApiError")<{
   message: string;
   rateLimited: boolean;
-}>() {}
+}> {}
 
 const result = await Result.tryPromise(
   {
@@ -527,6 +527,9 @@ const describeErrorDirectly = (error: AppError) =>
     ValidationError: (e) => `Bad field: ${e.field}`,
   });
 
+// If a selected handler throws, match and matchError throw Panic with that exception as cause.
+// `match` is reserved and cannot be declared as a TaggedError payload property.
+
 // Result error handlers infer the union, so no annotation is needed
 const response = result.match({
   ok: (user) => ({ status: 200, body: user }),
@@ -602,7 +605,7 @@ class NetworkError extends TaggedError("NetworkError")<{
   url: string;
   status: number;
   message: string;
-}>() {
+}> {
   constructor(args: { url: string; status: number }) {
     super({ ...args, message: `Request to ${args.url} failed: ${args.status}` });
   }
@@ -807,7 +810,7 @@ Migration differences:
 
 | Method                                             | Description                                             |
 | -------------------------------------------------- | ------------------------------------------------------- |
-| `TaggedError(tag)<Props>()`                        | Factory for tagged error class                          |
+| `TaggedError(tag)<Props>`                          | Factory for tagged error class                          |
 | `TaggedError.is(value)`                            | Type guard for any TaggedError                          |
 | `error.match(handlers)`                            | Exhaustive instance pattern match by `_tag`             |
 | `matchError(err, handlers)`                        | Exhaustive standalone pattern match by `_tag`           |

--- a/skills/adopt-better-result/references/tagged-errors.md
+++ b/skills/adopt-better-result/references/tagged-errors.md
@@ -63,6 +63,19 @@ Record every `UnhandledException` fallback in the adoption report or implementat
 
 ## Design for handling
 
-Use discriminated error unions and exhaustive `matchError` handling at decision boundaries. Error fields should provide the facts required for retries, status mapping, compensation, logging, and user presentation without parsing the message string.
+Use discriminated error unions and exhaustive matching at decision boundaries. Prefer the `error.match({ ... })` instance method when every variant is created by `TaggedError`; its receiver supplies the complete error union and each handler narrows to its concrete variant. Use the standalone `matchError(error, handlers)` function for structurally tagged errors or its data-last form.
+
+```ts
+const response = result.match({
+  ok: (user) => ({ status: 200, body: user }),
+  err: (error) =>
+    error.match({
+      UserNotFound: () => ({ status: 404, body: null }),
+      UserStoreUnavailable: () => ({ status: 503, body: null }),
+    }),
+});
+```
+
+Error fields should provide the facts required for retries, status mapping, compensation, logging, and user presentation without parsing the message string. Treat `match` as a reserved TaggedError instance method; do not declare an error payload property or subclass method with that name.
 
 For errors crossing serialized boundaries, apply [`result-boundaries.md`](result-boundaries.md). Expose stable public codes and safe fields; reconstruct the appropriate tagged error during trusted deserialization when the receiving side needs domain behavior.

--- a/skills/adopt-better-result/references/tagged-errors.md
+++ b/skills/adopt-better-result/references/tagged-errors.md
@@ -76,6 +76,6 @@ const response = result.match({
 });
 ```
 
-Error fields should provide the facts required for retries, status mapping, compensation, logging, and user presentation without parsing the message string. Treat `match` as a reserved TaggedError instance method; do not declare an error payload property or subclass method with that name.
+Error fields should provide the facts required for retries, status mapping, compensation, logging, and user presentation without parsing the message string. Treat `match` as a reserved TaggedError instance method; TypeScript rejects payload properties and incompatible subclass members with that name. If an exhaustive `.match()` or `matchError` handler throws, the operation throws `Panic` with the original exception as `cause`.
 
 For errors crossing serialized boundaries, apply [`result-boundaries.md`](result-boundaries.md). Expose stable public codes and safe fields; reconstruct the appropriate tagged error during trusted deserialization when the receiving side needs domain behavior.

--- a/skills/migrate-better-result-3/SKILL.md
+++ b/skills/migrate-better-result-3/SKILL.md
@@ -62,7 +62,7 @@ Account for changed control flow: serialization can now return `ResultSerializat
 Type-check after the mechanical and codec changes. Resolve diagnostics using [references/v3-api-diff.md](references/v3-api-diff.md), especially:
 
 - `tryRecover` and `tryRecoverAsync` now preserve the original success and union it with a different recovered success type.
-- `matchError`, `matchErrorPartial`, and the additive `TaggedError#match` method infer unions from divergent handler returns. Before adopting the instance method, search error payloads and subclasses for a member named `match`.
+- `matchError`, `matchErrorPartial`, and the additive `TaggedError#match` method infer unions from divergent handler returns. Exhaustive matching turns thrown handlers into `Panic`; `match` is reserved, so rename payload or subclass collisions rejected by the v3 types.
 - `matchErrorPartial` may omit its fallback; an unhandled tagged error is then returned unchanged.
 - `Result.partition` now supports heterogeneous inputs; `all`, `allAsync`, and `partitionAsync` are new.
 - `Result.tryPromise` adds abort context, dynamic delays, and jitter while retaining valid v2 static retry configurations.

--- a/skills/migrate-better-result-3/SKILL.md
+++ b/skills/migrate-better-result-3/SKILL.md
@@ -62,7 +62,7 @@ Account for changed control flow: serialization can now return `ResultSerializat
 Type-check after the mechanical and codec changes. Resolve diagnostics using [references/v3-api-diff.md](references/v3-api-diff.md), especially:
 
 - `tryRecover` and `tryRecoverAsync` now preserve the original success and union it with a different recovered success type.
-- `matchError` and `matchErrorPartial` infer unions from divergent handler returns.
+- `matchError`, `matchErrorPartial`, and the additive `TaggedError#match` method infer unions from divergent handler returns. Before adopting the instance method, search error payloads and subclasses for a member named `match`.
 - `matchErrorPartial` may omit its fallback; an unhandled tagged error is then returned unchanged.
 - `Result.partition` now supports heterogeneous inputs; `all`, `allAsync`, and `partitionAsync` are new.
 - `Result.tryPromise` adds abort context, dynamic delays, and jitter while retaining valid v2 static retry configurations.

--- a/skills/migrate-better-result-3/references/v3-api-diff.md
+++ b/skills/migrate-better-result-3/references/v3-api-diff.md
@@ -1,6 +1,6 @@
 # Audited 2.10.0 → 3.0 API diff
 
-This reference is derived from the public source and tests between `v2.10.0` and the `3.0` branch at `a43cead`. Verify the installed target declarations when migrating to a later 3.x release.
+This reference is derived from the public source and tests between `v2.10.0` and the `3.0` branch through `c4d0a42`. Verify the installed target declarations when migrating to a later 3.x release.
 
 ## Required source changes
 
@@ -105,6 +105,23 @@ Existing three-argument data-first and two-argument pipeable calls with a fallba
 ## Additive 3.0 APIs
 
 These additions require no migration unless the codebase chooses to adopt them.
+
+### TaggedError instance matching
+
+Every `TaggedError` instance exposes exhaustive `.match(handlers)` with the same handler narrowing and return-union inference as data-first `matchError`:
+
+```ts
+const response = result.match({
+  ok: (user) => ({ status: 200, body: user }),
+  err: (error) =>
+    error.match({
+      UserNotFound: () => ({ status: 404, body: null }),
+      DatabaseUnavailable: () => ({ status: 503, body: null }),
+    }),
+});
+```
+
+No annotation is needed for `error` when the enclosing Result retains its error union. Keep `matchError` for structurally tagged errors and data-last matching. Before adopting the method, search TaggedError payloads and subclasses for an existing member named `match`; rename collisions because payload assignment can shadow the prototype method.
 
 ### Validated codecs and errors
 

--- a/skills/migrate-better-result-3/references/v3-api-diff.md
+++ b/skills/migrate-better-result-3/references/v3-api-diff.md
@@ -121,7 +121,9 @@ const response = result.match({
 });
 ```
 
-No annotation is needed for `error` when the enclosing Result retains its error union. Keep `matchError` for structurally tagged errors and data-last matching. Before adopting the method, search TaggedError payloads and subclasses for an existing member named `match`; rename collisions because payload assignment can shadow the prototype method.
+No annotation is needed for `error` when the enclosing Result retains its error union. Keep `matchError` for structurally tagged errors and data-last matching. Both exhaustive forms turn a selected handler exception into `Panic` and preserve the exception as `cause`.
+
+`match` is a reserved TaggedError instance name. The v3 types reject payload properties and incompatible subclass members with that name; search for and rename collisions during migration.
 
 ### Validated codecs and errors
 

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -15,6 +15,129 @@ type HttpErrorResponse = {
   readonly message: string;
 };
 
+describe("TaggedError.match", () => {
+  it("infers the error union and divergent handler returns from the receiver", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = result.error.match({
+      ErrorA: (_error) => 1,
+      ErrorB: (_error) => "B",
+    });
+
+    expectTypeOf(outcome).toEqualTypeOf<number | string>();
+  });
+
+  it("composes directly inside a Result error handler", () => {
+    const result = Result.err<{ readonly id: string }, ErrorA | ErrorB>(new ErrorA());
+    const outcome = result.match({
+      ok: () => 200 as const,
+      err: (error) =>
+        error.match({
+          ErrorA: () => 400 as const,
+          ErrorB: () => 503 as const,
+        }),
+    });
+
+    expectTypeOf(outcome).toEqualTypeOf<200 | 400 | 503>();
+  });
+
+  it("narrows every handler parameter to its tagged error variant", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+
+    result.error.match({
+      ErrorA: (error) => expectTypeOf(error).toEqualTypeOf<ErrorA>(),
+      ErrorB: (error) => expectTypeOf(error).toEqualTypeOf<ErrorB>(),
+    });
+  });
+
+  it("requires every error union variant to have a handler", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+
+    // @ts-expect-error - ErrorB handler is missing
+    result.error.match({
+      ErrorA: (_error) => 1,
+    });
+  });
+
+  it("rejects properties from another error variant in a narrowed handler", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+
+    result.error.match({
+      ErrorA: (error) => {
+        // @ts-expect-error - ErrorA does not have DetailedError properties
+        return error.detail;
+      },
+      ErrorB: (_error) => "B",
+    });
+  });
+
+  it("requires only the concrete receiver's handler", () => {
+    const error = new DetailedError({ detail: "context" });
+    const outcome = error.match({
+      DetailedError: (selectedError) => selectedError.detail,
+    });
+
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("drops never contributed by a throwing handler", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = result.error.match({
+      ErrorA: (_error) => 1,
+      ErrorB: (error) => {
+        throw error;
+      },
+    });
+
+    expectTypeOf(outcome).toBeNumber();
+  });
+
+  it("infers never when every handler throws", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = result.error.match({
+      ErrorA: (error) => {
+        throw error;
+      },
+      ErrorB: (error) => {
+        throw error;
+      },
+    });
+
+    expectTypeOf(outcome).toBeNever();
+  });
+
+  it("supports an explicit error union and shared return type", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+    const outcome = result.error.match<ErrorA | ErrorB, string>({
+      ErrorA: () => "A" as const,
+      ErrorB: () => "B" as const,
+    });
+
+    expectTypeOf(outcome).toBeString();
+  });
+
+  it("uses an explicit return type to constrain every handler", () => {
+    const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());
+
+    result.error.match<ErrorA | ErrorB, string>({
+      ErrorA: () => "A",
+      // @ts-expect-error - number is not assignable to the explicit string return type
+      ErrorB: () => 123,
+    });
+  });
+
+  it("supports a concrete function return type when another handler throws", () => {
+    const toHttpErrorResponse = (error: ErrorA | ErrorB): HttpErrorResponse =>
+      error.match({
+        ErrorA: () => ({ status: 400, message: "Invalid request" }),
+        ErrorB: (selectedError) => {
+          throw selectedError;
+        },
+      });
+
+    expectTypeOf(toHttpErrorResponse).returns.toEqualTypeOf<HttpErrorResponse>();
+  });
+});
+
 describe("matchError", () => {
   it("infers union from divergent handler returns", () => {
     const result = Result.err<void, ErrorA | ErrorB>(new ErrorA());

--- a/src/error.test-d.ts
+++ b/src/error.test-d.ts
@@ -6,6 +6,21 @@ class ErrorB extends TaggedError("ErrorB")<{}> {}
 class ErrorC extends TaggedError("ErrorC")<{}> {}
 class DetailedError extends TaggedError("DetailedError")<{ detail: string }> {}
 
+// @ts-expect-error - match is reserved for the exhaustive instance method
+class ReservedMatchPropertyError extends TaggedError("ReservedMatchPropertyError")<{
+  match: string;
+}> {}
+
+// @ts-expect-error - match is reserved even when the payload value is undefined
+class UndefinedReservedMatchPropertyError extends TaggedError(
+  "UndefinedReservedMatchPropertyError",
+)<{
+  match: undefined;
+}> {}
+
+void ReservedMatchPropertyError;
+void UndefinedReservedMatchPropertyError;
+
 class StructuralTaggedError extends Error {
   readonly _tag = "StructuralTaggedError";
 }

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  Panic,
   TaggedError,
   UnhandledException,
   ResultDeserializationError,
@@ -254,7 +255,7 @@ describe("TaggedError", () => {
       expect(selected).toBe(error);
     });
 
-    it("propagates an exception from the selected handler", () => {
+    it("panics when the selected handler throws", () => {
       const error = new NetworkError({
         url: "https://api.example.com",
         message: "failed",
@@ -271,7 +272,11 @@ describe("TaggedError", () => {
         thrown = cause;
       }
 
-      expect(thrown).toBe(error);
+      expect(Panic.is(thrown)).toBe(true);
+      if (Panic.is(thrown)) {
+        expect(thrown.message).toBe("matchError handler threw");
+        expect(thrown.cause).toBe(error);
+      }
     });
   });
 
@@ -301,7 +306,7 @@ describe("TaggedError", () => {
       expect(matchAppError(error)).toBe("network: https://api.example.com");
     });
 
-    it("propagates an exception from the selected handler", () => {
+    it("panics when the selected handler throws", () => {
       const throwSelectedHandler = (error: AppError) =>
         matchError(error, {
           NotFoundError: (e) => `missing: ${e.id}`,
@@ -322,7 +327,11 @@ describe("TaggedError", () => {
         thrown = cause;
       }
 
-      expect(thrown).toBe(error);
+      expect(Panic.is(thrown)).toBe(true);
+      if (Panic.is(thrown)) {
+        expect(thrown.message).toBe("matchError handler threw");
+        expect(thrown.cause).toBe(error);
+      }
     });
 
     it("matches structurally tagged errors without requiring TaggedError methods", () => {

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -223,6 +223,58 @@ describe("TaggedError", () => {
     });
   });
 
+  describe("match() method", () => {
+    const matchAppError = (error: AppError) =>
+      error.match({
+        NotFoundError: (selectedError) => `missing: ${selectedError.id}`,
+        ValidationError: (selectedError) => `invalid: ${selectedError.field}`,
+        NetworkError: (selectedError) => `network: ${selectedError.url}`,
+      });
+
+    it("dispatches every tagged error variant to its handler", () => {
+      const notFound = new NotFoundError({ id: "123", message: "not found" });
+      const validation = new ValidationError({ field: "email", message: "invalid" });
+      const network = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      expect(matchAppError(notFound)).toBe("missing: 123");
+      expect(matchAppError(validation)).toBe("invalid: email");
+      expect(matchAppError(network)).toBe("network: https://api.example.com");
+    });
+
+    it("passes the selected error instance to its handler", () => {
+      const error: AppError = new NotFoundError({ id: "456", message: "not found" });
+
+      const selected = error.match({
+        NotFoundError: (selectedError) => selectedError,
+      });
+
+      expect(selected).toBe(error);
+    });
+
+    it("propagates an exception from the selected handler", () => {
+      const error = new NetworkError({
+        url: "https://api.example.com",
+        message: "failed",
+      });
+
+      let thrown: unknown;
+      try {
+        error.match({
+          NetworkError: (selectedError) => {
+            throw selectedError;
+          },
+        });
+      } catch (cause) {
+        thrown = cause;
+      }
+
+      expect(thrown).toBe(error);
+    });
+  });
+
   describe("matchError", () => {
     const matchAppError = (error: AppError) =>
       matchError(error, {

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,6 +13,13 @@ const serializeCause = (cause: unknown): unknown => {
 /** Tagged error-like value (for generic constraints). */
 type TaggedErrorLike = Error & { readonly _tag: string };
 
+/** Candidate properties accepted by TaggedError before reserved names are excluded. */
+type TaggedErrorProps = Record<string, unknown>;
+
+/** Rejects TaggedError properties that collide with the built-in match method. */
+type TaggedErrorPropsWithoutReservedNames<Props extends TaggedErrorProps> =
+  "match" extends keyof Props ? never : Props;
+
 /** Any TaggedError instance. */
 export type AnyTaggedError = TaggedErrorLike & { toJSON(): object };
 
@@ -36,6 +43,9 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  *   message: string;
  * }> {}
  *
+ * The `match` property name is reserved for exhaustive instance matching and cannot be declared
+ * in `Props`.
+ *
  * const err = new NotFoundError({ id: "123", message: "Not found: 123" });
  * err._tag    // "NotFoundError"
  * err.id      // "123"
@@ -45,7 +55,7 @@ const isAnyTaggedError = (value: unknown): value is AnyTaggedError => {
  * TaggedError.is(err) // true
  */
 export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag> => {
-  class Base<Props extends Record<string, unknown> = {}> extends Error {
+  class Base<Props extends TaggedErrorProps = {}> extends Error {
     readonly _tag: Tag = tag;
 
     constructor(args?: Props) {
@@ -79,7 +89,10 @@ export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag>
       };
     }
 
-    /** Exhaustively matches a tagged error union and returns the selected handler's result. */
+    /**
+     * Exhaustively matches a tagged error union and returns the selected handler's result.
+     * @throws {Panic} If the selected handler throws.
+     */
     match<E extends TaggedErrorLike, const H extends MatchHandlers<E>>(
       this: E,
       handlers: H,
@@ -111,7 +124,10 @@ export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag>
 TaggedError.is = isAnyTaggedError;
 
 interface TaggedErrorMethods extends Error {
-  /** Exhaustively matches a tagged error union and returns the selected handler's result. */
+  /**
+   * Exhaustively matches a tagged error union and returns the selected handler's result.
+   * @throws {Panic} If the selected handler throws.
+   */
   match<E extends TaggedErrorLike, const H extends MatchHandlers<E>>(
     this: E,
     handlers: H,
@@ -134,9 +150,11 @@ type TaggedErrorConstructor = abstract new (...args: never[]) => object;
 
 /** Class type produced by TaggedError factory */
 export type TaggedErrorClass<Tag extends string> = {
-  new <Props extends Record<string, unknown> = {}>(
-    ...args: keyof Props extends never ? [args?: {}] : [args: Props]
-  ): TaggedErrorInstance<Tag, Props>;
+  new <Props extends TaggedErrorProps = {}>(
+    ...args: keyof Props extends never
+      ? [args?: {}]
+      : [args: TaggedErrorPropsWithoutReservedNames<Props>]
+  ): TaggedErrorInstance<Tag, TaggedErrorPropsWithoutReservedNames<Props>>;
   /** Type guard for the concrete error class on which this method is called. */
   is<C extends TaggedErrorConstructor>(this: C, value: unknown): value is InstanceType<C>;
 };
@@ -192,6 +210,8 @@ type UnhandledMatchErrors<E extends TaggedErrorLike, H> = Exclude<E, { _tag: Han
  *   NotFoundError: (e) => `Missing: ${e.id}`,
  *   ValidationError: (e) => `Invalid: ${e.field}`,
  * }));
+ *
+ * @throws {Panic} If the selected handler throws.
  */
 export const matchError: {
   /** Data-last, E deferred to application; returns the union of handler returns */
@@ -206,8 +226,12 @@ export const matchError: {
   <E extends TaggedErrorLike, R>(err: E, handlers: MatchHandlersWithReturn<E, R>): R;
 } = dual(2, <E extends TaggedErrorLike>(err: E, handlers: MatchHandlers<E>): unknown => {
   const handler = handlers[err._tag as E["_tag"]];
-  // SAFETY: exhaustiveness is enforced at the type level
-  return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
+  try {
+    // SAFETY: exhaustiveness is enforced at the type level
+    return handler(err as Extract<E, { _tag: (typeof err)["_tag"] }>);
+  } catch (cause) {
+    return panic("matchError handler threw", cause);
+  }
 });
 
 const returnTaggedErrorIdentity = (error: TaggedErrorLike): TaggedErrorLike => error;

--- a/src/error.ts
+++ b/src/error.ts
@@ -79,6 +79,17 @@ export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag>
       };
     }
 
+    /** Exhaustively matches a tagged error union and returns the selected handler's result. */
+    match<E extends TaggedErrorLike, const H extends MatchHandlers<E>>(
+      this: E,
+      handlers: H,
+    ): MatchReturn<H>;
+    /** Exhaustively matches a tagged error union while constraining every handler to return `R`. */
+    match<E extends TaggedErrorLike, R>(this: E, handlers: MatchHandlersWithReturn<E, R>): R;
+    match<E extends TaggedErrorLike>(this: E, handlers: MatchHandlers<E>): unknown {
+      return matchError(this, handlers);
+    }
+
     /**
      * Makes this TaggedError yieldable in Result.gen blocks.
      * Yielding short-circuits with this error, matching Err semantics.
@@ -99,13 +110,21 @@ export const TaggedError = <Tag extends string>(tag: Tag): TaggedErrorClass<Tag>
 };
 TaggedError.is = isAnyTaggedError;
 
-interface IterableError extends Error {
+interface TaggedErrorMethods extends Error {
+  /** Exhaustively matches a tagged error union and returns the selected handler's result. */
+  match<E extends TaggedErrorLike, const H extends MatchHandlers<E>>(
+    this: E,
+    handlers: H,
+  ): MatchReturn<H>;
+  /** Exhaustively matches a tagged error union while constraining every handler to return `R`. */
+  match<E extends TaggedErrorLike, R>(this: E, handlers: MatchHandlersWithReturn<E, R>): R;
+
   /** Makes TaggedError instances yieldable in Result.gen blocks. */
   [Symbol.iterator](): Generator<Err<never, this>, never, unknown>;
 }
 
 /** Instance type produced by TaggedError factory */
-export type TaggedErrorInstance<Tag extends string, Props> = IterableError & {
+export type TaggedErrorInstance<Tag extends string, Props> = TaggedErrorMethods & {
   readonly _tag: Tag;
   toJSON(): object;
 } & Readonly<Props>;

--- a/website/docs/core/narrowing-and-matching.mdx
+++ b/website/docs/core/narrowing-and-matching.mdx
@@ -74,7 +74,7 @@ displayName(result);
 const response = result.match({
   ok: (user) => ({ status: 200, body: user }),
   err: (error) =>
-    matchError(error, {
+    error.match({
       UserNotFound: () => ({ status: 404, body: null }),
       DatabaseUnavailable: () => ({ status: 503, body: null }),
     }),

--- a/website/docs/errors/matching-errors.mdx
+++ b/website/docs/errors/matching-errors.mdx
@@ -48,7 +48,9 @@ const message = matchError(error, {
 });
 ```
 
-The standalone function has the same exhaustive narrowing and return inference as `.match()`.
+The standalone function has the same exhaustive narrowing, return inference, and defect behavior as `.match()`. If the selected exhaustive handler throws, `.match()` and `matchError` throw `Panic` with the original exception as `cause`.
+
+`match` is a reserved `TaggedError` instance name. The factory rejects payload property types named `match`, preventing constructor assignment from shadowing the method.
 
 ## Data-last matching
 

--- a/website/docs/errors/matching-errors.mdx
+++ b/website/docs/errors/matching-errors.mdx
@@ -3,7 +3,43 @@ title: Matching errors
 description: Handle tagged-error unions exhaustively or partially with inferred handler return unions.
 ---
 
-## Exhaustive `matchError`
+## Exhaustive instance matching
+
+Every `TaggedError` instance has a `.match()` method:
+
+```ts
+const message = error.match({
+  UserNotFound: (error) => `No user ${error.userId}`,
+  PermissionDenied: (error) => `Missing permission ${error.permission}`,
+});
+```
+
+Every `_tag` in the receiver union needs a handler. Handler parameters narrow to their exact error class. Different handler outputs produce a return union.
+
+```ts
+const outcome = error.match({
+  UserNotFound: () => 404,
+  PermissionDenied: () => "forbidden" as const,
+});
+// number | "forbidden"
+```
+
+This composes directly inside a `Result` error branch without annotating the inferred error:
+
+```ts
+const response = result.match({
+  ok: (user) => ({ status: 200, body: user }),
+  err: (error) =>
+    error.match({
+      UserNotFound: () => ({ status: 404, body: null }),
+      DatabaseUnavailable: () => ({ status: 503, body: null }),
+    }),
+});
+```
+
+## Standalone `matchError`
+
+Use `matchError(error, handlers)` when working with structurally tagged errors that were not created by `TaggedError`:
 
 ```ts
 const message = matchError(error, {
@@ -12,15 +48,7 @@ const message = matchError(error, {
 });
 ```
 
-Every `_tag` in the input union needs a handler. Handler parameters narrow to their exact error class. Different handler outputs produce a return union.
-
-```ts
-const outcome = matchError(error, {
-  UserNotFound: () => 404,
-  PermissionDenied: () => "forbidden" as const,
-});
-// number | "forbidden"
-```
+The standalone function has the same exhaustive narrowing and return inference as `.match()`.
 
 ## Data-last matching
 

--- a/website/docs/errors/panic-and-defects.mdx
+++ b/website/docs/errors/panic-and-defects.mdx
@@ -11,7 +11,7 @@ If `.map()` silently converted every thrown callback into `Err<unknown>`, `Resul
 
 ## Common Panic sources
 
-- callbacks passed to `map`, `mapError`, `andThen`, recovery, `match`, or observation throw;
+- callbacks passed to `map`, `mapError`, `andThen`, recovery, Result or TaggedError `match`, `matchError`, or observation throw;
 - async callbacks reject;
 - `Result.gen` body or cleanup throws;
 - a generator returns a non-Result value;

--- a/website/docs/errors/tagged-errors.mdx
+++ b/website/docs/errors/tagged-errors.mdx
@@ -27,8 +27,20 @@ The class has normal `Error` behavior plus:
 - `_tag === "UserNotFound"` as a string literal;
 - readonly `userId` and other declared properties;
 - `toJSON()`;
+- exhaustive `.match()` by `_tag`;
 - `UserNotFound.is(value)`;
 - iterator support for `yield*`.
+
+## Match an error union
+
+```ts
+const message = error.match({
+  UserNotFound: (error) => `No user ${error.userId}`,
+  PermissionDenied: (error) => `Missing permission ${error.permission}`,
+});
+```
+
+The handler map must cover every variant in the receiver's error union. Each handler receives its concrete error subtype. Use the standalone `matchError` function for structurally tagged errors or data-last matching.
 
 ## Add a computed message
 

--- a/website/docs/errors/tagged-errors.mdx
+++ b/website/docs/errors/tagged-errors.mdx
@@ -40,7 +40,9 @@ const message = error.match({
 });
 ```
 
-The handler map must cover every variant in the receiver's error union. Each handler receives its concrete error subtype. Use the standalone `matchError` function for structurally tagged errors or data-last matching.
+The handler map must cover every variant in the receiver's error union. Each handler receives its concrete error subtype. If the selected handler throws, `.match()` throws `Panic` with that exception as its cause. Use the standalone `matchError` function for structurally tagged errors or data-last matching.
+
+`match` is reserved for this method. A TaggedError payload property or incompatible subclass member named `match` is rejected by TypeScript.
 
 ## Add a computed message
 

--- a/website/docs/getting-started/quickstart.mdx
+++ b/website/docs/getting-started/quickstart.mdx
@@ -8,7 +8,7 @@ This example parses an environment value, validates it, and builds a server addr
 ## 1. Define errors callers can distinguish
 
 ```ts
-import { Result, TaggedError, matchError, type Result as ResultType } from "better-result";
+import { Result, TaggedError, type Result as ResultType } from "better-result";
 
 class MissingEnv extends TaggedError("MissingEnv")<{
   name: string;
@@ -68,7 +68,7 @@ const exitCode = readServerAddress().match({
   },
   err: (error) => {
     console.error(
-      matchError(error, {
+      error.match({
         MissingEnv: (missing) => `Configuration missing: ${missing.name}`,
         InvalidPort: (invalid) => `Invalid PORT ${JSON.stringify(invalid.input)}`,
       }),
@@ -78,7 +78,7 @@ const exitCode = readServerAddress().match({
 });
 ```
 
-Adding a new tagged error to this workflow makes the exhaustive `matchError` handlers fail to type-check until you decide how to present it.
+Adding a new tagged error to this workflow makes the exhaustive `.match()` handlers fail to type-check until you decide how to present it.
 
 ## Next steps
 

--- a/website/docs/guides/agents.mdx
+++ b/website/docs/guides/agents.mdx
@@ -49,7 +49,7 @@ Use literal public names in searches and prompts:
 
 - `Result.tryPromise` for exceptions, retries, jitter, and abort signals;
 - `Result.gen` and `Result.await` for generator composition;
-- `TaggedError`, `matchError`, and `matchErrorPartial` for error unions;
+- `TaggedError#match`, `matchError`, and `matchErrorPartial` for error unions;
 - `Result.codec` for validated transport/persistence boundaries;
 - `Panic`, `isPanic`, and `panic` for defects;
 - `Result.all`, `allAsync`, `partition`, and `partitionAsync` for collections.

--- a/website/docs/guides/application-patterns.mdx
+++ b/website/docs/guides/application-patterns.mdx
@@ -55,7 +55,7 @@ const toHttpResponse = (result: ResultType<User, RegisterUserError>) =>
   result.match({
     ok: (user) => Response.json(user, { status: 201 }),
     err: (error) =>
-      matchError(error, {
+      error.match({
         InvalidCreateUser: (error) => Response.json(error.toJSON(), { status: 400 }),
         EmailTaken: (error) => Response.json(error.toJSON(), { status: 409 }),
         UserStoreUnavailable: () => Response.json({ message: "Try again" }, { status: 503 }),

--- a/website/docs/migration/from-2.mdx
+++ b/website/docs/migration/from-2.mdx
@@ -74,7 +74,9 @@ const response = result.match({
 });
 ```
 
-Use `matchError` for structurally tagged errors or data-last matching. Before adopting `.match()`, rename any TaggedError payload property or subclass method already named `match`.
+Use `matchError` for structurally tagged errors or data-last matching. Both exhaustive forms turn a selected handler exception into `Panic` and preserve the exception as `cause`.
+
+`match` is now a reserved TaggedError instance name. TypeScript rejects payload properties and incompatible subclass members with that name; rename any collision during migration.
 
 ## Collection additions
 

--- a/website/docs/migration/from-2.mdx
+++ b/website/docs/migration/from-2.mdx
@@ -59,6 +59,23 @@ const output = matchErrorPartial(error, {
 // 404 | unhandled error variants
 ```
 
+## TaggedError instance matching
+
+Tagged errors can now match their union directly. This is additive; existing `matchError` calls remain valid.
+
+```ts
+const response = result.match({
+  ok: (user) => ({ status: 200, body: user }),
+  err: (error) =>
+    error.match({
+      UserNotFound: () => ({ status: 404, body: null }),
+      DatabaseUnavailable: () => ({ status: 503, body: null }),
+    }),
+});
+```
+
+Use `matchError` for structurally tagged errors or data-last matching. Before adopting `.match()`, rename any TaggedError payload property or subclass method already named `match`.
+
 ## Collection additions
 
 - `Result.all` preserves tuple success types and returns the first error.

--- a/website/docs/reference/errors.mdx
+++ b/website/docs/reference/errors.mdx
@@ -37,7 +37,9 @@ Instances expose `_tag`, declared properties, native Error fields, `toJSON()`, e
 | `matchErrorPartial(error, handlers, fallback)` | Handle selected tags; transform others with fallback |
 | `matchErrorPartial(handlers, fallback)(error)` | Data-last partial match                              |
 
-Handler return types are inferred as a union when they differ.
+Handler return types are inferred as a union when they differ. If an exhaustive `.match()` or `matchError` handler throws, the operation throws `Panic` with the original exception as `cause`. `matchErrorPartial` retains its fallback and handler exception behavior.
+
+The `match` property name is reserved on `TaggedError` payloads; TypeScript also rejects incompatible subclass members with that name.
 
 ## Built-in error classes
 

--- a/website/docs/reference/errors.mdx
+++ b/website/docs/reference/errors.mdx
@@ -14,7 +14,7 @@ class NotFound extends TaggedError("NotFound")<{
 }> {}
 ```
 
-Instances expose `_tag`, declared properties, native Error fields, `toJSON()`, and generator iterator behavior. Concrete classes expose `.is(value)`.
+Instances expose `_tag`, declared properties, native Error fields, `toJSON()`, exhaustive `.match(handlers)`, and generator iterator behavior. Concrete classes expose `.is(value)`.
 
 ## Guards
 
@@ -30,7 +30,8 @@ Instances expose `_tag`, declared properties, native Error fields, `toJSON()`, a
 
 | API                                            | Behavior                                             |
 | ---------------------------------------------- | ---------------------------------------------------- |
-| `matchError(error, handlers)`                  | Exhaustive match over every `_tag`                   |
+| `error.match(handlers)`                        | Exhaustive instance match over every `_tag`          |
+| `matchError(error, handlers)`                  | Exhaustive standalone match over every `_tag`        |
 | `matchError(handlers)(error)`                  | Data-last exhaustive match                           |
 | `matchErrorPartial(error, handlers)`           | Handle selected tags; return others unchanged        |
 | `matchErrorPartial(error, handlers, fallback)` | Handle selected tags; transform others with fallback |


### PR DESCRIPTION
## Summary

- add an exhaustive `TaggedError#match` instance method backed by `matchError`
- preserve handler narrowing, union return inference, `never` elimination, and explicit shared return constraints
- reserve `match` from TaggedError payload properties and convert exhaustive handler exceptions to `Panic`
- document direct matching for concise `Result.match` error branches
- update the README, Blume documentation site, and portable adoption/migration skills

## Examples

### Map application errors to HTTP responses

```ts
class UserNotFound extends TaggedError("UserNotFound")<{
  userId: string;
  message: string;
}> {}

class DatabaseUnavailable extends TaggedError("DatabaseUnavailable")<{
  retryAfterMs: number;
  message: string;
}> {}

type LoadUserError = UserNotFound | DatabaseUnavailable;

const response = loadUserResult.match({
  ok: (user) => ({ status: 200, body: user }),
  err: (error) =>
    error.match({
      UserNotFound: () => ({ status: 404, body: null }),
      DatabaseUnavailable: (cause) => ({
        status: 503,
        body: { retryAfterMs: cause.retryAfterMs },
      }),
    }),
});
```

### Choose a retry policy exhaustively

```ts
type RetryDecision =
  | { readonly action: "retry"; readonly delayMs: number }
  | { readonly action: "discard"; readonly reason: string };

const retryDecision = paymentError.match<PaymentError, RetryDecision>({
  CardDeclined: (error) => ({ action: "discard", reason: error.declineReason }),
  DuplicatePayment: () => ({ action: "discard", reason: "already processed" }),
  PaymentGatewayUnavailable: (error) => ({
    action: "retry",
    delayMs: error.retryAfterMs,
  }),
});
```

Adding another `PaymentError` variant makes this policy fail to compile until its retry behavior is defined.

### Build variant-specific telemetry without a switch

```ts
const failureContext = error.match({
  InvalidWebhookSignature: (cause) => ({
    category: "invalid-signature" as const,
    webhookId: cause.webhookId,
  }),
  WebhookDeliveryFailed: (cause) => ({
    category: "delivery-failed" as const,
    webhookId: cause.webhookId,
    statusCode: cause.statusCode,
  }),
});

logger.warn("Webhook processing failed", failureContext);
```

Each handler receives its concrete error subtype, and `failureContext` is inferred as the union of the handler return types.

## Test coverage

- runtime coverage for every tagged variant, selected-error identity, and thrown-handler conversion to `Panic` with the original cause
- compile-time coverage for exhaustive handlers, variant narrowing, divergent returns, `never`, concrete receivers, explicit return constraints, reserved payload names, invalid handlers, and direct composition inside `Result.match`

## Downstream compatibility audit

Known npm dependents were checked for `TaggedError`, `matchError`, and `.match()` usage:

- `@prisma/compute-sdk@0.38.0` — npm package at gitHead `759fa9367b01bdc0e5e180e535c01832e2066b76`
- `@prisma/streams-server@0.1.11` and `@prisma/streams-local@0.1.11` — `prisma/streams@8d6e12b6558285a9330de38c354d796f118a5f3f`
- `create-better-t-stack@3.38.0` and `@better-t-stack/template-generator@3.38.0` — `create-better-t-stack@c86c0860c45b1f6859cec7fb1a906739572c36f3`

All currently depend on better-result 2.x. They create ordinary `TaggedError` subclasses and have no error payload or subclass member named `match`, so this additive method introduces no identified migration conflict.

## Verification

- `bun run test`
- `bun run check`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`
- `cd website && bun run check`
- `cd website && bun run build`
