### PR TITLE
fix: infer callback error lanes in tryRecover and andThen

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -139,26 +139,26 @@ type MapErrorReturn<R, E2> =
  */
 type TryRecoverReturn<R, F> =
   IsUnion<R> extends true
-    ? Result<InferOk<R> | InferOk<F>, CallbackError<F>>
+    ? Result<InferOk<R> | CallbackSuccess<F>, CallbackError<F>>
     : R extends Ok<infer A, unknown>
       ? Ok<A, CallbackError<F>>
       : R extends Err<unknown, unknown>
-        ? F
+        ? Result<CallbackSuccess<F>, CallbackError<F>>
         : never;
 
 /**
  * Return type for andThen that preserves concrete variants but prints public
  * Result for Result unions. `F` captures the callback's whole return type so
- * the error lane is distributed afterwards instead of being pinned to one
- * branch of a multi-statement callback.
+ * its success and error lanes are distributed afterwards instead of being
+ * pinned to one branch of a multi-statement callback.
  */
 type AndThenReturn<R, F> =
   IsUnion<R> extends true
-    ? Result<InferOk<F>, InferErr<R> | CallbackError<F>>
+    ? Result<CallbackSuccess<F>, InferErr<R> | CallbackError<F>>
     : R extends Ok<unknown, infer E>
-      ? Result<InferOk<F>, E | CallbackError<F>>
+      ? Result<CallbackSuccess<F>, E | CallbackError<F>>
       : R extends Err<unknown, infer E>
-        ? Err<InferOk<F>, E | CallbackError<F>>
+        ? Err<CallbackSuccess<F>, E | CallbackError<F>>
         : never;
 
 type TapBothHandlersFor<R> = {
@@ -305,7 +305,7 @@ export class Ok<A, E = never> {
   andThen<F extends AnyResult>(
     this: Ok<A, E>,
     fn: (a: A) => F,
-  ): Result<InferOk<F>, E | CallbackError<F>>;
+  ): Result<CallbackSuccess<F>, E | CallbackError<F>>;
   andThen<B, E2>(this: Ok<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
   andThen<F extends AnyResult, R extends AnyResult>(
     this: R,
@@ -315,11 +315,11 @@ export class Ok<A, E = never> {
     this: R,
     fn: (a: InferOk<R>) => Result<B, E2>,
   ): AndThenReturn<R, Result<B, E2>>;
-  andThen<F extends AnyResult>(fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>> {
-    // SAFETY: F is the callback's own Result type; `Result<InferOk<F>, E | CallbackError<F>>`
+  andThen<F extends AnyResult>(fn: (a: A) => F): Result<CallbackSuccess<F>, E | CallbackError<F>> {
+    // SAFETY: F is the callback's own Result type; `Result<CallbackSuccess<F>, E | CallbackError<F>>`
     // is the same value re-summarized with the receiver's error lane joined in.
     return tryOrPanic(() => fn(this.value), "andThen callback threw") as Result<
-      InferOk<F>,
+      CallbackSuccess<F>,
       E | CallbackError<F>
     >;
   }
@@ -339,7 +339,7 @@ export class Ok<A, E = never> {
   andThenAsync<F extends AnyResult>(
     this: Ok<A, E>,
     fn: (a: A) => Promise<F>,
-  ): Promise<Result<InferOk<F>, E | CallbackError<F>>>;
+  ): Promise<Result<CallbackSuccess<F>, E | CallbackError<F>>>;
   andThenAsync<B, E2>(
     this: Ok<A, E>,
     fn: (a: A) => Promise<Result<B, E2>>,
@@ -354,11 +354,11 @@ export class Ok<A, E = never> {
   ): Promise<AndThenReturn<R, Result<B, E2>>>;
   andThenAsync<F extends AnyResult>(
     fn: (a: A) => Promise<F>,
-  ): Promise<Result<InferOk<F>, E | CallbackError<F>>> {
-    // SAFETY: F is the callback's own Result type; `Result<InferOk<F>, E | CallbackError<F>>`
+  ): Promise<Result<CallbackSuccess<F>, E | CallbackError<F>>> {
+    // SAFETY: F is the callback's own Result type; `Result<CallbackSuccess<F>, E | CallbackError<F>>`
     // is the same value re-summarized with the receiver's error lane joined in.
     return tryOrPanicAsync(() => fn(this.value), "andThenAsync callback threw") as Promise<
-      Result<InferOk<F>, E | CallbackError<F>>
+      Result<CallbackSuccess<F>, E | CallbackError<F>>
     >;
   }
 
@@ -594,7 +594,10 @@ export class Err<T, E> {
    * @example
    * err<number, string>("missing").tryRecover(e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
-  tryRecover<F extends AnyResult>(this: Err<T, E>, fn: (e: E) => F): F;
+  tryRecover<F extends AnyResult>(
+    this: Err<T, E>,
+    fn: (e: E) => F,
+  ): Result<CallbackSuccess<F>, CallbackError<F>>;
   tryRecover<E2, B = T>(this: Err<T, E>, fn: (e: E) => Result<B, E2>): Result<B, E2>;
   tryRecover<F extends AnyResult, R extends AnyResult>(
     this: R,
@@ -604,8 +607,13 @@ export class Err<T, E> {
     this: R,
     fn: (e: InferErr<R>) => Result<B, E2>,
   ): TryRecoverReturn<R, Result<B, E2>>;
-  tryRecover<F extends AnyResult>(fn: (e: E) => F): F {
-    return tryOrPanic(() => fn(this.error), "tryRecover callback threw");
+  tryRecover<F extends AnyResult>(fn: (e: E) => F): Result<CallbackSuccess<F>, CallbackError<F>> {
+    // SAFETY: F is a Result whose phantom and concrete lanes are summarized by
+    // CallbackSuccess<F> and CallbackError<F>.
+    return tryOrPanic(() => fn(this.error), "tryRecover callback threw") as Result<
+      CallbackSuccess<F>,
+      CallbackError<F>
+    >;
   }
 
   /**
@@ -620,7 +628,10 @@ export class Err<T, E> {
    * @example
    * await err<number, string>("missing").tryRecoverAsync(async e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
-  tryRecoverAsync<F extends AnyResult>(this: Err<T, E>, fn: (e: E) => Promise<F>): Promise<F>;
+  tryRecoverAsync<F extends AnyResult>(
+    this: Err<T, E>,
+    fn: (e: E) => Promise<F>,
+  ): Promise<Result<CallbackSuccess<F>, CallbackError<F>>>;
   tryRecoverAsync<E2, B = T>(
     this: Err<T, E>,
     fn: (e: E) => Promise<Result<B, E2>>,
@@ -633,8 +644,14 @@ export class Err<T, E> {
     this: R,
     fn: (e: InferErr<R>) => Promise<Result<B, E2>>,
   ): Promise<TryRecoverReturn<R, Result<B, E2>>>;
-  tryRecoverAsync<F extends AnyResult>(fn: (e: E) => Promise<F>): Promise<F> {
-    return tryOrPanicAsync(() => fn(this.error), "tryRecoverAsync callback threw");
+  tryRecoverAsync<F extends AnyResult>(
+    fn: (e: E) => Promise<F>,
+  ): Promise<Result<CallbackSuccess<F>, CallbackError<F>>> {
+    // SAFETY: F is a Result whose phantom and concrete lanes are summarized by
+    // CallbackSuccess<F> and CallbackError<F>.
+    return tryOrPanicAsync(() => fn(this.error), "tryRecoverAsync callback threw") as Promise<
+      Result<CallbackSuccess<F>, CallbackError<F>>
+    >;
   }
 
   /**
@@ -648,7 +665,7 @@ export class Err<T, E> {
   andThen<F extends AnyResult>(
     this: Err<T, E>,
     _fn: (a: never) => F,
-  ): Err<InferOk<F>, E | CallbackError<F>>;
+  ): Err<CallbackSuccess<F>, E | CallbackError<F>>;
   andThen<U, E2>(this: Err<T, E>, _fn: (a: never) => Result<U, E2>): Err<U, E | E2>;
   andThen<F extends AnyResult, R extends AnyResult>(
     this: R,
@@ -658,9 +675,11 @@ export class Err<T, E> {
     this: R,
     _fn: (a: InferOk<R>) => Result<U, E2>,
   ): AndThenReturn<R, Result<U, E2>>;
-  andThen<F extends AnyResult>(_fn: (a: never) => F): Err<InferOk<F>, E | CallbackError<F>> {
+  andThen<F extends AnyResult>(
+    _fn: (a: never) => F,
+  ): Err<CallbackSuccess<F>, E | CallbackError<F>> {
     // SAFETY: T is phantom, E⊂(E|CallbackError<F>) so error type widens safely.
-    return this as unknown as Err<InferOk<F>, E | CallbackError<F>>;
+    return this as unknown as Err<CallbackSuccess<F>, E | CallbackError<F>>;
   }
 
   /**
@@ -674,7 +693,7 @@ export class Err<T, E> {
   andThenAsync<F extends AnyResult>(
     this: Err<T, E>,
     _fn: (a: never) => Promise<F>,
-  ): Promise<Err<InferOk<F>, E | CallbackError<F>>>;
+  ): Promise<Err<CallbackSuccess<F>, E | CallbackError<F>>>;
   andThenAsync<U, E2>(
     this: Err<T, E>,
     _fn: (a: never) => Promise<Result<U, E2>>,
@@ -689,9 +708,9 @@ export class Err<T, E> {
   ): Promise<AndThenReturn<R, Result<U, E2>>>;
   andThenAsync<F extends AnyResult>(
     _fn: (a: never) => Promise<F>,
-  ): Promise<Err<InferOk<F>, E | CallbackError<F>>> {
+  ): Promise<Err<CallbackSuccess<F>, E | CallbackError<F>>> {
     // SAFETY: T is phantom, E⊂(E|CallbackError<F>) so error type widens safely.
-    return Promise.resolve(this as unknown as Err<InferOk<F>, E | CallbackError<F>>);
+    return Promise.resolve(this as unknown as Err<CallbackSuccess<F>, E | CallbackError<F>>);
   }
 
   /**
@@ -888,8 +907,14 @@ export type InferOk<R> = R extends Ok<infer T, unknown> ? T : never;
 export type InferErr<R> = R extends Err<unknown, infer E> ? E : never;
 
 /**
- * Error lane of a callback's Result type, extracted from *either* variant —
- * `Ok<U, E2>` carries `E2` as a phantom that `InferErr` (Err-only) would drop.
+ * Success lane of a callback's Result type, extracted from either variant.
+ * `Err<T, E>` carries `T` as a phantom that `InferOk` (Ok-only) would drop.
+ */
+export type CallbackSuccess<F> = F extends Result<infer T, unknown> ? T : never;
+
+/**
+ * Error lane of a callback's Result type, extracted from either variant.
+ * `Ok<T, E>` carries `E` as a phantom that `InferErr` (Err-only) would drop.
  */
 export type CallbackError<F> = F extends Result<unknown, infer E> ? E : never;
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -134,7 +134,7 @@ type MapErrorReturn<R, E2> =
  * Return type for recovery that widens success unions while preserving
  * concrete variant precision. `F` is the callback's *whole* return type —
  * capturing it as one type parameter keeps TS from pinning the error lane to
- * the first branch of a multi-statement callback; `CallbackError<F>`
+ * one branch of a multi-statement callback; `CallbackError<F>`
  * distributes the union afterwards.
  */
 type TryRecoverReturn<R, F> =
@@ -149,8 +149,8 @@ type TryRecoverReturn<R, F> =
 /**
  * Return type for andThen that preserves concrete variants but prints public
  * Result for Result unions. `F` captures the callback's whole return type so
- * the error lane is distributed afterwards instead of being pinned to the
- * first branch of a multi-statement callback.
+ * the error lane is distributed afterwards instead of being pinned to one
+ * branch of a multi-statement callback.
  */
 type AndThenReturn<R, F> =
   IsUnion<R> extends true
@@ -283,7 +283,9 @@ export class Ok<A, E = never> {
     this: R,
     _fn: (e: InferErr<R>) => Promise<Result<B, E2>>,
   ): Promise<TryRecoverReturn<R, Result<B, E2>>>;
-  tryRecoverAsync<F extends AnyResult>(_fn: (e: never) => Promise<F>): Promise<Ok<A, CallbackError<F>>> {
+  tryRecoverAsync<F extends AnyResult>(
+    _fn: (e: never) => Promise<F>,
+  ): Promise<Ok<A, CallbackError<F>>> {
     // SAFETY: E is phantom on Ok (not used at runtime).
     return Promise.resolve(this as unknown as Ok<A, CallbackError<F>>);
   }
@@ -300,7 +302,10 @@ export class Ok<A, E = never> {
    * @example
    * ok(2).andThen(x => x > 0 ? ok(x) : err("negative")) // Ok(2)
    */
-  andThen<F extends AnyResult>(this: Ok<A, E>, fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>>;
+  andThen<F extends AnyResult>(
+    this: Ok<A, E>,
+    fn: (a: A) => F,
+  ): Result<InferOk<F>, E | CallbackError<F>>;
   andThen<B, E2>(this: Ok<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
   andThen<F extends AnyResult, R extends AnyResult>(
     this: R,
@@ -347,7 +352,9 @@ export class Ok<A, E = never> {
     this: R,
     fn: (a: InferOk<R>) => Promise<Result<B, E2>>,
   ): Promise<AndThenReturn<R, Result<B, E2>>>;
-  andThenAsync<F extends AnyResult>(fn: (a: A) => Promise<F>): Promise<Result<InferOk<F>, E | CallbackError<F>>> {
+  andThenAsync<F extends AnyResult>(
+    fn: (a: A) => Promise<F>,
+  ): Promise<Result<InferOk<F>, E | CallbackError<F>>> {
     // SAFETY: F is the callback's own Result type; `Result<InferOk<F>, E | CallbackError<F>>`
     // is the same value re-summarized with the receiver's error lane joined in.
     return tryOrPanicAsync(() => fn(this.value), "andThenAsync callback threw") as Promise<
@@ -613,10 +620,7 @@ export class Err<T, E> {
    * @example
    * await err<number, string>("missing").tryRecoverAsync(async e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
-  tryRecoverAsync<F extends AnyResult>(
-    this: Err<T, E>,
-    fn: (e: E) => Promise<F>,
-  ): Promise<F>;
+  tryRecoverAsync<F extends AnyResult>(this: Err<T, E>, fn: (e: E) => Promise<F>): Promise<F>;
   tryRecoverAsync<E2, B = T>(
     this: Err<T, E>,
     fn: (e: E) => Promise<Result<B, E2>>,
@@ -641,7 +645,10 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Self.
    */
-  andThen<F extends AnyResult>(this: Err<T, E>, _fn: (a: never) => F): Err<InferOk<F>, E | CallbackError<F>>;
+  andThen<F extends AnyResult>(
+    this: Err<T, E>,
+    _fn: (a: never) => F,
+  ): Err<InferOk<F>, E | CallbackError<F>>;
   andThen<U, E2>(this: Err<T, E>, _fn: (a: never) => Result<U, E2>): Err<U, E | E2>;
   andThen<F extends AnyResult, R extends AnyResult>(
     this: R,
@@ -680,7 +687,9 @@ export class Err<T, E> {
     this: R,
     _fn: (a: InferOk<R>) => Promise<Result<U, E2>>,
   ): Promise<AndThenReturn<R, Result<U, E2>>>;
-  andThenAsync<F extends AnyResult>(_fn: (a: never) => Promise<F>): Promise<Err<InferOk<F>, E | CallbackError<F>>> {
+  andThenAsync<F extends AnyResult>(
+    _fn: (a: never) => Promise<F>,
+  ): Promise<Err<InferOk<F>, E | CallbackError<F>>> {
     // SAFETY: T is phantom, E⊂(E|CallbackError<F>) so error type widens safely.
     return Promise.resolve(this as unknown as Err<InferOk<F>, E | CallbackError<F>>);
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -130,24 +130,35 @@ type MapErrorReturn<R, E2> =
         ? Err<T, E2>
         : never;
 
-/** Return type for recovery that widens success unions while preserving concrete variant precision. */
-type TryRecoverReturn<R, B, E2> =
+/**
+ * Return type for recovery that widens success unions while preserving
+ * concrete variant precision. `F` is the callback's *whole* return type —
+ * capturing it as one type parameter keeps TS from pinning the error lane to
+ * the first branch of a multi-statement callback; `CallbackError<F>`
+ * distributes the union afterwards.
+ */
+type TryRecoverReturn<R, F> =
   IsUnion<R> extends true
-    ? Result<InferOk<R> | B, E2>
+    ? Result<InferOk<R> | InferOk<F>, CallbackError<F>>
     : R extends Ok<infer A, unknown>
-      ? Ok<A, E2>
+      ? Ok<A, CallbackError<F>>
       : R extends Err<unknown, unknown>
-        ? Result<B, E2>
+        ? F
         : never;
 
-/** Return type for andThen that preserves concrete variants but prints public Result for Result unions. */
-type AndThenReturn<R, B, E2> =
+/**
+ * Return type for andThen that preserves concrete variants but prints public
+ * Result for Result unions. `F` captures the callback's whole return type so
+ * the error lane is distributed afterwards instead of being pinned to the
+ * first branch of a multi-statement callback.
+ */
+type AndThenReturn<R, F> =
   IsUnion<R> extends true
-    ? Result<B, InferErr<R> | E2>
+    ? Result<InferOk<F>, InferErr<R> | CallbackError<F>>
     : R extends Ok<unknown, infer E>
-      ? Result<B, E | E2>
+      ? Result<InferOk<F>, E | CallbackError<F>>
       : R extends Err<unknown, infer E>
-        ? Err<B, E | E2>
+        ? Err<InferOk<F>, E | CallbackError<F>>
         : never;
 
 type TapBothHandlersFor<R> = {
@@ -230,14 +241,19 @@ export class Ok<A, E = never> {
    * @example
    * ok(42).tryRecover(() => err("fallback")) // Ok(42)
    */
+  tryRecover<F extends AnyResult>(this: Ok<A, E>, _fn: (e: never) => F): Ok<A, CallbackError<F>>;
   tryRecover<E2, B = A>(this: Ok<A, E>, _fn: (e: never) => Result<B, E2>): Ok<A, E2>;
+  tryRecover<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    _fn: (e: InferErr<R>) => F,
+  ): TryRecoverReturn<R, F>;
   tryRecover<E2, B = A, R extends AnyResult = Result<A, E>>(
     this: R,
     _fn: (e: InferErr<R>) => Result<B, E2>,
-  ): TryRecoverReturn<R, B, E2>;
-  tryRecover<E2, B = A>(_fn: (e: never) => Result<B, E2>): Ok<A, E2> {
+  ): TryRecoverReturn<R, Result<B, E2>>;
+  tryRecover<F extends AnyResult>(_fn: (e: never) => F): Ok<A, CallbackError<F>> {
     // SAFETY: E is phantom on Ok (not used at runtime).
-    return this as unknown as Ok<A, E2>;
+    return this as unknown as Ok<A, CallbackError<F>>;
   }
 
   /**
@@ -251,17 +267,25 @@ export class Ok<A, E = never> {
    * @example
    * await ok(42).tryRecoverAsync(async () => err("fallback")) // Ok(42)
    */
+  tryRecoverAsync<F extends AnyResult>(
+    this: Ok<A, E>,
+    _fn: (e: never) => Promise<F>,
+  ): Promise<Ok<A, CallbackError<F>>>;
   tryRecoverAsync<E2, B = A>(
     this: Ok<A, E>,
     _fn: (e: never) => Promise<Result<B, E2>>,
   ): Promise<Ok<A, E2>>;
+  tryRecoverAsync<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    _fn: (e: InferErr<R>) => Promise<F>,
+  ): Promise<TryRecoverReturn<R, F>>;
   tryRecoverAsync<E2, B = A, R extends AnyResult = Result<A, E>>(
     this: R,
     _fn: (e: InferErr<R>) => Promise<Result<B, E2>>,
-  ): Promise<TryRecoverReturn<R, B, E2>>;
-  tryRecoverAsync<E2, B = A>(_fn: (e: never) => Promise<Result<B, E2>>): Promise<Ok<A, E2>> {
+  ): Promise<TryRecoverReturn<R, Result<B, E2>>>;
+  tryRecoverAsync<F extends AnyResult>(_fn: (e: never) => Promise<F>): Promise<Ok<A, CallbackError<F>>> {
     // SAFETY: E is phantom on Ok (not used at runtime).
-    return Promise.resolve(this as unknown as Ok<A, E2>);
+    return Promise.resolve(this as unknown as Ok<A, CallbackError<F>>);
   }
 
   /**
@@ -276,13 +300,23 @@ export class Ok<A, E = never> {
    * @example
    * ok(2).andThen(x => x > 0 ? ok(x) : err("negative")) // Ok(2)
    */
+  andThen<F extends AnyResult>(this: Ok<A, E>, fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>>;
   andThen<B, E2>(this: Ok<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
+  andThen<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    fn: (a: InferOk<R>) => F,
+  ): AndThenReturn<R, F>;
   andThen<B, E2, R extends AnyResult = Result<A, E>>(
     this: R,
     fn: (a: InferOk<R>) => Result<B, E2>,
-  ): AndThenReturn<R, B, E2>;
-  andThen<B, E2>(fn: (a: A) => Result<B, E2>): Result<B, E | E2> {
-    return tryOrPanic(() => fn(this.value), "andThen callback threw");
+  ): AndThenReturn<R, Result<B, E2>>;
+  andThen<F extends AnyResult>(fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>> {
+    // SAFETY: F is the callback's own Result type; `Result<InferOk<F>, E | CallbackError<F>>`
+    // is the same value re-summarized with the receiver's error lane joined in.
+    return tryOrPanic(() => fn(this.value), "andThen callback threw") as Result<
+      InferOk<F>,
+      E | CallbackError<F>
+    >;
   }
 
   /**
@@ -297,16 +331,28 @@ export class Ok<A, E = never> {
    * @example
    * await ok(1).andThenAsync(async x => ok(await fetchData(x)))
    */
+  andThenAsync<F extends AnyResult>(
+    this: Ok<A, E>,
+    fn: (a: A) => Promise<F>,
+  ): Promise<Result<InferOk<F>, E | CallbackError<F>>>;
   andThenAsync<B, E2>(
     this: Ok<A, E>,
     fn: (a: A) => Promise<Result<B, E2>>,
   ): Promise<Result<B, E | E2>>;
+  andThenAsync<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    fn: (a: InferOk<R>) => Promise<F>,
+  ): Promise<AndThenReturn<R, F>>;
   andThenAsync<B, E2, R extends AnyResult = Result<A, E>>(
     this: R,
     fn: (a: InferOk<R>) => Promise<Result<B, E2>>,
-  ): Promise<AndThenReturn<R, B, E2>>;
-  andThenAsync<B, E2>(fn: (a: A) => Promise<Result<B, E2>>): Promise<Result<B, E | E2>> {
-    return tryOrPanicAsync(() => fn(this.value), "andThenAsync callback threw");
+  ): Promise<AndThenReturn<R, Result<B, E2>>>;
+  andThenAsync<F extends AnyResult>(fn: (a: A) => Promise<F>): Promise<Result<InferOk<F>, E | CallbackError<F>>> {
+    // SAFETY: F is the callback's own Result type; `Result<InferOk<F>, E | CallbackError<F>>`
+    // is the same value re-summarized with the receiver's error lane joined in.
+    return tryOrPanicAsync(() => fn(this.value), "andThenAsync callback threw") as Promise<
+      Result<InferOk<F>, E | CallbackError<F>>
+    >;
   }
 
   /**
@@ -541,12 +587,17 @@ export class Err<T, E> {
    * @example
    * err<number, string>("missing").tryRecover(e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
+  tryRecover<F extends AnyResult>(this: Err<T, E>, fn: (e: E) => F): F;
   tryRecover<E2, B = T>(this: Err<T, E>, fn: (e: E) => Result<B, E2>): Result<B, E2>;
+  tryRecover<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    fn: (e: InferErr<R>) => F,
+  ): TryRecoverReturn<R, F>;
   tryRecover<E2, B = T, R extends AnyResult = Result<T, E>>(
     this: R,
     fn: (e: InferErr<R>) => Result<B, E2>,
-  ): TryRecoverReturn<R, B, E2>;
-  tryRecover<E2, B = T>(fn: (e: E) => Result<B, E2>): Result<B, E2> {
+  ): TryRecoverReturn<R, Result<B, E2>>;
+  tryRecover<F extends AnyResult>(fn: (e: E) => F): F {
     return tryOrPanic(() => fn(this.error), "tryRecover callback threw");
   }
 
@@ -562,15 +613,23 @@ export class Err<T, E> {
    * @example
    * await err<number, string>("missing").tryRecoverAsync(async e => e === "missing" ? ok("fallback") : err(new Error(e))) // Ok("fallback")
    */
+  tryRecoverAsync<F extends AnyResult>(
+    this: Err<T, E>,
+    fn: (e: E) => Promise<F>,
+  ): Promise<F>;
   tryRecoverAsync<E2, B = T>(
     this: Err<T, E>,
     fn: (e: E) => Promise<Result<B, E2>>,
   ): Promise<Result<B, E2>>;
+  tryRecoverAsync<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    fn: (e: InferErr<R>) => Promise<F>,
+  ): Promise<TryRecoverReturn<R, F>>;
   tryRecoverAsync<E2, B = T, R extends AnyResult = Result<T, E>>(
     this: R,
     fn: (e: InferErr<R>) => Promise<Result<B, E2>>,
-  ): Promise<TryRecoverReturn<R, B, E2>>;
-  tryRecoverAsync<E2, B = T>(fn: (e: E) => Promise<Result<B, E2>>): Promise<Result<B, E2>> {
+  ): Promise<TryRecoverReturn<R, Result<B, E2>>>;
+  tryRecoverAsync<F extends AnyResult>(fn: (e: E) => Promise<F>): Promise<F> {
     return tryOrPanicAsync(() => fn(this.error), "tryRecoverAsync callback threw");
   }
 
@@ -582,14 +641,19 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Self.
    */
+  andThen<F extends AnyResult>(this: Err<T, E>, _fn: (a: never) => F): Err<InferOk<F>, E | CallbackError<F>>;
   andThen<U, E2>(this: Err<T, E>, _fn: (a: never) => Result<U, E2>): Err<U, E | E2>;
+  andThen<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    _fn: (a: InferOk<R>) => F,
+  ): AndThenReturn<R, F>;
   andThen<U, E2, R extends AnyResult = Result<T, E>>(
     this: R,
     _fn: (a: InferOk<R>) => Result<U, E2>,
-  ): AndThenReturn<R, U, E2>;
-  andThen<U, E2>(_fn: (a: never) => Result<U, E2>): Err<U, E | E2> {
-    // SAFETY: T is phantom, E⊂(E|E2) so error type widens safely.
-    return this as unknown as Err<U, E | E2>;
+  ): AndThenReturn<R, Result<U, E2>>;
+  andThen<F extends AnyResult>(_fn: (a: never) => F): Err<InferOk<F>, E | CallbackError<F>> {
+    // SAFETY: T is phantom, E⊂(E|CallbackError<F>) so error type widens safely.
+    return this as unknown as Err<InferOk<F>, E | CallbackError<F>>;
   }
 
   /**
@@ -600,17 +664,25 @@ export class Err<T, E> {
    * @param _fn Ignored.
    * @returns Promise of self.
    */
+  andThenAsync<F extends AnyResult>(
+    this: Err<T, E>,
+    _fn: (a: never) => Promise<F>,
+  ): Promise<Err<InferOk<F>, E | CallbackError<F>>>;
   andThenAsync<U, E2>(
     this: Err<T, E>,
     _fn: (a: never) => Promise<Result<U, E2>>,
   ): Promise<Err<U, E | E2>>;
+  andThenAsync<F extends AnyResult, R extends AnyResult>(
+    this: R,
+    _fn: (a: InferOk<R>) => Promise<F>,
+  ): Promise<AndThenReturn<R, F>>;
   andThenAsync<U, E2, R extends AnyResult = Result<T, E>>(
     this: R,
     _fn: (a: InferOk<R>) => Promise<Result<U, E2>>,
-  ): Promise<AndThenReturn<R, U, E2>>;
-  andThenAsync<U, E2>(_fn: (a: never) => Promise<Result<U, E2>>): Promise<Err<U, E | E2>> {
-    // SAFETY: T is phantom, E⊂(E|E2) so error type widens safely.
-    return Promise.resolve(this as unknown as Err<U, E | E2>);
+  ): Promise<AndThenReturn<R, Result<U, E2>>>;
+  andThenAsync<F extends AnyResult>(_fn: (a: never) => Promise<F>): Promise<Err<InferOk<F>, E | CallbackError<F>>> {
+    // SAFETY: T is phantom, E⊂(E|CallbackError<F>) so error type widens safely.
+    return Promise.resolve(this as unknown as Err<InferOk<F>, E | CallbackError<F>>);
   }
 
   /**
@@ -805,6 +877,12 @@ export type InferOk<R> = R extends Ok<infer T, unknown> ? T : never;
  * Distributive: InferErr<Err<X, A> | Err<Y, B>> = A | B
  */
 export type InferErr<R> = R extends Err<unknown, infer E> ? E : never;
+
+/**
+ * Error lane of a callback's Result type, extracted from *either* variant —
+ * `Ok<U, E2>` carries `E2` as a phantom that `InferErr` (Err-only) would drop.
+ */
+export type CallbackError<F> = F extends Result<unknown, infer E> ? E : never;
 
 /**
  * Constraint for any union of Ok/Err types.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { Result, Ok, Err } from "./result";
 export type {
+  CallbackError,
   InferOk,
   InferErr,
   ResultCodec,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { Result, Ok, Err } from "./result";
 export type {
   CallbackError,
+  CallbackSuccess,
   InferOk,
   InferErr,
   ResultCodec,

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1191,6 +1191,31 @@ describe("Result", () => {
       expect(dataFirst.unwrap()).toBe(4);
       expect(dataLast.unwrap()).toBe(4);
     });
+
+    it("unions the error types of a multi-branch recovery callback (regression)", () => {
+      // The exact shape that used to collapse E2 to one branch: a
+      // multi-statement callback whose last path throws.
+      const result = Result.tryRecover(Result.err<number, "boom">("boom"), (e) => {
+        if (e === "boom") return Result.err<never, "slug-taken">("slug-taken");
+        if (e === "other") return Result.err<never, "not-found">("not-found");
+        throw e;
+      });
+
+      // E2 must be the union of every branch the callback can produce, not the
+      // first branch only — a collapsed E2 would lie about the error surface.
+      expectTypeOf(result).toEqualTypeOf<Result<number, "slug-taken" | "not-found">>();
+    });
+
+    it("unions the error types of a multi-branch andThen callback (regression)", () => {
+      const result = Result.ok(1).andThen((value) => {
+        if (value > 0) return Result.err<never, "slug-taken">("slug-taken");
+        return Result.err<never, "not-found">("not-found");
+      });
+
+      // The receiver's error lane joins the callback's union — same collapse
+      // category as tryRecover, same fix.
+      expectTypeOf(result).toEqualTypeOf<Result<never, "slug-taken" | "not-found">>();
+    });
   });
 
   describe("tryRecoverAsync", () => {
@@ -3536,6 +3561,8 @@ describe("Type Inference", () => {
         const mappedError = myResult.mapError<string>((error) => error._tag);
         expectTypeOf(mappedError).toEqualTypeOf<Result<{ name: string }, string>>();
 
+        // Explicit type arguments remain supported (v3 public API); inference
+        // is now the default path for unannotated callbacks.
         const chained = myResult.andThen<string, ErrorB>((value) =>
           Result.ok<string, ErrorB>(value.name),
         );
@@ -3582,8 +3609,10 @@ describe("Type Inference", () => {
         const okRecovered = okDirect.tryRecover(() => Result.ok(123));
         expectTypeOf(okRecovered).toEqualTypeOf<Ok<string, never>>();
 
+        // The recovery result is the callback's exact type — no impossible
+        // Err member is synthesized into it anymore.
         const errRecovered = errDirect.tryRecover(() => Result.ok(123));
-        expectTypeOf(errRecovered).toEqualTypeOf<Result<number, never>>();
+        expectTypeOf(errRecovered).toEqualTypeOf<Ok<number, never>>();
       };
 
       expect(typeof compileTimeOnly).toBe("function");

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -3361,6 +3361,34 @@ describe("Type Inference", () => {
 
       expectTypeOf(result).toEqualTypeOf<Result<string, ErrorA | ErrorC>>();
     });
+
+    it("preserves a phantom success lane from an Err callback", async () => {
+      const callback = () => Result.err<number, ErrorA>(new ErrorA());
+      const callbackAsync = async () => callback();
+      const input = (): Result<string, ErrorC> => Result.ok("start");
+
+      const dataFirst = Result.andThen(input(), callback);
+      const method = input().andThen(callback);
+      const dataLast = Result.andThen(callback)(input());
+      const asyncResult = Result.andThenAsync(input(), callbackAsync);
+      const recovered = Result.tryRecover(Result.err<string, ErrorC>(new ErrorC()), callback);
+      const recoveredAsync = Result.tryRecoverAsync(
+        Result.err<string, ErrorC>(new ErrorC()),
+        callbackAsync,
+      );
+
+      expectTypeOf(dataFirst).toEqualTypeOf<Result<number, ErrorA | ErrorC>>();
+      expectTypeOf(method).toEqualTypeOf<Result<number, ErrorA | ErrorC>>();
+      expectTypeOf(dataLast).toEqualTypeOf<Result<number, ErrorA | ErrorC>>();
+      expectTypeOf(asyncResult).toEqualTypeOf<Promise<Result<number, ErrorA | ErrorC>>>();
+      expectTypeOf(recovered).toEqualTypeOf<Result<string | number, ErrorA>>();
+      expectTypeOf(recoveredAsync).toEqualTypeOf<Promise<Result<string | number, ErrorA>>>();
+
+      // This follow-up chain compiles on v3 and catches a dropped phantom lane:
+      // CallbackSuccess<Err<number, ErrorA>> must be number, not never.
+      method.andThen((value) => Result.ok(value.toFixed()));
+      await Promise.all([asyncResult, recoveredAsync]);
+    });
   });
 
   describe("tryPromise retry jitter config", () => {
@@ -3659,10 +3687,13 @@ describe("Type Inference", () => {
         const okRecovered = okDirect.tryRecover(() => Result.ok(123));
         expectTypeOf(okRecovered).toEqualTypeOf<Ok<string, never>>();
 
-        // The recovery result is the callback's exact type — no impossible
-        // Err member is synthesized into it anymore.
+        // Preserve the v3 public Result shape even though this concrete Err
+        // always invokes a callback that returns Ok.
         const errRecovered = errDirect.tryRecover(() => Result.ok(123));
-        expectTypeOf(errRecovered).toEqualTypeOf<Ok<number, never>>();
+        expectTypeOf(errRecovered).toEqualTypeOf<Result<number, never>>();
+
+        const errRecoveredAsync = errDirect.tryRecoverAsync(async () => Result.ok(123));
+        expectTypeOf(errRecoveredAsync).toEqualTypeOf<Promise<Result<number, never>>>();
       };
 
       expect(typeof compileTimeOnly).toBe("function");

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1191,31 +1191,6 @@ describe("Result", () => {
       expect(dataFirst.unwrap()).toBe(4);
       expect(dataLast.unwrap()).toBe(4);
     });
-
-    it("unions the error types of a multi-branch recovery callback (regression)", () => {
-      // The exact shape that used to collapse E2 to one branch: a
-      // multi-statement callback whose last path throws.
-      const result = Result.tryRecover(Result.err<number, "boom">("boom"), (e) => {
-        if (e === "boom") return Result.err<never, "slug-taken">("slug-taken");
-        if (e === "other") return Result.err<never, "not-found">("not-found");
-        throw e;
-      });
-
-      // E2 must be the union of every branch the callback can produce, not the
-      // first branch only — a collapsed E2 would lie about the error surface.
-      expectTypeOf(result).toEqualTypeOf<Result<number, "slug-taken" | "not-found">>();
-    });
-
-    it("unions the error types of a multi-branch andThen callback (regression)", () => {
-      const result = Result.ok(1).andThen((value) => {
-        if (value > 0) return Result.err<never, "slug-taken">("slug-taken");
-        return Result.err<never, "not-found">("not-found");
-      });
-
-      // The receiver's error lane joins the callback's union — same collapse
-      // category as tryRecover, same fix.
-      expectTypeOf(result).toEqualTypeOf<Result<never, "slug-taken" | "not-found">>();
-    });
   });
 
   describe("tryRecoverAsync", () => {
@@ -3312,6 +3287,81 @@ describe("Type Inference", () => {
   class ErrorC extends Error {
     readonly _tag = "ErrorC" as const;
   }
+
+  describe("Result-returning callback unions", () => {
+    // Mirrors wrappers that deliberately expose the public Result union instead
+    // of better-result's concrete Err return type.
+    const errorResult = <E>(error: E): Result<never, E> => Result.err(error);
+    const recoverable = (): Result<number, "boom" | "other"> => Result.err("boom");
+    const chainable = (): Result<number, ErrorC> => Result.ok(1);
+
+    const recover = (error: "boom" | "other") => {
+      if (error === "boom") return errorResult(new ErrorA());
+      if (error === "other") return errorResult(new ErrorB());
+      throw error;
+    };
+
+    const chain = (value: number) =>
+      value > 0 ? errorResult(new ErrorA()) : errorResult(new ErrorB());
+
+    it("unions structured error types across synchronous callback branches", () => {
+      const dataFirstRecovered = Result.tryRecover(recoverable(), recover);
+      const methodRecovered = recoverable().tryRecover(recover);
+      const dataLastRecovered = Result.tryRecover(recover)(recoverable());
+
+      expectTypeOf(dataFirstRecovered).toEqualTypeOf<Result<number, ErrorA | ErrorB>>();
+      expectTypeOf(methodRecovered).toEqualTypeOf<Result<number, ErrorA | ErrorB>>();
+      expectTypeOf(dataLastRecovered).toEqualTypeOf<Result<number, ErrorA | ErrorB>>();
+
+      const dataFirstChained = Result.andThen(chainable(), chain);
+      const methodChained = chainable().andThen(chain);
+      const dataLastChained = Result.andThen(chain)(chainable());
+
+      expectTypeOf(dataFirstChained).toEqualTypeOf<Result<never, ErrorA | ErrorB | ErrorC>>();
+      expectTypeOf(methodChained).toEqualTypeOf<Result<never, ErrorA | ErrorB | ErrorC>>();
+      expectTypeOf(dataLastChained).toEqualTypeOf<Result<never, ErrorA | ErrorB | ErrorC>>();
+    });
+
+    it("unions structured error types across asynchronous callback branches", async () => {
+      const recoverAsync = async (error: "boom" | "other") => recover(error);
+      const chainAsync = async (value: number) => chain(value);
+
+      const dataFirstRecovered = Result.tryRecoverAsync(recoverable(), recoverAsync);
+      const methodRecovered = recoverable().tryRecoverAsync(recoverAsync);
+      const dataLastRecovered = Result.tryRecoverAsync(recoverAsync)(recoverable());
+
+      expectTypeOf(dataFirstRecovered).toEqualTypeOf<Promise<Result<number, ErrorA | ErrorB>>>();
+      expectTypeOf(methodRecovered).toEqualTypeOf<Promise<Result<number, ErrorA | ErrorB>>>();
+      expectTypeOf(dataLastRecovered).toEqualTypeOf<Promise<Result<number, ErrorA | ErrorB>>>();
+
+      const dataFirstChained = Result.andThenAsync(chainable(), chainAsync);
+      const methodChained = chainable().andThenAsync(chainAsync);
+      const dataLastChained = Result.andThenAsync(chainAsync)(chainable());
+
+      expectTypeOf(dataFirstChained).toEqualTypeOf<
+        Promise<Result<never, ErrorA | ErrorB | ErrorC>>
+      >();
+      expectTypeOf(methodChained).toEqualTypeOf<Promise<Result<never, ErrorA | ErrorB | ErrorC>>>();
+      expectTypeOf(dataLastChained).toEqualTypeOf<
+        Promise<Result<never, ErrorA | ErrorB | ErrorC>>
+      >();
+
+      await Promise.all([
+        dataFirstRecovered,
+        methodRecovered,
+        dataLastRecovered,
+        dataFirstChained,
+        methodChained,
+        dataLastChained,
+      ]);
+    });
+
+    it("preserves a phantom error lane from an Ok callback", () => {
+      const result = Result.ok<number, ErrorC>(1).andThen(() => Result.ok<string, ErrorA>("done"));
+
+      expectTypeOf(result).toEqualTypeOf<Result<string, ErrorA | ErrorC>>();
+    });
+  });
 
   describe("tryPromise retry jitter config", () => {
     it("preserves return and callback inference through both overloads", () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -10,6 +10,7 @@ import {
   ok,
   panic,
   type AnyResult,
+  type CallbackError,
   type InferErr,
   type InferOk,
   type TapBothAsyncHandlers,
@@ -17,7 +18,7 @@ import {
 } from "./core";
 
 export { Err, Ok } from "./core";
-export type { InferErr, InferOk } from "./core";
+export type { CallbackError, InferErr, InferOk } from "./core";
 export type { StandardSchemaV1 } from "./standard-schema";
 export type Result<T, E> = import("./core").Result<T, E>;
 /** A validation issue reported by a Standard Schema-compatible schema. */
@@ -284,28 +285,39 @@ const mapError: {
 });
 
 const tryRecover: {
+  <A, E, F extends AnyResult>(result: Result<A, E>, fn: (e: E) => F): Result<A | InferOk<F>, CallbackError<F>>;
   <A, E, E2, B = A>(result: Result<A, E>, fn: (e: E) => Result<B, E2>): Result<A | B, E2>;
+  <E, F extends AnyResult>(fn: (e: E) => F): <A>(result: Result<A, E>) => Result<A | InferOk<F>, CallbackError<F>>;
   <E, E2>(fn: (e: E) => Result<never, E2>): <A>(result: Result<A, E>) => Result<A, E2>;
   <E, B, E2>(fn: (e: E) => Result<B, E2>): <A>(result: Result<A, E>) => Result<A | B, E2>;
 } = dual(
   2,
-  <A, E, E2, B = A>(result: Result<A, E>, fn: (e: E) => Result<B, E2>): Result<A | B, E2> => {
+  <A, E, F extends AnyResult>(result: Result<A, E>, fn: (e: E) => F): Result<A | InferOk<F>, CallbackError<F>> => {
     return result.tryRecover(fn);
   },
 );
 
 const andThen: {
+  <A, E, F extends AnyResult>(result: Result<A, E>, fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>>;
   <A, B, E, E2>(result: Result<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
+  <A, F extends AnyResult>(fn: (a: A) => F): <E>(result: Result<A, E>) => Result<InferOk<F>, E | CallbackError<F>>;
   <A, B, E2>(fn: (a: A) => Result<B, E2>): <E>(result: Result<A, E>) => Result<B, E | E2>;
-} = dual(2, <A, B, E, E2>(result: Result<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2> => {
+} = dual(2, <A, E, F extends AnyResult>(result: Result<A, E>, fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>> => {
   return result.andThen(fn);
 });
 
 const tryRecoverAsync: {
+  <A, E, F extends AnyResult>(
+    result: Result<A, E>,
+    fn: (e: E) => Promise<F>,
+  ): Promise<Result<A | InferOk<F>, CallbackError<F>>>;
   <A, E, E2, B = A>(
     result: Result<A, E>,
     fn: (e: E) => Promise<Result<B, E2>>,
   ): Promise<Result<A | B, E2>>;
+  <E, F extends AnyResult>(
+    fn: (e: E) => Promise<F>,
+  ): <A>(result: Result<A, E>) => Promise<Result<A | InferOk<F>, CallbackError<F>>>;
   <E, E2>(
     fn: (e: E) => Promise<Result<never, E2>>,
   ): <A>(result: Result<A, E>) => Promise<Result<A, E2>>;
@@ -314,28 +326,35 @@ const tryRecoverAsync: {
   ): <A>(result: Result<A, E>) => Promise<Result<A | B, E2>>;
 } = dual(
   2,
-  <A, E, E2, B = A>(
+  <A, E, F extends AnyResult>(
     result: Result<A, E>,
-    fn: (e: E) => Promise<Result<B, E2>>,
-  ): Promise<Result<A | B, E2>> => {
+    fn: (e: E) => Promise<F>,
+  ): Promise<Result<A | InferOk<F>, CallbackError<F>>> => {
     return result.tryRecoverAsync(fn);
   },
 );
 
 const andThenAsync: {
+  <A, E, F extends AnyResult>(
+    result: Result<A, E>,
+    fn: (a: A) => Promise<F>,
+  ): Promise<Result<InferOk<F>, E | CallbackError<F>>>;
   <A, B, E, E2>(
     result: Result<A, E>,
     fn: (a: A) => Promise<Result<B, E2>>,
   ): Promise<Result<B, E | E2>>;
+  <A, F extends AnyResult>(
+    fn: (a: A) => Promise<F>,
+  ): <E>(result: Result<A, E>) => Promise<Result<InferOk<F>, E | CallbackError<F>>>;
   <A, B, E2>(
     fn: (a: A) => Promise<Result<B, E2>>,
   ): <E>(result: Result<A, E>) => Promise<Result<B, E | E2>>;
 } = dual(
   2,
-  <A, B, E, E2>(
+  <A, E, F extends AnyResult>(
     result: Result<A, E>,
-    fn: (a: A) => Promise<Result<B, E2>>,
-  ): Promise<Result<B, E | E2>> => {
+    fn: (a: A) => Promise<F>,
+  ): Promise<Result<InferOk<F>, E | CallbackError<F>>> => {
     return result.andThenAsync(fn);
   },
 );

--- a/src/result.ts
+++ b/src/result.ts
@@ -285,26 +285,45 @@ const mapError: {
 });
 
 const tryRecover: {
-  <A, E, F extends AnyResult>(result: Result<A, E>, fn: (e: E) => F): Result<A | InferOk<F>, CallbackError<F>>;
+  <A, E, F extends AnyResult>(
+    result: Result<A, E>,
+    fn: (e: E) => F,
+  ): Result<A | InferOk<F>, CallbackError<F>>;
   <A, E, E2, B = A>(result: Result<A, E>, fn: (e: E) => Result<B, E2>): Result<A | B, E2>;
-  <E, F extends AnyResult>(fn: (e: E) => F): <A>(result: Result<A, E>) => Result<A | InferOk<F>, CallbackError<F>>;
+  <E, F extends AnyResult>(
+    fn: (e: E) => F,
+  ): <A>(result: Result<A, E>) => Result<A | InferOk<F>, CallbackError<F>>;
   <E, E2>(fn: (e: E) => Result<never, E2>): <A>(result: Result<A, E>) => Result<A, E2>;
   <E, B, E2>(fn: (e: E) => Result<B, E2>): <A>(result: Result<A, E>) => Result<A | B, E2>;
 } = dual(
   2,
-  <A, E, F extends AnyResult>(result: Result<A, E>, fn: (e: E) => F): Result<A | InferOk<F>, CallbackError<F>> => {
+  <A, E, F extends AnyResult>(
+    result: Result<A, E>,
+    fn: (e: E) => F,
+  ): Result<A | InferOk<F>, CallbackError<F>> => {
     return result.tryRecover(fn);
   },
 );
 
 const andThen: {
-  <A, E, F extends AnyResult>(result: Result<A, E>, fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>>;
+  <A, E, F extends AnyResult>(
+    result: Result<A, E>,
+    fn: (a: A) => F,
+  ): Result<InferOk<F>, E | CallbackError<F>>;
   <A, B, E, E2>(result: Result<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
-  <A, F extends AnyResult>(fn: (a: A) => F): <E>(result: Result<A, E>) => Result<InferOk<F>, E | CallbackError<F>>;
+  <A, F extends AnyResult>(
+    fn: (a: A) => F,
+  ): <E>(result: Result<A, E>) => Result<InferOk<F>, E | CallbackError<F>>;
   <A, B, E2>(fn: (a: A) => Result<B, E2>): <E>(result: Result<A, E>) => Result<B, E | E2>;
-} = dual(2, <A, E, F extends AnyResult>(result: Result<A, E>, fn: (a: A) => F): Result<InferOk<F>, E | CallbackError<F>> => {
-  return result.andThen(fn);
-});
+} = dual(
+  2,
+  <A, E, F extends AnyResult>(
+    result: Result<A, E>,
+    fn: (a: A) => F,
+  ): Result<InferOk<F>, E | CallbackError<F>> => {
+    return result.andThen(fn);
+  },
+);
 
 const tryRecoverAsync: {
   <A, E, F extends AnyResult>(

--- a/src/result.ts
+++ b/src/result.ts
@@ -11,6 +11,7 @@ import {
   panic,
   type AnyResult,
   type CallbackError,
+  type CallbackSuccess,
   type InferErr,
   type InferOk,
   type TapBothAsyncHandlers,
@@ -18,7 +19,7 @@ import {
 } from "./core";
 
 export { Err, Ok } from "./core";
-export type { CallbackError, InferErr, InferOk } from "./core";
+export type { CallbackError, CallbackSuccess, InferErr, InferOk } from "./core";
 export type { StandardSchemaV1 } from "./standard-schema";
 export type Result<T, E> = import("./core").Result<T, E>;
 /** A validation issue reported by a Standard Schema-compatible schema. */
@@ -288,11 +289,11 @@ const tryRecover: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (e: E) => F,
-  ): Result<A | InferOk<F>, CallbackError<F>>;
+  ): Result<A | CallbackSuccess<F>, CallbackError<F>>;
   <A, E, E2, B = A>(result: Result<A, E>, fn: (e: E) => Result<B, E2>): Result<A | B, E2>;
   <E, F extends AnyResult>(
     fn: (e: E) => F,
-  ): <A>(result: Result<A, E>) => Result<A | InferOk<F>, CallbackError<F>>;
+  ): <A>(result: Result<A, E>) => Result<A | CallbackSuccess<F>, CallbackError<F>>;
   <E, E2>(fn: (e: E) => Result<never, E2>): <A>(result: Result<A, E>) => Result<A, E2>;
   <E, B, E2>(fn: (e: E) => Result<B, E2>): <A>(result: Result<A, E>) => Result<A | B, E2>;
 } = dual(
@@ -300,7 +301,7 @@ const tryRecover: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (e: E) => F,
-  ): Result<A | InferOk<F>, CallbackError<F>> => {
+  ): Result<A | CallbackSuccess<F>, CallbackError<F>> => {
     return result.tryRecover(fn);
   },
 );
@@ -309,18 +310,18 @@ const andThen: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (a: A) => F,
-  ): Result<InferOk<F>, E | CallbackError<F>>;
+  ): Result<CallbackSuccess<F>, E | CallbackError<F>>;
   <A, B, E, E2>(result: Result<A, E>, fn: (a: A) => Result<B, E2>): Result<B, E | E2>;
   <A, F extends AnyResult>(
     fn: (a: A) => F,
-  ): <E>(result: Result<A, E>) => Result<InferOk<F>, E | CallbackError<F>>;
+  ): <E>(result: Result<A, E>) => Result<CallbackSuccess<F>, E | CallbackError<F>>;
   <A, B, E2>(fn: (a: A) => Result<B, E2>): <E>(result: Result<A, E>) => Result<B, E | E2>;
 } = dual(
   2,
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (a: A) => F,
-  ): Result<InferOk<F>, E | CallbackError<F>> => {
+  ): Result<CallbackSuccess<F>, E | CallbackError<F>> => {
     return result.andThen(fn);
   },
 );
@@ -329,14 +330,14 @@ const tryRecoverAsync: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (e: E) => Promise<F>,
-  ): Promise<Result<A | InferOk<F>, CallbackError<F>>>;
+  ): Promise<Result<A | CallbackSuccess<F>, CallbackError<F>>>;
   <A, E, E2, B = A>(
     result: Result<A, E>,
     fn: (e: E) => Promise<Result<B, E2>>,
   ): Promise<Result<A | B, E2>>;
   <E, F extends AnyResult>(
     fn: (e: E) => Promise<F>,
-  ): <A>(result: Result<A, E>) => Promise<Result<A | InferOk<F>, CallbackError<F>>>;
+  ): <A>(result: Result<A, E>) => Promise<Result<A | CallbackSuccess<F>, CallbackError<F>>>;
   <E, E2>(
     fn: (e: E) => Promise<Result<never, E2>>,
   ): <A>(result: Result<A, E>) => Promise<Result<A, E2>>;
@@ -348,7 +349,7 @@ const tryRecoverAsync: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (e: E) => Promise<F>,
-  ): Promise<Result<A | InferOk<F>, CallbackError<F>>> => {
+  ): Promise<Result<A | CallbackSuccess<F>, CallbackError<F>>> => {
     return result.tryRecoverAsync(fn);
   },
 );
@@ -357,14 +358,14 @@ const andThenAsync: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (a: A) => Promise<F>,
-  ): Promise<Result<InferOk<F>, E | CallbackError<F>>>;
+  ): Promise<Result<CallbackSuccess<F>, E | CallbackError<F>>>;
   <A, B, E, E2>(
     result: Result<A, E>,
     fn: (a: A) => Promise<Result<B, E2>>,
   ): Promise<Result<B, E | E2>>;
   <A, F extends AnyResult>(
     fn: (a: A) => Promise<F>,
-  ): <E>(result: Result<A, E>) => Promise<Result<InferOk<F>, E | CallbackError<F>>>;
+  ): <E>(result: Result<A, E>) => Promise<Result<CallbackSuccess<F>, E | CallbackError<F>>>;
   <A, B, E2>(
     fn: (a: A) => Promise<Result<B, E2>>,
   ): <E>(result: Result<A, E>) => Promise<Result<B, E | E2>>;
@@ -373,7 +374,7 @@ const andThenAsync: {
   <A, E, F extends AnyResult>(
     result: Result<A, E>,
     fn: (a: A) => Promise<F>,
-  ): Promise<Result<InferOk<F>, E | CallbackError<F>>> => {
+  ): Promise<Result<CallbackSuccess<F>, E | CallbackError<F>>> => {
     return result.andThenAsync(fn);
   },
 );


### PR DESCRIPTION
## Problem

`tryRecover` and `andThen` (plus their async twins) currently infer nested `B` and `E2` parameters from the callback shape `Result<B, E2>`.

That breaks when a callback has multiple branches returning Results that are already widened to the public `Result<never, E>` union. This is a common boundary pattern; for example, `result-rpc` deliberately exposes its constrained `err` constructor as `Result<never, E>` rather than concrete `Err<never, E>`:

```ts
import { Result } from "better-result";
import { err } from "result-rpc";

const recovered = Result.tryRecover(await insertPost(), (error) => {
  if (UniqueViolation.is(error)) {
    return err(errors.slugTaken({ slug: input.slug }));
  }
  if (ForeignKeyViolation.is(error)) {
    return err(errors.notFound({ slug: input.categorySlug ?? "" }));
  }
  throw error;
});
```

The callback above returns:

```ts
Result<never, SlugTakenError> | Result<never, NotFoundError>
```

On `main`, TypeScript fixes `E2` to one structured error branch while contextually checking the callback, rejects the other branch, and can degrade the outer result error lane to `unknown` after overload resolution fails.

This does not reproduce with string literals returned directly from `Result.err`: that constructor returns concrete `Err` variants, and TypeScript can already combine that simpler shape on `main`.

## Fix

Capture the callback's complete return type as a single `F extends AnyResult`, then project its success and error lanes distributively:

- `CallbackError<F> = F extends Result<unknown, infer E> ? E : never` extracts the error lane from either variant. This also preserves a phantom `E` carried by `Ok<U, E>` under the new `F`-based inference.
- `TryRecoverReturn<R, F>` and `AndThenReturn<R, F>` now derive their output from the receiver `R` and the complete callback result `F`, instead of inferring nested `B` and `E2` independently.
- The change covers `tryRecover`, `tryRecoverAsync`, `andThen`, and `andThenAsync` across instance, data-first, and data-last APIs.
- A concrete `Err.tryRecover` now returns the callback's exact result variant because that callback always runs.

The v3 explicit-generic overloads, including `tryRecover<ErrorB>(...)` and `andThen<string, ErrorB>(...)`, remain available for source compatibility.

There is no runtime behavior change.

## Verification

- Added regression tests whose branches return `Result<never, E>` with distinct structured `ErrorA` / `ErrorB` types. The representative test fails on clean `main` and passes on this branch.
- Covered sync and async recovery/chaining across instance, data-first, and data-last forms.
- Added coverage for a phantom error lane returned through `Ok<U, E>`.
- Confirmed the original downstream handler in `blog/src/blog/rpc-server.ts` fails against `main` and typechecks with this branch.
- 359 tests pass.
- `bun run check`, `bun run test`, `bun run lint`, `bun run fmt:check`, `bun run build`, and the TypeScript 5.4.5 minimum-consumer check all pass.
- Audited the known Prisma and Better T Stack dependents; none use the changed combinators or helper types.
